### PR TITLE
GH-156 Create new queue if null queue

### DIFF
--- a/Xamarin.Essentials/Accelerometer/Accelerometer.ios.cs
+++ b/Xamarin.Essentials/Accelerometer/Accelerometer.ios.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Essentials
                     break;
             }
 
-            manager.StartAccelerometerUpdates(Platform.CurrentQueue, DataUpdated);
+            manager.StartAccelerometerUpdates(Platform.GetCurrentQueue(), DataUpdated);
         }
 
         static void DataUpdated(CMAccelerometerData data, NSError error)

--- a/Xamarin.Essentials/Accelerometer/Accelerometer.ios.cs
+++ b/Xamarin.Essentials/Accelerometer/Accelerometer.ios.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Essentials
                     break;
             }
 
-            manager.StartAccelerometerUpdates(NSOperationQueue.CurrentQueue, DataUpdated);
+            manager.StartAccelerometerUpdates(Platform.CurrentQueue, DataUpdated);
         }
 
         static void DataUpdated(CMAccelerometerData data, NSError error)

--- a/Xamarin.Essentials/Gyroscope/Gyroscope.ios.cs
+++ b/Xamarin.Essentials/Gyroscope/Gyroscope.ios.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Essentials
                     break;
             }
 
-            manager.StartGyroUpdates(Platform.CurrentQueue, DataUpdated);
+            manager.StartGyroUpdates(Platform.GetCurrentQueue(), DataUpdated);
         }
 
         static void DataUpdated(CMGyroData data, NSError error)

--- a/Xamarin.Essentials/Gyroscope/Gyroscope.ios.cs
+++ b/Xamarin.Essentials/Gyroscope/Gyroscope.ios.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Essentials
                     break;
             }
 
-            manager.StartGyroUpdates(NSOperationQueue.CurrentQueue, DataUpdated);
+            manager.StartGyroUpdates(Platform.CurrentQueue, DataUpdated);
         }
 
         static void DataUpdated(CMGyroData data, NSError error)

--- a/Xamarin.Essentials/Magnetometer/Magnetometer.ios.cs
+++ b/Xamarin.Essentials/Magnetometer/Magnetometer.ios.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Essentials
                     break;
             }
 
-            manager.StartMagnetometerUpdates(NSOperationQueue.CurrentQueue, DataUpdated);
+            manager.StartMagnetometerUpdates(Platform.CurrentQueue, DataUpdated);
         }
 
         static void DataUpdated(CMMagnetometerData data, NSError error)

--- a/Xamarin.Essentials/Magnetometer/Magnetometer.ios.cs
+++ b/Xamarin.Essentials/Magnetometer/Magnetometer.ios.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Essentials
                     break;
             }
 
-            manager.StartMagnetometerUpdates(Platform.CurrentQueue, DataUpdated);
+            manager.StartMagnetometerUpdates(Platform.GetCurrentQueue(), DataUpdated);
         }
 
         static void DataUpdated(CMMagnetometerData data, NSError error)

--- a/Xamarin.Essentials/Platform/Platform.ios.cs
+++ b/Xamarin.Essentials/Platform/Platform.ios.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Essentials
         internal static CMMotionManager MotionManager =>
             motionManager ?? (motionManager = new CMMotionManager());
 
-        internal static NSOperationQueue CurrentQueue =>
+        internal static NSOperationQueue GetCurrentQueue() =>
             NSOperationQueue.CurrentQueue ?? new NSOperationQueue();
     }
 }

--- a/Xamarin.Essentials/Platform/Platform.ios.cs
+++ b/Xamarin.Essentials/Platform/Platform.ios.cs
@@ -57,5 +57,8 @@ namespace Xamarin.Essentials
 
         internal static CMMotionManager MotionManager =>
             motionManager ?? (motionManager = new CMMotionManager());
+
+        internal static NSOperationQueue CurrentQueue =>
+            NSOperationQueue.CurrentQueue ?? new NSOperationQueue();
     }
 }


### PR DESCRIPTION
via:  https://stackoverflow.com/questions/33642590/nsoperationqueue-currentqueue-not-working

### Description of Change ###

If the current queue is null because it is being called from an outside context then create a new one :)

### Bugs Fixed ###

- Related to issue #156

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Xamarin.Essentials/wiki/Documenting-your-code-with-mdoc))
