### PR TITLE
GT-200 - Use Vector3 for sensor data returns.

### DIFF
--- a/Samples/Samples/ViewModel/AccelerometerViewModel.cs
+++ b/Samples/Samples/ViewModel/AccelerometerViewModel.cs
@@ -101,15 +101,15 @@ namespace Samples.ViewModel
                 case SensorSpeed.Game:
                     Platform.BeginInvokeOnMainThread(() =>
                     {
-                        X = data.AccelerometerX;
-                        Y = data.AccelerometerY;
-                        Z = data.AccelerometerZ;
+                        X = data.Acceleration.X;
+                        Y = data.Acceleration.Y;
+                        Z = data.Acceleration.Z;
                     });
                     break;
                 default:
-                    X = data.AccelerometerX;
-                    Y = data.AccelerometerY;
-                    Z = data.AccelerometerZ;
+                    X = data.Acceleration.X;
+                    Y = data.Acceleration.Y;
+                    Z = data.Acceleration.Z;
                     break;
             }
         }

--- a/Samples/Samples/ViewModel/GyroscopeViewModel.cs
+++ b/Samples/Samples/ViewModel/GyroscopeViewModel.cs
@@ -82,15 +82,15 @@ namespace Samples.ViewModel
                 case SensorSpeed.Game:
                     Platform.BeginInvokeOnMainThread(() =>
                     {
-                        X = data.AngularVelocityX;
-                        Y = data.AngularVelocityY;
-                        Z = data.AngularVelocityZ;
+                        X = data.AngularVelocity.X;
+                        Y = data.AngularVelocity.Y;
+                        Z = data.AngularVelocity.Z;
                     });
                     break;
                 default:
-                    X = data.AngularVelocityX;
-                    Y = data.AngularVelocityY;
-                    Z = data.AngularVelocityZ;
+                    X = data.AngularVelocity.X;
+                    Y = data.AngularVelocity.Y;
+                    Z = data.AngularVelocity.Z;
                     break;
             }
         }

--- a/Samples/Samples/ViewModel/MagnetometerViewModel.cs
+++ b/Samples/Samples/ViewModel/MagnetometerViewModel.cs
@@ -82,15 +82,15 @@ namespace Samples.ViewModel
                 case SensorSpeed.Game:
                     Platform.BeginInvokeOnMainThread(() =>
                     {
-                        X = data.MagneticFieldX;
-                        Y = data.MagneticFieldY;
-                        Z = data.MagneticFieldZ;
+                        X = data.MagneticField.X;
+                        Y = data.MagneticField.Y;
+                        Z = data.MagneticField.Z;
                     });
                     break;
                 default:
-                    X = data.MagneticFieldX;
-                    Y = data.MagneticFieldY;
-                    Z = data.MagneticFieldZ;
+                    X = data.MagneticField.X;
+                    Y = data.MagneticField.Y;
+                    Z = data.MagneticField.Z;
                     break;
             }
         }

--- a/Xamarin.Essentials/Accelerometer/Accelerometer.shared.cs
+++ b/Xamarin.Essentials/Accelerometer/Accelerometer.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 
 namespace Xamarin.Essentials
 {
@@ -81,16 +82,13 @@ namespace Xamarin.Essentials
     public struct AccelerometerData
     {
         internal AccelerometerData(double x, double y, double z)
+            : this((float)x, (float)y, (float)z)
         {
-            AccelerometerX = x;
-            AccelerometerY = y;
-            AccelerometerZ = z;
         }
 
-        public double AccelerometerX { get; }
+        internal AccelerometerData(float x, float y, float z) =>
+            Acceleration = new Vector3(x, y, z);
 
-        public double AccelerometerY { get; }
-
-        public double AccelerometerZ { get; }
+        public Vector3 Acceleration { get; }
     }
 }

--- a/Xamarin.Essentials/Compass/Compass.shared.cs
+++ b/Xamarin.Essentials/Compass/Compass.shared.cs
@@ -81,10 +81,8 @@ namespace Xamarin.Essentials
 
     public struct CompassData
     {
-        internal CompassData(double headingMagneticNorth)
-        {
+        internal CompassData(double headingMagneticNorth) =>
             HeadingMagneticNorth = headingMagneticNorth;
-        }
 
         public double HeadingMagneticNorth { get; }
     }

--- a/Xamarin.Essentials/Gyroscope/Gyroscope.shared.cs
+++ b/Xamarin.Essentials/Gyroscope/Gyroscope.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 
 namespace Xamarin.Essentials
 {
@@ -81,16 +82,13 @@ namespace Xamarin.Essentials
     public struct GyroscopeData
     {
         internal GyroscopeData(double x, double y, double z)
+            : this((float)x, (float)y, (float)z)
         {
-            AngularVelocityX = x;
-            AngularVelocityY = y;
-            AngularVelocityZ = z;
         }
 
-        public double AngularVelocityX { get; }
+        internal GyroscopeData(float x, float y, float z) =>
+            AngularVelocity = new Vector3(x, y, z);
 
-        public double AngularVelocityY { get; }
-
-        public double AngularVelocityZ { get; }
+        public Vector3 AngularVelocity { get; }
     }
 }

--- a/Xamarin.Essentials/Magnetometer/Magnetometer.shared.cs
+++ b/Xamarin.Essentials/Magnetometer/Magnetometer.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 
 namespace Xamarin.Essentials
 {
@@ -81,16 +82,13 @@ namespace Xamarin.Essentials
     public struct MagnetometerData
     {
         internal MagnetometerData(double x, double y, double z)
+            : this((float)x, (float)y, (float)z)
         {
-            MagneticFieldX = x;
-            MagneticFieldY = y;
-            MagneticFieldZ = z;
         }
 
-        public double MagneticFieldX { get; }
+        internal MagnetometerData(float x, float y, float z) =>
+            MagneticField = new Vector3(x, y, z);
 
-        public double MagneticFieldY { get; }
-
-        public double MagneticFieldZ { get; }
+        public Vector3 MagneticField { get; }
     }
 }

--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -46,6 +46,7 @@
     <Compile Include="**\*.shared.*.cs" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
+    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
     <Compile Include="**\*.netstandard.cs" />
     <Compile Include="**\*.netstandard.*.cs" />
   </ItemGroup>
@@ -61,11 +62,14 @@
     
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="25.4.0.2" />
     <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="25.4.0.2" />
-    
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors" />
     <Compile Include="**\*.android.cs" />
     <Compile Include="**\*.android.*.cs" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors" />
     <Compile Include="**\*.ios.cs" />
     <Compile Include="**\*.ios.*.cs" />
   </ItemGroup>

--- a/docs/en/Xamarin.Essentials/AccelerometerData.xml
+++ b/docs/en/Xamarin.Essentials/AccelerometerData.xml
@@ -17,64 +17,22 @@
     </remarks>
   </Docs>
   <Members>
-    <Member MemberName="AccelerometerX">
-      <MemberSignature Language="C#" Value="public double AccelerometerX { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance float64 AccelerometerX" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.AccelerometerData.AccelerometerX" />
+    <Member MemberName="Acceleration">
+      <MemberSignature Language="C#" Value="public System.Numerics.Vector3 Acceleration { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype System.Numerics.Vector3 Acceleration" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
         <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
+        <ReturnType>System.Numerics.Vector3</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the value for the X-Axis in m/s². </summary>
-        <value>The X-Axis value.</value>
-        <remarks>
-          <para />
-        </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="AccelerometerY">
-      <MemberSignature Language="C#" Value="public double AccelerometerY { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance float64 AccelerometerY" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.AccelerometerData.AccelerometerY" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Gets the value for the Y-Axis in m/s². </summary>
-        <value>The Y-Axis value.</value>
-        <remarks>
-          <para />
-        </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="AccelerometerZ">
-      <MemberSignature Language="C#" Value="public double AccelerometerZ { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance float64 AccelerometerZ" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.AccelerometerData.AccelerometerZ" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Gets the value for the Z-Axis in m/s². </summary>
-        <value>The Z-Axis value.</value>
-        <remarks>
-          <para />
-        </remarks>
+        <summary>Gets the acceleration vector in m/s². </summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/docs/en/Xamarin.Essentials/GyroscopeData.xml
+++ b/docs/en/Xamarin.Essentials/GyroscopeData.xml
@@ -17,58 +17,22 @@
     </remarks>
   </Docs>
   <Members>
-    <Member MemberName="AngularVelocityX">
-      <MemberSignature Language="C#" Value="public double AngularVelocityX { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance float64 AngularVelocityX" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.GyroscopeData.AngularVelocityX" />
+    <Member MemberName="AngularVelocity">
+      <MemberSignature Language="C#" Value="public System.Numerics.Vector3 AngularVelocity { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype System.Numerics.Vector3 AngularVelocity" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.GyroscopeData.AngularVelocity" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
         <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
+        <ReturnType>System.Numerics.Vector3</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the value for the X-Axis in rad/s.</summary>
-        <value>The X-Axis value.</value>
-        <remarks></remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="AngularVelocityY">
-      <MemberSignature Language="C#" Value="public double AngularVelocityY { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance float64 AngularVelocityY" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.GyroscopeData.AngularVelocityY" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Gets the value for the Y-Axis in rad/s.</summary>
-        <value>The Y-Axis value.</value>
-        <remarks></remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="AngularVelocityZ">
-      <MemberSignature Language="C#" Value="public double AngularVelocityZ { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance float64 AngularVelocityZ" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.GyroscopeData.AngularVelocityZ" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Gets the value for the Z-Axis in rad/s.</summary>
-        <value>The Z-Axis value.</value>
-        <remarks></remarks>
+        <summary>Gets the angular velocity vector in rad/s.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/docs/en/Xamarin.Essentials/MagnetometerData.xml
+++ b/docs/en/Xamarin.Essentials/MagnetometerData.xml
@@ -17,62 +17,22 @@
     </remarks>
   </Docs>
   <Members>
-    <Member MemberName="MagneticFieldX">
-      <MemberSignature Language="C#" Value="public double MagneticFieldX { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance float64 MagneticFieldX" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.MagnetometerData.MagneticFieldX" />
+    <Member MemberName="MagneticField">
+      <MemberSignature Language="C#" Value="public System.Numerics.Vector3 MagneticField { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype System.Numerics.Vector3 MagneticField" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.MagnetometerData.MagneticField" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
         <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
+        <ReturnType>System.Numerics.Vector3</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets X-axis magnetic field in mciroteslas.</summary>
-        <value>X-axis data</value>
-        <remarks></remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="MagneticFieldY">
-      <MemberSignature Language="C#" Value="public double MagneticFieldY { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance float64 MagneticFieldY" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.MagnetometerData.MagneticFieldY" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Gets Y-axis magnetic field in mciroteslas.</summary>
-        <value>Y-axis data.</value>
-        <remarks>
-          <para />
-        </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="MagneticFieldZ">
-      <MemberSignature Language="C#" Value="public double MagneticFieldZ { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance float64 MagneticFieldZ" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.MagnetometerData.MagneticFieldZ" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Gets Z-axis magnetid field in mciroteslas.</summary>
-        <value>Z-axis data.</value>
-        <remarks>
-          <para></para>
-        </remarks>
+        <summary>Gets the magnetic field vector in microteslas.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
### Description of Change ###

Brings in vectors nuget into .net standard and update all sensors to use vector3

### Bugs Fixed ###

- Related to issue #200 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

Updated GyroData/AccelerometerData/Magentometer Data to have a single Vector#

### Behavioral Changes ###

None.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
