### PR TITLE
GH-221: Add iOS SecAccessible properties

### DIFF
--- a/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
@@ -23,6 +23,13 @@ namespace DeviceTests
             // TODO: we don't know how to write iOS apps, it appears, so just skip for now
             if (DeviceInfo.DeviceType == DeviceType.Virtual)
                 return;
+
+            // Try the new platform specific api
+            await SecureStorage.SetAsync(key, data, Security.SecAccessible.AfterFirstUnlock);
+
+            var b = await SecureStorage.GetAsync(key, Security.SecAccessible.AfterFirstUnlock);
+
+            Assert.Equal(data, b);
 #endif
 
 #if __ANDROID__

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -8,39 +8,59 @@ namespace Xamarin.Essentials
 {
     public static partial class SecureStorage
     {
-        static Task<string> PlatformGetAsync(string key)
+        public static Task<string> GetAsync(string key, SecAccessible accessible)
         {
-            var kc = new KeyChain();
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+
+            var kc = new KeyChain(accessible);
 
             return Task.FromResult(kc.ValueForKey(key, Alias));
         }
 
-        static Task PlatformSetAsync(string key, string data)
+        public static Task SetAsync(string key, string value, SecAccessible accessible)
         {
-            var kc = new KeyChain();
-            kc.SetValueForKey(data, key, Alias);
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            var kc = new KeyChain(accessible);
+            kc.SetValueForKey(value, key, Alias);
 
             return Task.CompletedTask;
         }
+
+        static Task<string> PlatformGetAsync(string key) =>
+            GetAsync(key, SecAccessible.AfterFirstUnlockThisDeviceOnly);
+
+        static Task PlatformSetAsync(string key, string data) =>
+            SetAsync(key, data, SecAccessible.AfterFirstUnlockThisDeviceOnly);
     }
 
     class KeyChain
     {
-        static SecRecord ExistingRecordForKey(string key, string service)
+        SecAccessible accessible;
+
+        internal KeyChain(SecAccessible accessible) =>
+            this.accessible = accessible;
+
+        SecRecord ExistingRecordForKey(string key, string service)
         {
             return new SecRecord(SecKind.GenericPassword)
             {
                 Account = key,
                 Service = service,
                 Label = key,
+                Accessible = accessible
             };
         }
 
         internal string ValueForKey(string key, string service)
         {
             var record = ExistingRecordForKey(key, service);
-            SecStatusCode resultCode;
-            var match = SecKeyChain.QueryAsRecord(record, out resultCode);
+            var match = SecKeyChain.QueryAsRecord(record, out var resultCode);
 
             if (resultCode == SecStatusCode.Success)
                 return NSString.FromData(match.ValueData, NSStringEncoding.UTF8);
@@ -75,6 +95,7 @@ namespace Xamarin.Essentials
                 Account = key,
                 Service = service,
                 Label = key,
+                Accessible = accessible,
                 ValueData = NSData.FromString(value, NSStringEncoding.UTF8),
             };
         }

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -8,6 +8,9 @@ namespace Xamarin.Essentials
 {
     public static partial class SecureStorage
     {
+        public static SecAccessible DefaultAccessible { get; set; } =
+            SecAccessible.AfterFirstUnlockThisDeviceOnly;
+
         public static Task<string> GetAsync(string key, SecAccessible accessible)
         {
             if (string.IsNullOrWhiteSpace(key))
@@ -33,10 +36,10 @@ namespace Xamarin.Essentials
         }
 
         static Task<string> PlatformGetAsync(string key) =>
-            GetAsync(key, SecAccessible.AfterFirstUnlockThisDeviceOnly);
+            GetAsync(key, DefaultAccessible);
 
         static Task PlatformSetAsync(string key, string data) =>
-            SetAsync(key, data, SecAccessible.AfterFirstUnlockThisDeviceOnly);
+            SetAsync(key, data, DefaultAccessible);
     }
 
     class KeyChain

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Essentials
     public static partial class SecureStorage
     {
         public static SecAccessible DefaultAccessible { get; set; } =
-            SecAccessible.AfterFirstUnlockThisDeviceOnly;
+            SecAccessible.AfterFirstUnlock;
 
         public static Task<string> GetAsync(string key, SecAccessible accessible)
         {


### PR DESCRIPTION
### Description of Change ###

Default iOS to AfterFirstUnlockThisDeviceOnly for the cross-platform API, but allow custom platform specific methods to pass in the SecAccessible

### Bugs Fixed ###

- Related to issue #221

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
-  Task<string> GetAsync(string key, SecAccessible accessible)
- Task SetAsync(string key, string value, SecAccessible accessible)

### Behavioral Changes ###

Nothing for iOS as this was the default before and what should be exposed.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
