### PR TITLE
GH-205: Fix for flashlight toggling off when permission was prompted.

### DIFF
--- a/Samples/Samples/ViewModel/FlashlightViewModel.cs
+++ b/Samples/Samples/ViewModel/FlashlightViewModel.cs
@@ -30,6 +30,9 @@ namespace Samples.ViewModel
 
         public override void OnDisappearing()
         {
+            if (!IsOn)
+                return;
+
             try
             {
                 Flashlight.TurnOffAsync();

--- a/Xamarin.Essentials/Flashlight/Flashlight.android.cs
+++ b/Xamarin.Essentials/Flashlight/Flashlight.android.cs
@@ -28,14 +28,14 @@ namespace Xamarin.Essentials
 
             await ToggleTorchAsync(true);
         }
-        
+
         static async Task PlatformTurnOffAsync()
         {
             await CheckSupportAsync();
 
             await ToggleTorchAsync(false);
         }
-        
+
         static async Task CheckSupportAsync()
         {
             if (!IsSupported)

--- a/Xamarin.Essentials/Flashlight/Flashlight.android.cs
+++ b/Xamarin.Essentials/Flashlight/Flashlight.android.cs
@@ -24,20 +24,22 @@ namespace Xamarin.Essentials
 
         static async Task PlatformTurnOnAsync()
         {
-            await Permissions.RequireAsync(PermissionType.Flashlight);
-
-            if (!IsSupported)
-                throw new FeatureNotSupportedException();
+            await CheckSupport();
 
             await ToggleTorchAsync(true);
         }
 
-        static async Task PlatformTurnOffAsync()
+        private static async Task CheckSupport()
         {
-            await Permissions.RequireAsync(PermissionType.Flashlight);
-
             if (!IsSupported)
                 throw new FeatureNotSupportedException();
+
+            await Permissions.RequireAsync(PermissionType.Flashlight);
+        }
+
+        static async Task PlatformTurnOffAsync()
+        {
+            await CheckSupport();
 
             await ToggleTorchAsync(false);
         }

--- a/Xamarin.Essentials/Flashlight/Flashlight.android.cs
+++ b/Xamarin.Essentials/Flashlight/Flashlight.android.cs
@@ -24,24 +24,24 @@ namespace Xamarin.Essentials
 
         static async Task PlatformTurnOnAsync()
         {
-            await CheckSupport();
+            await CheckSupportAsync();
 
             await ToggleTorchAsync(true);
         }
+        
+        static async Task PlatformTurnOffAsync()
+        {
+            await CheckSupportAsync();
 
-        private static async Task CheckSupport()
+            await ToggleTorchAsync(false);
+        }
+        
+        static async Task CheckSupportAsync()
         {
             if (!IsSupported)
                 throw new FeatureNotSupportedException();
 
             await Permissions.RequireAsync(PermissionType.Flashlight);
-        }
-
-        static async Task PlatformTurnOffAsync()
-        {
-            await CheckSupport();
-
-            await ToggleTorchAsync(false);
         }
 
         static Task ToggleTorchAsync(bool switchOn)


### PR DESCRIPTION
### Description of Change ###

Don't turn off flashlight if not on on dissappearing. (permission prompt).

Also refactor a bit of code.

### Bugs Fixed ###

- Related to issue #205

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

None

### Behavioral Changes ###

Don't prompt for permission if not supported. Throw first.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
