### PR TITLE
changed mdoc frameworks to match OPS monikers

### DIFF
--- a/Xamarin.Essentials/mdoc.targets
+++ b/Xamarin.Essentials/mdoc.targets
@@ -91,10 +91,10 @@
     <RemoveDir Directories="$(TmpDir)" />
     <MakeDir Directories="$(TmpDir)" />
     <Copy SourceFiles="$(MDocDocumentationDirectory)\..\frameworks.xml" DestinationFolder="$(TmpDir)" />
-    <Copy SourceFiles="$(BinConfigDir)netstandard2.0\$(AssemblyName).dll" DestinationFolder="$(TmpDir)Xamarin.Essentials" />
-    <Copy SourceFiles="$(BinConfigDir)monoandroid71\$(AssemblyName).dll" DestinationFolder="$(TmpDir)Xamarin.Essentials.Android" />
-    <Copy SourceFiles="$(BinConfigDir)xamarin.ios10\$(AssemblyName).dll" DestinationFolder="$(TmpDir)Xamarin.Essentials.iOS" />
-    <Copy SourceFiles="$(BinConfigDir)uap10.0.16299\$(AssemblyName).dll" DestinationFolder="$(TmpDir)Xamarin.Essentials.UWP" />
+    <Copy SourceFiles="$(BinConfigDir)netstandard2.0\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials" />
+    <Copy SourceFiles="$(BinConfigDir)monoandroid71\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials-android" />
+    <Copy SourceFiles="$(BinConfigDir)xamarin.ios10\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials-ios" />
+    <Copy SourceFiles="$(BinConfigDir)uap10.0.16299\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials-uwp" />
     <Exec Command="$(_ManagedExeLauncher) &quot;$(MDocToolPath)&quot; update -lang=DocId --frameworks=&quot;$(TmpDir)frameworks.xml&quot; --out=&quot;$(MDocDocumentationDirectory)&quot; $(MDocReferenceAssemblies)" />
     <_FormatDocs DocsRoot="$(MDocDocumentationDirectory)" />
     <_VerifyAllDocsAreComplete DocsRoot="$(MDocDocumentationDirectory)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -1,4 +1,4 @@
-<Framework Name="Xamarin.Essentials.Android">
+<Framework Name="xamarin-essentials-android">
   <Namespace Name="Xamarin.Essentials">
     <Type Name="Xamarin.Essentials.Accelerometer" Id="T:Xamarin.Essentials.Accelerometer">
       <Member Id="E:Xamarin.Essentials.Accelerometer.ReadingChanged" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -1,4 +1,4 @@
-<Framework Name="Xamarin.Essentials.iOS">
+<Framework Name="xamarin-essentials-ios">
   <Namespace Name="Xamarin.Essentials">
     <Type Name="Xamarin.Essentials.Accelerometer" Id="T:Xamarin.Essentials.Accelerometer">
       <Member Id="E:Xamarin.Essentials.Accelerometer.ReadingChanged" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -1,4 +1,4 @@
-<Framework Name="Xamarin.Essentials">
+<Framework Name="xamarin-essentials-uwp">
   <Namespace Name="Xamarin.Essentials">
     <Type Name="Xamarin.Essentials.Accelerometer" Id="T:Xamarin.Essentials.Accelerometer">
       <Member Id="E:Xamarin.Essentials.Accelerometer.ReadingChanged" />

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -1,4 +1,4 @@
-<Framework Name="Xamarin.Essentials.UWP">
+<Framework Name="xamarin-essentials">
   <Namespace Name="Xamarin.Essentials">
     <Type Name="Xamarin.Essentials.Accelerometer" Id="T:Xamarin.Essentials.Accelerometer">
       <Member Id="E:Xamarin.Essentials.Accelerometer.ReadingChanged" />

--- a/docs/frameworks.xml
+++ b/docs/frameworks.xml
@@ -1,6 +1,6 @@
 <Frameworks>
-  <Framework Name="Xamarin.Essentials" Source="Xamarin.Essentials" />
-  <Framework Name="Xamarin.Essentials.Android" Source="Xamarin.Essentials.Android" />
-  <Framework Name="Xamarin.Essentials.iOS" Source="Xamarin.Essentials.iOS" />
-  <Framework Name="Xamarin.Essentials.UWP" Source="Xamarin.Essentials.UWP" />
+  <Framework Name="xamarin-essentials" Source="xamarin-essentials" />
+  <Framework Name="xamarin-essentials-android" Source="xamarin-essentials-android" />
+  <Framework Name="xamarin-essentials-ios" Source="xamarin-essentials-ios" />
+  <Framework Name="xamarin-essentials-uwp" Source="xamarin-essentials-uwp" />
 </Frameworks>


### PR DESCRIPTION
### Description of Change ###

Changed the monikers per OPS documentation here: https://opsdocs.azurewebsites.net/en-us/opsdocs/partnerdocs/versions-monikers?branch=master

### Bugs Fixed ###

n/a

### API Changes ###

none

### Behavioral Changes ###

No behavioral change, only changed the names of some docs-related artifacts

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
