### PR TITLE
Remove Default Accessibility Modifiers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -44,6 +44,7 @@ dotnet_style_qualification_for_event = false:suggestion
 # Use language keywords instead of framework type names for type references
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_require_accessibility_modifiers = omit_if_default:warning
 
 # Suggest more modern language features when available
 dotnet_style_object_initializer = true:suggestion

--- a/DeviceTests/DeviceTests.Shared/FileSystem_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/FileSystem_Tests.cs
@@ -7,7 +7,7 @@ namespace DeviceTests
 {
     public class FileSystem_Tests
     {
-        private const string bundleFileContents = "This file was in the app bundle.";
+        const string bundleFileContents = "This file was in the app bundle.";
 
         [Fact]
         public void CacheDirectory_Is_Valid()

--- a/DeviceTests/DeviceTests.Shared/Traits.cs
+++ b/DeviceTests/DeviceTests.Shared/Traits.cs
@@ -6,7 +6,7 @@ using XUnitFilter = UnitTests.HeadlessRunner.Xunit.XUnitFilter;
 
 namespace DeviceTests
 {
-    internal static class Traits
+    static class Traits
     {
         public const string DeviceType = "DeviceType";
         public const string InteractionType = "InteractionType";

--- a/Xamarin.Essentials/Connectivity/Connectivity.ios.reachability.cs
+++ b/Xamarin.Essentials/Connectivity/Connectivity.ios.reachability.cs
@@ -8,14 +8,14 @@ using SystemConfiguration;
 
 namespace Xamarin.Essentials
 {
-    internal enum NetworkStatus
+    enum NetworkStatus
     {
         NotReachable,
         ReachableViaCarrierDataNetwork,
         ReachableViaWiFiNetwork
     }
 
-    internal static class Reachability
+    static class Reachability
     {
         static string hostName = "www.microsoft.com";
 

--- a/Xamarin.Essentials/DataTransfer/DataTransfer.ios.cs
+++ b/Xamarin.Essentials/DataTransfer/DataTransfer.ios.cs
@@ -49,5 +49,5 @@ namespace Xamarin.Essentials
         public override NSObject GetPlaceholderData(UIActivityViewController activityViewController) => item;
 
         public override string GetSubjectForActivity(UIActivityViewController activityViewController, NSString activityType) => subject;
-    }s
+    }
 }

--- a/Xamarin.Essentials/DataTransfer/DataTransfer.ios.cs
+++ b/Xamarin.Essentials/DataTransfer/DataTransfer.ios.cs
@@ -31,23 +31,23 @@ namespace Xamarin.Essentials
 
             return vc.PresentViewControllerAsync(activityController, true);
         }
-
-        class ShareActivityItemSource : UIActivityItemSource
-        {
-            NSObject item;
-            string subject;
-
-            public ShareActivityItemSource(NSObject item, string subject)
-            {
-                this.item = item;
-                this.subject = subject;
-            }
-
-            public override NSObject GetItemForActivity(UIActivityViewController activityViewController, NSString activityType) => item;
-
-            public override NSObject GetPlaceholderData(UIActivityViewController activityViewController) => item;
-
-            public override string GetSubjectForActivity(UIActivityViewController activityViewController, NSString activityType) => subject;
-        }
     }
+
+    class ShareActivityItemSource : UIActivityItemSource
+    {
+        NSObject item;
+        string subject;
+
+        public ShareActivityItemSource(NSObject item, string subject)
+        {
+            this.item = item;
+            this.subject = subject;
+        }
+
+        public override NSObject GetItemForActivity(UIActivityViewController activityViewController, NSString activityType) => item;
+
+        public override NSObject GetPlaceholderData(UIActivityViewController activityViewController) => item;
+
+        public override string GetSubjectForActivity(UIActivityViewController activityViewController, NSString activityType) => subject;
+    }s
 }

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
@@ -184,18 +184,18 @@ namespace Xamarin.Essentials
 
         static string GetSystemSetting(string name)
            => Settings.System.GetString(Essentials.Platform.CurrentContext.ContentResolver, name);
+    }
 
-        class Listener : OrientationEventListener
+    class Listener : OrientationEventListener
+    {
+        Action onChanged;
+
+        public Listener(Context context, Action handler)
+            : base(context)
         {
-            Action onChanged;
-
-            public Listener(Context context, Action handler)
-                : base(context)
-            {
-                onChanged = handler;
-            }
-
-            public override void OnOrientationChanged(int orientation) => onChanged();
+            onChanged = handler;
         }
+
+        public override void OnOrientationChanged(int orientation) => onChanged();
     }
 }

--- a/Xamarin.Essentials/Geolocation/Geolocation.android.cs
+++ b/Xamarin.Essentials/Geolocation/Geolocation.android.cs
@@ -87,35 +87,6 @@ namespace Xamarin.Essentials
             }
         }
 
-        class SingleLocationListener : Java.Lang.Object, ILocationListener
-        {
-            bool wasRaised = false;
-
-            public Action<AndroidLocation> LocationHandler { get; set; }
-
-            public void OnLocationChanged(AndroidLocation location)
-            {
-                if (wasRaised)
-                    return;
-
-                wasRaised = true;
-
-                LocationHandler?.Invoke(location);
-            }
-
-            public void OnProviderDisabled(string provider)
-            {
-            }
-
-            public void OnProviderEnabled(string provider)
-            {
-            }
-
-            public void OnStatusChanged(string provider, [GeneratedEnum] Availability status, Bundle extras)
-            {
-            }
-        }
-
         static string GetBestProvider(LocationManager locationManager, GeolocationAccuracy accuracy)
         {
             var criteria = new Criteria();
@@ -189,6 +160,35 @@ namespace Xamarin.Essentials
                 return true;
 
             return false;
+        }
+    }
+
+    class SingleLocationListener : Java.Lang.Object, ILocationListener
+    {
+        bool wasRaised = false;
+
+        public Action<AndroidLocation> LocationHandler { get; set; }
+
+        public void OnLocationChanged(AndroidLocation location)
+        {
+            if (wasRaised)
+                return;
+
+            wasRaised = true;
+
+            LocationHandler?.Invoke(location);
+        }
+
+        public void OnProviderDisabled(string provider)
+        {
+        }
+
+        public void OnProviderEnabled(string provider)
+        {
+        }
+
+        public void OnStatusChanged(string provider, [GeneratedEnum] Availability status, Bundle extras)
+        {
         }
     }
 }

--- a/Xamarin.Essentials/Geolocation/Geolocation.ios.cs
+++ b/Xamarin.Essentials/Geolocation/Geolocation.ios.cs
@@ -66,27 +66,27 @@ namespace Xamarin.Essentials
                 tcs.TrySetResult(null);
             }
         }
+    }
 
-        class SingleLocationListener : CLLocationManagerDelegate
+    class SingleLocationListener : CLLocationManagerDelegate
+    {
+        bool wasRaised = false;
+
+        public Action<CLLocation> LocationHandler { get; set; }
+
+        public override void LocationsUpdated(CLLocationManager manager, CLLocation[] locations)
         {
-            bool wasRaised = false;
+            if (wasRaised)
+                return;
 
-            public Action<CLLocation> LocationHandler { get; set; }
+            wasRaised = true;
 
-            public override void LocationsUpdated(CLLocationManager manager, CLLocation[] locations)
-            {
-                if (wasRaised)
-                    return;
+            var location = locations.LastOrDefault();
 
-                wasRaised = true;
+            if (location == null)
+                return;
 
-                var location = locations.LastOrDefault();
-
-                if (location == null)
-                    return;
-
-                LocationHandler?.Invoke(location);
-            }
+            LocationHandler?.Invoke(location);
         }
     }
 }

--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -10,7 +10,7 @@ using Android.Support.V4.Content;
 
 namespace Xamarin.Essentials
 {
-    static partial class Permissions
+    internal static partial class Permissions
     {
         static readonly object locker = new object();
         static int requestCode = 0;

--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -10,7 +10,7 @@ using Android.Support.V4.Content;
 
 namespace Xamarin.Essentials
 {
-    internal static partial class Permissions
+    static partial class Permissions
     {
         static readonly object locker = new object();
         static int requestCode = 0;
@@ -133,7 +133,7 @@ namespace Xamarin.Essentials
         }
     }
 
-    internal static class PermissionTypeExtensions
+    static class PermissionTypeExtensions
     {
         internal static IEnumerable<string> ToAndroidPermissions(this PermissionType permissionType, bool onlyRuntimePermissions)
         {

--- a/Xamarin.Essentials/Permissions/Permissions.shared.enums.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.enums.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Essentials
 {
-    internal enum PermissionStatus
+    enum PermissionStatus
     {
         // Denied by user
         Denied,
@@ -18,7 +18,7 @@
         Unknown
     }
 
-    internal enum PermissionType
+    enum PermissionType
     {
         Unknown,
         Battery,

--- a/Xamarin.Essentials/Permissions/Permissions.uwp.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.uwp.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Essentials
         }
     }
 
-    internal static class PermissionTypeExtensions
+    static class PermissionTypeExtensions
     {
         internal static string[] ToUWPCapabilities(this PermissionType permissionType)
         {

--- a/Xamarin.Essentials/Types/Shared/PreserveAttribute.shared.cs
+++ b/Xamarin.Essentials/Types/Shared/PreserveAttribute.shared.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Essentials
 {
     [AttributeUsage(AttributeTargets.All)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal sealed class PreserveAttribute : Attribute
+    sealed class PreserveAttribute : Attribute
     {
 #pragma warning disable SA1401 // Fields should be private
         public bool AllMembers;


### PR DESCRIPTION
### Description of Change ###

Removed default accessibility, no `private` modifiers for members, and no `internal` modifiers for global.
Also, moved a few classes out of the nest and into the globe.

### Bugs Fixed ###

- None.

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
