### PR TITLE
Fix restore / build issue

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -17,7 +17,7 @@ if ($IsMacOS) {
 Write-Output "Using MSBuild from: $msbuild"
 
 # Build the projects
-& $msbuild "./Xamarin.Essentials.sln" /t:"Restore;Build" /p:Configuration=Release
+& $msbuild "./Xamarin.Essentials.sln" /restore /t:Build /p:Configuration=Release
 if ($lastexitcode -ne 0) { exit $lastexitcode; }
 
 # Create the stable NuGet package


### PR DESCRIPTION
Restore and build cannot be invoked at the same time. Restore must be done with a switch.

### Description of Change ###
Fixes incorrect msbuild usage.

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #
See this issue: https://github.com/dotnet/sdk/issues/2170

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- string - string Class.Property { get; set; } 
- void Class.Method();

Changed:

 - object Cell.OldPropertyName => object Cell.NewPropertyName

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
