### PR TITLE
Update links after rebranding

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,4 +31,4 @@ Describe any non-bug related behavioral changes that may change how users app be
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of master at time of PR
 - [ ] Changes adhere to coding standard
-- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Xamarin.Essentials/wiki/Documenting-your-code-with-mdoc))
+- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ You will need to complete a Contribution License Agreement before any pull reque
 
 ## Contributing Code
 
-Check out [A Beginner's Guide for Contributing to Xamarin.Essentials](https://github.com/xamarin/Xamarin.Essentials/wiki/A-Beginner's-Guide-for-Contributing-to-Xamarin.Essentials).
+Check out [A Beginner's Guide for Contributing to Xamarin.Essentials](https://github.com/xamarin/Essentials/wiki/A-Beginner's-Guide-for-Contributing-to-Xamarin.Essentials).
 
 ## Documentation - mdoc
 
@@ -25,7 +25,7 @@ Every pull request which affects public types or members should include correspo
 
 ### Bug Fixes
 
-If you're looking for something to fix, please browse [open issues](https://github.com/xamarin/Xamarin.Essentials/issues). 
+If you're looking for something to fix, please browse [open issues](https://github.com/xamarin/Essentials/issues). 
 
 Follow the style used by the [.NET Foundation](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md), with two primary exceptions:
 
@@ -33,11 +33,11 @@ Follow the style used by the [.NET Foundation](https://github.com/dotnet/corefx/
 - We will **not** use `_` or `s_` as a prefix for internal or private field names
 - We will use `camelCaseFieldName` for naming internal or private fields in both instance and static implementations
 
-Read and follow our [Pull Request template](https://github.com/xamarin/Xamarin.Essentials/blob/master/PULL_REQUEST_TEMPLATE.md)
+Read and follow our [Pull Request template](https://github.com/xamarin/Essentials/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
 
 ### Proposals
 
-To propose a change or new feature, review the guidance below and then [open an issue using this template](https://github.com/xamarin/Xamarin.Essentials/issues/new).
+To propose a change or new feature, review the guidance below and then [open an issue using this template](https://github.com/xamarin/Essentials/issues/new).
 
 #### Non-Starter Topics
 The following topics should generally not be proposed for discussion as they are non-starters:

--- a/SUBMITTING-ISSUES.md
+++ b/SUBMITTING-ISSUES.md
@@ -1,4 +1,4 @@
-If you think you've found a bug to report, before doing anything else you should check the [Issues](https://github.com/xamarin/Xamarin.Essentials/issues) page to see if an issue has already been filed! This can help reduce the number of duplicate reports.
+If you think you've found a bug to report, before doing anything else you should check the [Issues](https://github.com/xamarin/Essentials/issues) page to see if an issue has already been filed! This can help reduce the number of duplicate reports.
 
 If you're ready to submit a new issue, taking the following steps helps expedite the bug triage process:
 


### PR DESCRIPTION
Some links in PULL_REQUEST_TEMPLATE.md, CONTRIBUTING.md and SUBMITTING-ISSUES.md were dead. Probably due to the rebranding. I don't know if you are changing the repo name Xamarin.Essentials.