### PR TITLE
GH-229: Make sure to set the email properties

### DIFF
--- a/Xamarin.Essentials/Email/Email.shared.cs
+++ b/Xamarin.Essentials/Email/Email.shared.cs
@@ -53,6 +53,8 @@ namespace Xamarin.Essentials
 
         public EmailMessage(string subject, string body, params string[] to)
         {
+            Subject = subject;
+            Body = body;
             To = to?.ToList() ?? new List<string>();
         }
 


### PR DESCRIPTION
### Description of Change ###

Set the `EmailMessage` properties when using the constructor.

### Bugs Fixed ###

- Related to issue #229

### API Changes ###

No public changes.

### Behavioral Changes ###

Fixed a bug.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
