### PR TITLE
GH-202: Don't ever show calibration on iOS for location

### DIFF
--- a/Xamarin.Essentials/Geolocation/Geolocation.ios.cs
+++ b/Xamarin.Essentials/Geolocation/Geolocation.ios.cs
@@ -88,5 +88,7 @@ namespace Xamarin.Essentials
 
             LocationHandler?.Invoke(location);
         }
+
+        public override bool ShouldDisplayHeadingCalibration(CLLocationManager manager) => false;
     }
 }


### PR DESCRIPTION
### Description of Change ###

We should not ever show the calibration screen as it will be very annoying

### Bugs Fixed ###

- Related to issue #202

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### Behavioral Changes ###

This will ensure it the calibration for heading never comes up.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
