### PR TITLE
[SecureStorage] Use IvParameterSpec instead of GCM

### DIFF
--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -237,14 +237,27 @@ namespace Xamarin.Essentials
                 return null;
 
             var key = GetKey();
-            var cipher = Cipher.GetInstance(cipherTransformationSymmetric);
 
             // IV will be the first 16 bytes of the encrypted data
             var iv = new byte[initializationVectorLen];
             Buffer.BlockCopy(data, 0, iv, 0, initializationVectorLen);
 
-            var gcm = new GCMParameterSpec(128, iv);
-            cipher.Init(CipherMode.DecryptMode, key, gcm);
+            // Attempt to use GCMParameterSpec by default
+            try
+            {
+                cipher = Cipher.GetInstance(cipherTransformationSymmetric);
+                cipher.Init(CipherMode.DecryptMode, key, new GCMParameterSpec(128, iv));
+            }
+            catch (Java.Security.InvalidAlgorithmParameterException)
+            {
+                // If we encounter this error, it's likely an old bouncycastle provider version
+                // is being used which does not recognize GCMParameterSpec, but should work
+                // with IvParameterSpec, however we only do this as a last effort since other
+                // implementations will error if you use IvParameterSpec when GCMParameterSpec
+                // is recognized and expected.
+                cipher = Cipher.GetInstance(cipherTransformationSymmetric);
+                cipher.Init(CipherMode.DecryptMode, key, new IvParameterSpec(iv));
+            }
 
             // Decrypt starting after the first 16 bytes from the IV
             var decryptedData = cipher.DoFinal(data, initializationVectorLen, data.Length - initializationVectorLen);

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Essentials
                 cipher = Cipher.GetInstance(cipherTransformationSymmetric);
                 cipher.Init(CipherMode.EncryptMode, key, new GCMParameterSpec(128, iv));
             }
-            catch (Java.Security.InvalidAlgorithmParameterException apEx)
+            catch (Java.Security.InvalidAlgorithmParameterException)
             {
                 // If we encounter this error, it's likely an old bouncycastle provider version
                 // is being used which does not recognize GCMParameterSpec, but should work

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -202,7 +202,7 @@ namespace Xamarin.Essentials
             sr.NextBytes(iv);
 
             var cipher = Cipher.GetInstance(cipherTransformationSymmetric);
-            cipher.Init(CipherMode.EncryptMode, key, new GCMParameterSpec(128, iv));
+            cipher.Init(CipherMode.EncryptMode, key, new IvParameterSpec(iv));
 
             var decryptedData = Encoding.UTF8.GetBytes(data);
             var encryptedBytes = cipher.DoFinal(decryptedData);

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -202,7 +202,12 @@ namespace Xamarin.Essentials
             sr.NextBytes(iv);
 
             var cipher = Cipher.GetInstance(cipherTransformationSymmetric);
-            cipher.Init(CipherMode.EncryptMode, key, new IvParameterSpec(iv));
+
+            // Use GCMParameterSpec on newer API levels and IvParameterSpec on older
+            if (Platform.HasApiLevel(BuildVersionCodes.M) && !alwaysUseAsymmetricKey)
+                cipher.Init(CipherMode.EncryptMode, key, new GCMParameterSpec(128, iv));
+            else
+                cipher.Init(CipherMode.EncryptMode, key, new IvParameterSpec(iv));
 
             var decryptedData = Encoding.UTF8.GetBytes(data);
             var encryptedBytes = cipher.DoFinal(decryptedData);

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -242,6 +242,8 @@ namespace Xamarin.Essentials
             var iv = new byte[initializationVectorLen];
             Buffer.BlockCopy(data, 0, iv, 0, initializationVectorLen);
 
+            Cipher cipher;
+
             // Attempt to use GCMParameterSpec by default
             try
             {

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -204,7 +204,7 @@ namespace Xamarin.Essentials
             var cipher = Cipher.GetInstance(cipherTransformationSymmetric);
 
             // Use GCMParameterSpec on newer API levels and IvParameterSpec on older
-            if (Platform.HasApiLevel(BuildVersionCodes.M) && !alwaysUseAsymmetricKey)
+            if (Platform.HasApiLevel(BuildVersionCodes.M))
                 cipher.Init(CipherMode.EncryptMode, key, new GCMParameterSpec(128, iv));
             else
                 cipher.Init(CipherMode.EncryptMode, key, new IvParameterSpec(iv));


### PR DESCRIPTION
Seeing some older devices have issues with `GCMParameterSpec` not being supported in older BouncyCastle library versions.  We are hitting the exception here: https://github.com/bcgit/bc-java/blob/r1rv49/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/util/BaseBlockCipher.java#L533

If you look at the code, it's clear that `GCMParameterSpec` is not recognized as a valid parameter type yet in that commit, however newer commits of this library do recognize it.

It seems like switching to `IvParameterSpec` should be harmless and make this work on older implementations.  It looks like the only difference is the ability to specify the GCM Tag size, but we are using the default 128 size anyway.

### Description of Change ###

Fixes some issues on older android devices with Secure Storage
