### PR TITLE
GH-120: Add NFC API

### DIFF
--- a/Caboodle/Nfc/Nfc.android.cs
+++ b/Caboodle/Nfc/Nfc.android.cs
@@ -1,10 +1,66 @@
 ﻿using System;
 using Android;
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.Nfc;
 using Android.OS;
 
 namespace Microsoft.Caboodle
 {
     public static partial class Nfc
     {
+        static NfcAdapter nfcAdapter;
+
+        internal static bool IsSupported
+            => Platform.HasSystemFeature(PackageManager.FeatureNfc);
+
+        static void StartTagListeners()
+        {
+            Ensure();
+
+            var activity = Platform.CurrentActivity;
+
+            var intent = new Intent(activity, activity.GetType())
+                .AddFlags(ActivityFlags.SingleTop);
+            var pendingIntent = PendingIntent.GetActivity(activity, 0, intent, 0);
+
+            var tagDetected = new IntentFilter(NfcAdapter.ActionTagDiscovered);
+            var filters = new[] { tagDetected };
+
+            nfcAdapter.EnableForegroundDispatch(activity, pendingIntent, filters, null);
+        }
+
+        static void StopTagListeners()
+        {
+        }
+
+        static void StartNdefMessageListeners()
+        {
+            Ensure();
+        }
+
+        static void StopNdefMessageListeners()
+        {
+        }
+
+        static void PlatformPublishMessage(string messageType, byte[] message)
+        {
+            Ensure();
+        }
+
+        static void PlatformStopPublishing()
+        {
+        }
+
+        static void Ensure()
+        {
+            // Permissions.RequireAsync(PermissionType.Flashlight);
+
+            nfcAdapter = NfcAdapter.GetDefaultAdapter(Platform.CurrentContext);
+
+            if (nfcAdapter?.IsEnabled != true)
+                throw new NotSupportedException();
+        }
     }
 }

--- a/Caboodle/Nfc/Nfc.android.cs
+++ b/Caboodle/Nfc/Nfc.android.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using Android;
+using Android.OS;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class Nfc
+    {
+    }
+}

--- a/Caboodle/Nfc/Nfc.ios.cs
+++ b/Caboodle/Nfc/Nfc.ios.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using AudioToolbox;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class Nfc
+    {
+    }
+}

--- a/Caboodle/Nfc/Nfc.ios.cs
+++ b/Caboodle/Nfc/Nfc.ios.cs
@@ -1,9 +1,178 @@
 ﻿using System;
-using AudioToolbox;
+using System.IO;
+using CoreFoundation;
+using CoreNFC;
+using Foundation;
 
 namespace Microsoft.Caboodle
 {
     public static partial class Nfc
     {
+        static NfcReader nfcReader;
+
+        internal static bool IsSupported
+            => NFCNdefReaderSession.ReadingAvailable;
+
+        static void EnsureReader()
+        {
+        }
+
+        static void PlatformPublishMessage(string messageType, byte[] message)
+        {
+            throw new NotSupportedException();
+        }
+
+        static void PlatformStopPublishing()
+        {
+            throw new NotSupportedException();
+        }
+
+        static void StartTagListeners()
+        {
+            EnsureReader();
+            nfcReader.Start();
+        }
+
+        static void StopTagListeners()
+        {
+            nfcReader.Stop();
+        }
+
+        static void StartNdefMessageListeners()
+        {
+            EnsureReader();
+            nfcReader.Start();
+        }
+
+        static void StopNdefMessageListeners()
+        {
+            nfcReader.Stop();
+        }
+
+        class NfcReader : NSObject, INFCNdefReaderSessionDelegate
+        {
+            NFCNdefReaderSession session;
+
+            public void Start()
+            {
+                if (session != null)
+                {
+                    session = new NFCNdefReaderSession(this, DispatchQueue.CurrentQueue, false);
+                    session.BeginSession();
+                }
+            }
+
+            public void Stop()
+            {
+                session?.InvalidateSession();
+                session = null;
+            }
+
+            public void DidDetect(NFCNdefReaderSession session, NFCNdefMessage[] messages)
+            {
+                TagArrived?.Invoke(NfcTagEventArgs.Empty);
+
+                foreach (var message in messages)
+                {
+                    NdefMessageReceived?.Invoke(new NdefMessageReceivedEventArgs(message.ToByteArray()));
+                }
+            }
+
+            public void DidInvalidate(NFCNdefReaderSession session, NSError error)
+            {
+                // TODO: probably throw
+            }
+        }
+    }
+
+    static class NFCNdefMessageExtensions
+    {
+        public static byte[] ToByteArray(this NFCNdefMessage message)
+        {
+            var records = message?.Records;
+
+            // Empty message: single empty record
+            if (records == null || records.Length == 0)
+            {
+                records = new NFCNdefPayload[] { null };
+            }
+
+            var m = new MemoryStream();
+            for (var i = 0; i < records.Length; i++)
+            {
+                var record = records[i];
+                var typeNameFormat = record?.TypeNameFormat ?? NFCTypeNameFormat.Empty;
+                var payload = record?.Payload;
+                var id = record?.Identifier;
+                var type = record?.Type;
+
+                var flags = (byte)typeNameFormat;
+
+                // Message begin / end flags. If there is only one record in the message, both flags are set.
+                if (i == 0)
+                    flags |= 0x80;      // MB (message begin = first record in the message)
+                if (i == records.Length - 1)
+                    flags |= 0x40;      // ME (message end = last record in the message)
+
+                // cf (chunked records) not supported yet
+
+                // SR (Short Record)?
+                if (payload == null || payload.Length < 255)
+                    flags |= 0x10;
+
+                // ID present?
+                if (id != null && id.Length > 0)
+                    flags |= 0x08;
+
+                m.WriteByte(flags);
+
+                // Type length
+                if (type != null)
+                    m.WriteByte((byte)type.Length);
+                else
+                    m.WriteByte(0);
+
+                // Payload length 1 byte (SR) or 4 bytes
+                if (payload == null)
+                {
+                    m.WriteByte(0);
+                }
+                else
+                {
+                    if ((flags & 0x10) != 0)
+                    {
+                        // SR
+                        m.WriteByte((byte)payload.Length);
+                    }
+                    else
+                    {
+                        // No SR (Short Record)
+                        var payloadLength = (uint)payload.Length;
+                        m.WriteByte((byte)(payloadLength >> 24));
+                        m.WriteByte((byte)(payloadLength >> 16));
+                        m.WriteByte((byte)(payloadLength >> 8));
+                        m.WriteByte((byte)(payloadLength & 0x000000ff));
+                    }
+                }
+
+                // ID length
+                if (id != null && (flags & 0x08) != 0)
+                    m.WriteByte((byte)id.Length);
+
+                // Type length
+                if (type != null && type.Length > 0)
+                    m.Write(type.ToArray(), 0, (int)type.Length);
+
+                // ID data
+                if (id != null && id.Length > 0)
+                    m.Write(id.ToArray(), 0, (int)id.Length);
+
+                // Payload data
+                if (payload != null && payload.Length > 0)
+                    m.Write(payload.ToArray(), 0, (int)payload.Length);
+            }
+
+            return m.ToArray();
+        }
     }
 }

--- a/Caboodle/Nfc/Nfc.ios.cs
+++ b/Caboodle/Nfc/Nfc.ios.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Caboodle
             {
                 if (session != null)
                 {
-                    session = new NFCNdefReaderSession(this, DispatchQueue.CurrentQueue, false);
+                    session = new NFCNdefReaderSession(this, DispatchQueue.CurrentQueue, true);
                     session.BeginSession();
                 }
             }
@@ -76,11 +76,16 @@ namespace Microsoft.Caboodle
                 {
                     NdefMessageReceived?.Invoke(new NdefMessageReceivedEventArgs(message.ToByteArray()));
                 }
+
+                TagDeparted?.Invoke(NfcTagEventArgs.Empty);
+
+                // session has been invalidated after first read
+                session = null;
             }
 
             public void DidInvalidate(NFCNdefReaderSession session, NSError error)
             {
-                // TODO: probably throw
+                // TODO: probably throw if error != null
             }
         }
     }

--- a/Caboodle/Nfc/Nfc.netstandard.cs
+++ b/Caboodle/Nfc/Nfc.netstandard.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class Nfc
+    {
+    }
+}

--- a/Caboodle/Nfc/Nfc.shared.cs
+++ b/Caboodle/Nfc/Nfc.shared.cs
@@ -4,70 +4,35 @@ namespace Microsoft.Caboodle
 {
     public static partial class Nfc
     {
-        static event NfcTagEventHandler TagArrivedInternal;
+        static bool isListening;
 
-        static event NfcTagEventHandler TagDepartedInternal;
-
-        static event NdefMessageReceivedEventHandler NdefMessageReceivedInternal;
-
-        static bool HasTagListeners => TagArrivedInternal != null || TagDepartedInternal != null;
-
-        public static event NfcTagEventHandler TagArrived
+        public static bool IsListening
         {
-            add
+            get => isListening;
+            set
             {
-                var wasRunning = HasTagListeners;
-                TagArrivedInternal += value;
-                if (!wasRunning && HasTagListeners)
-                    StartTagListeners();
-            }
-
-            remove
-            {
-                var wasRunning = HasTagListeners;
-                TagArrivedInternal -= value;
-                if (wasRunning && !HasTagListeners)
-                    StopTagListeners();
+                if (isListening != value)
+                {
+                    isListening = value;
+                    if (isListening)
+                    {
+                        StartTagListeners();
+                        StartNdefMessageListeners();
+                    }
+                    else
+                    {
+                        StopNdefMessageListeners();
+                        StopTagListeners();
+                    }
+                }
             }
         }
 
-        public static event NfcTagEventHandler TagDeparted
-        {
-            add
-            {
-                var wasRunning = HasTagListeners;
-                TagDepartedInternal += value;
-                if (!wasRunning && HasTagListeners)
-                    StartTagListeners();
-            }
+        public static event NfcTagEventHandler TagArrived;
 
-            remove
-            {
-                var wasRunning = HasTagListeners;
-                TagDepartedInternal -= value;
-                if (wasRunning && HasTagListeners)
-                    StopTagListeners();
-            }
-        }
+        public static event NfcTagEventHandler TagDeparted;
 
-        public static event NdefMessageReceivedEventHandler NdefMessageReceived
-        {
-            add
-            {
-                var wasRunning = NdefMessageReceivedInternal != null;
-                NdefMessageReceivedInternal += value;
-                if (!wasRunning && NdefMessageReceivedInternal != null)
-                    StartNdefMessageListeners();
-            }
-
-            remove
-            {
-                var wasRunning = NdefMessageReceivedInternal != null;
-                NdefMessageReceivedInternal -= value;
-                if (wasRunning && NdefMessageReceivedInternal == null)
-                    StopNdefMessageListeners();
-            }
-        }
+        public static event NdefMessageReceivedEventHandler NdefMessageReceived;
 
         public static void PublishMessage(string messageType, byte[] message)
             => PlatformPublishMessage(messageType, message);

--- a/Caboodle/Nfc/Nfc.shared.cs
+++ b/Caboodle/Nfc/Nfc.shared.cs
@@ -1,0 +1,107 @@
+﻿using System;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class Nfc
+    {
+        static event NfcTagEventHandler TagArrivedInternal;
+
+        static event NfcTagEventHandler TagDepartedInternal;
+
+        static event NdefMessageReceivedEventHandler NdefMessageReceivedInternal;
+
+        static bool HasTagListeners => TagArrivedInternal != null || TagDepartedInternal != null;
+
+        public static event NfcTagEventHandler TagArrived
+        {
+            add
+            {
+                var wasRunning = HasTagListeners;
+                TagArrivedInternal += value;
+                if (!wasRunning && HasTagListeners)
+                    StartTagListeners();
+            }
+
+            remove
+            {
+                var wasRunning = HasTagListeners;
+                TagArrivedInternal -= value;
+                if (wasRunning && !HasTagListeners)
+                    StopTagListeners();
+            }
+        }
+
+        public static event NfcTagEventHandler TagDeparted
+        {
+            add
+            {
+                var wasRunning = HasTagListeners;
+                TagDepartedInternal += value;
+                if (!wasRunning && HasTagListeners)
+                    StartTagListeners();
+            }
+
+            remove
+            {
+                var wasRunning = HasTagListeners;
+                TagDepartedInternal -= value;
+                if (wasRunning && HasTagListeners)
+                    StopTagListeners();
+            }
+        }
+
+        public static event NdefMessageReceivedEventHandler NdefMessageReceived
+        {
+            add
+            {
+                var wasRunning = NdefMessageReceivedInternal != null;
+                NdefMessageReceivedInternal += value;
+                if (!wasRunning && NdefMessageReceivedInternal != null)
+                    StartNdefMessageListeners();
+            }
+
+            remove
+            {
+                var wasRunning = NdefMessageReceivedInternal != null;
+                NdefMessageReceivedInternal -= value;
+                if (wasRunning && NdefMessageReceivedInternal == null)
+                    StopNdefMessageListeners();
+            }
+        }
+
+        public static void PublishMessage(string messageType, byte[] message)
+            => PlatformPublishMessage(messageType, message);
+
+        public static void WriteTag(byte[] message)
+            => PublishMessage("NDEF:WriteTag", message);
+
+        public static void ShareTag(byte[] message)
+            => PublishMessage("NDEF", message);
+
+        public static void StopPublishing()
+            => PlatformStopPublishing();
+    }
+
+    public delegate void NfcTagEventHandler(NfcTagEventArgs e);
+
+    public delegate void NdefMessageReceivedEventHandler(NdefMessageReceivedEventArgs e);
+
+    public class NfcTagEventArgs : EventArgs
+    {
+        public static new readonly NfcTagEventArgs Empty = new NfcTagEventArgs();
+
+        public NfcTagEventArgs()
+        {
+        }
+    }
+
+    public class NdefMessageReceivedEventArgs : EventArgs
+    {
+        public NdefMessageReceivedEventArgs(byte[] message)
+        {
+            Message = message;
+        }
+
+        public byte[] Message { get; }
+    }
+}

--- a/Caboodle/Nfc/Nfc.uwp.cs
+++ b/Caboodle/Nfc/Nfc.uwp.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Networking.Proximity;
+using Windows.Storage.Streams;
+
+namespace Microsoft.Caboodle
+{
+    public static partial class Nfc
+    {
+        static long ndefSubscriptionId = -1;
+        static long publishedMessageId = -1;
+
+        static ProximityDevice DefaultDevice => ProximityDevice.GetDefault();
+
+        internal static bool IsSupported => DefaultDevice != null;
+
+        internal static bool IsEnabled
+        {
+            get
+            {
+                if (IsSupported)
+                {
+                    try
+                    {
+                        return DefaultDevice?.MaxMessageBytes > 0;
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        static void ValidateDeviceState()
+        {
+            if (!IsSupported)
+                throw new NotSupportedException();
+
+            if (!IsEnabled)
+                throw new NotSupportedException();
+        }
+
+        static void PlatformPublishMessage(string messageType, byte[] message)
+        {
+            ValidateDeviceState();
+
+            StopPublishing();
+
+            var dataWriter = new DataWriter
+            {
+                UnicodeEncoding = UnicodeEncoding.Utf16LE
+            };
+            dataWriter.WriteBytes(message);
+
+            publishedMessageId = DefaultDevice.PublishBinaryMessage(
+                messageType, dataWriter.DetachBuffer(), (d, msg) => StopPublishing());
+        }
+
+        static void PlatformStopPublishing()
+        {
+            ValidateDeviceState();
+
+            if (publishedMessageId != -1)
+            {
+                DefaultDevice.StopPublishingMessage(publishedMessageId);
+                publishedMessageId = -1;
+            }
+        }
+
+        static void StartTagListeners()
+        {
+            ValidateDeviceState();
+
+            DefaultDevice.DeviceArrived += OnDeviceArrived;
+            DefaultDevice.DeviceDeparted += OnDeviceDeparted;
+        }
+
+        static void StopTagListeners()
+        {
+            ValidateDeviceState();
+
+            DefaultDevice.DeviceArrived -= OnDeviceArrived;
+            DefaultDevice.DeviceDeparted -= OnDeviceDeparted;
+        }
+
+        static void OnDeviceArrived(ProximityDevice sender)
+        {
+            TagArrivedInternal?.Invoke(NfcTagEventArgs.Empty);
+        }
+
+        static void OnDeviceDeparted(ProximityDevice sender)
+        {
+            TagDepartedInternal?.Invoke(NfcTagEventArgs.Empty);
+        }
+
+        static void StartNdefMessageListeners()
+        {
+            ValidateDeviceState();
+
+            if (ndefSubscriptionId == -1)
+            {
+                ndefSubscriptionId = DefaultDevice.SubscribeForMessage("NDEF", OnNdefMessageReceived);
+            }
+        }
+
+        static void StopNdefMessageListeners()
+        {
+            ValidateDeviceState();
+
+            if (ndefSubscriptionId != -1)
+            {
+                DefaultDevice.StopSubscribingForMessage(ndefSubscriptionId);
+                ndefSubscriptionId = -1;
+            }
+        }
+
+        static void OnNdefMessageReceived(ProximityDevice sender, ProximityMessage message)
+        {
+            var bytes = message.Data.ToArray();
+            NdefMessageReceivedInternal?.Invoke(new NdefMessageReceivedEventArgs(bytes));
+        }
+    }
+}

--- a/Caboodle/Nfc/Nfc.uwp.cs
+++ b/Caboodle/Nfc/Nfc.uwp.cs
@@ -87,12 +87,12 @@ namespace Microsoft.Caboodle
 
         static void OnDeviceArrived(ProximityDevice sender)
         {
-            TagArrivedInternal?.Invoke(NfcTagEventArgs.Empty);
+            TagArrived?.Invoke(NfcTagEventArgs.Empty);
         }
 
         static void OnDeviceDeparted(ProximityDevice sender)
         {
-            TagDepartedInternal?.Invoke(NfcTagEventArgs.Empty);
+            TagDeparted?.Invoke(NfcTagEventArgs.Empty);
         }
 
         static void StartNdefMessageListeners()
@@ -119,7 +119,7 @@ namespace Microsoft.Caboodle
         static void OnNdefMessageReceived(ProximityDevice sender, ProximityMessage message)
         {
             var bytes = message.Data.ToArray();
-            NdefMessageReceivedInternal?.Invoke(new NdefMessageReceivedEventArgs(bytes));
+            NdefMessageReceived?.Invoke(new NdefMessageReceivedEventArgs(bytes));
         }
     }
 }

--- a/Samples/Caboodle.Samples/View/NfcPage.xaml
+++ b/Samples/Caboodle.Samples/View/NfcPage.xaml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:views="clr-namespace:Caboodle.Samples.View"
+                xmlns:viewmodels="clr-namespace:Caboodle.Samples.ViewModel"
+                x:Class="Caboodle.Samples.View.NfcPage"
+                Title="NFC">
+    <ContentPage.BindingContext>
+        <viewmodels:NfcViewModel />
+    </ContentPage.BindingContext>
+
+    <StackLayout>
+        <Label Text="Quickly and easily read and write NFC tags." FontAttributes="Bold" Margin="12" />
+
+        <ScrollView>
+            <StackLayout Padding="12,0,12,12" Spacing="6">
+                <Slider Minimum="0" Maximum="5000" Value="{Binding Duration}" />
+                <Button Text="Vibrate" Command="{Binding VibrateCommand}" />
+                <Button Text="Cancel" Command="{Binding CancelCommand}" />
+                <Label Text="Vibration is not supported." TextColor="Red" FontAttributes="Italic"
+                       IsVisible="{Binding IsSupported, Converter={StaticResource NegativeConverter}}" />
+            </StackLayout>
+        </ScrollView>
+    </StackLayout>
+
+</views:BasePage>

--- a/Samples/Caboodle.Samples/View/NfcPage.xaml.cs
+++ b/Samples/Caboodle.Samples/View/NfcPage.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Caboodle.Samples.View
+{
+    public partial class NfcPage : BasePage
+    {
+        public NfcPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Samples/Caboodle.Samples/ViewModel/HomeViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/HomeViewModel.cs
@@ -20,6 +20,7 @@ namespace Caboodle.Samples.ViewModel
                 new SampleItem("File System", typeof(FileSystemPage), "Easily save files to app data."),
                 new SampleItem("Flashlight", typeof(FlashlightPage), "A simple way to turn the flashlight on/off."),
                 new SampleItem("Geocoding", typeof(GeocodingPage), "Easily geocode and reverse geocoding."),
+                new SampleItem("NFC", typeof(NfcPage), "Quickly and easily read and write NFC tags."),
                 new SampleItem("Phone Dialer", typeof(PhoneDialerPage), "Easily open phone dialer."),
                 new SampleItem("Preferences", typeof(PreferencesPage), "Quickly and easily add persistent preferences."),
                 new SampleItem("Screen Lock", typeof(ScreenLockPage), "Keep the device screen awake."),

--- a/Samples/Caboodle.Samples/ViewModel/NfcViewModel.cs
+++ b/Samples/Caboodle.Samples/ViewModel/NfcViewModel.cs
@@ -1,0 +1,58 @@
+﻿using System.Windows.Input;
+using Microsoft.Caboodle;
+using Xamarin.Forms;
+
+namespace Caboodle.Samples.ViewModel
+{
+    public class NfcViewModel : BaseViewModel
+    {
+        int duration = 500;
+        bool isSupported = true;
+
+        public NfcViewModel()
+        {
+            VibrateCommand = new Command(OnVibrate);
+            CancelCommand = new Command(OnCancel);
+        }
+
+        public ICommand VibrateCommand { get; }
+
+        public ICommand CancelCommand { get; }
+
+        public int Duration
+        {
+            get => duration;
+            set => SetProperty(ref duration, value);
+        }
+
+        public bool IsSupported
+        {
+            get => isSupported;
+            set => SetProperty(ref isSupported, value);
+        }
+
+        void OnVibrate()
+        {
+            try
+            {
+                Vibration.Vibrate(duration);
+            }
+            catch (FeatureNotSupportedException)
+            {
+                IsSupported = false;
+            }
+        }
+
+        void OnCancel()
+        {
+            try
+            {
+                Vibration.Cancel();
+            }
+            catch (FeatureNotSupportedException)
+            {
+                IsSupported = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
**DISCLAIMER: I have no iOS device or any official tags. I am testing with an Android-based tag emulator. Things may not work. 😉**

### Description of Change ###

Adding the NFC API.

### Bugs Fixed ###

- Related to issue #120 

### API Changes ###

```csharp
public static partial class Nfc {
    // when a tag comes near
    public static event NfcTagEventHandler TagArrived;
    public static event NfcTagEventHandler TagDeparted;
    public static event NdefMessageReceivedEventHandler NdefMessageReceived;

    // basically enable/disable events
    public static bool IsListening { get; set; }

    // writing (not supported on iOS)
    public static void PublishMessage(string messageType, byte[] message);
    public static void StopPublishing();

    // helpers for writing NDEF tags (uses PublishMessage under the hood)
    public static void WriteTag(byte[] message);
    public static void ShareTag(byte[] message);
}

public delegate void NfcTagEventHandler(NfcTagEventArgs e);

public delegate void NdefMessageReceivedEventHandler(NdefMessageReceivedEventArgs e);

public class NfcTagEventArgs : EventArgs {
    public static new readonly NfcTagEventArgs Empty;
    public NfcTagEventArgs();
}

public class NdefMessageReceivedEventArgs : EventArgs {
    public NdefMessageReceivedEventArgs(byte[] message);
    public byte[] Message { get; }
}
```

### Behavioral Changes ###

Adding the NFC API.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Caboodle/wiki/Documenting-your-code-with-mdoc))
