### PR TITLE
GH-192: Added DateTime to Preferences

### DIFF
--- a/DeviceTests/DeviceTests.Shared/Preferences_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Preferences_Tests.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Essentials;
+﻿using System;
+using Xamarin.Essentials;
 using Xunit;
 
 namespace DeviceTests
@@ -6,6 +7,18 @@ namespace DeviceTests
     public class Preferences_Tests
     {
         const string sharedNameTestData = "Shared";
+
+        static DateTime testDateTime = new DateTime(2018, 05, 07);
+
+        [Theory]
+        [InlineData("datetime1", null)]
+        [InlineData("datetime1", sharedNameTestData)]
+        public void Set_Get_DateTime(string key, string sharedName)
+        {
+            Preferences.Set(key, testDateTime, sharedName);
+
+            Assert.Equal(testDateTime, Preferences.Get(key, DateTime.MinValue, sharedName));
+        }
 
         [Theory]
         [InlineData("string1", "TEST", null)]
@@ -129,6 +142,23 @@ namespace DeviceTests
             Preferences.Remove("NotContainsKey1", sharedName);
 
             Assert.False(Preferences.ContainsKey("NotContainsKey1", sharedName));
+        }
+
+        [Theory]
+        [InlineData(null, DateTimeKind.Utc)]
+        [InlineData(sharedNameTestData, DateTimeKind.Utc)]
+        [InlineData(null, DateTimeKind.Local)]
+        [InlineData(sharedNameTestData, DateTimeKind.Local)]
+        public void DateTimePreservesKind(string sharedName, DateTimeKind kind)
+        {
+            var date = new DateTime(2018, 05, 07, 8, 30, 0, kind);
+
+            Preferences.Set("datetime_utc", date, sharedName);
+
+            var get = Preferences.Get("datetime_utc", DateTime.MinValue, sharedName);
+
+            Assert.Equal(date, get);
+            Assert.Equal(kind, get.Kind);
         }
     }
 }

--- a/Xamarin.Essentials/Preferences/Preferences.shared.cs
+++ b/Xamarin.Essentials/Preferences/Preferences.shared.cs
@@ -1,63 +1,69 @@
-﻿namespace Xamarin.Essentials
+﻿using System;
+
+namespace Xamarin.Essentials
 {
     public static partial class Preferences
     {
         internal static string PrivatePreferencesSharedName =>
             $"{AppInfo.PackageName}.xamarinessentials";
 
+        // overloads
+
         public static bool ContainsKey(string key) =>
-            PlatformContainsKey(key, null);
+            ContainsKey(key, null);
+
+        public static void Remove(string key) =>
+            Remove(key, null);
+
+        public static void Clear() =>
+            Clear(null);
+
+        public static string Get(string key, string defaultValue) =>
+            Get(key, defaultValue, null);
+
+        public static bool Get(string key, bool defaultValue) =>
+            Get(key, defaultValue, null);
+
+        public static int Get(string key, int defaultValue) =>
+            Get(key, defaultValue, null);
+
+        public static double Get(string key, double defaultValue) =>
+            Get(key, defaultValue, null);
+
+        public static float Get(string key, float defaultValue) =>
+            Get(key, defaultValue, null);
+
+        public static long Get(string key, long defaultValue) =>
+            Get(key, defaultValue, null);
+
+        public static void Set(string key, string value) =>
+            Set(key, value, null);
+
+        public static void Set(string key, bool value) =>
+            Set(key, value, null);
+
+        public static void Set(string key, int value) =>
+            Set(key, value, null);
+
+        public static void Set(string key, double value) =>
+            Set(key, value, null);
+
+        public static void Set(string key, float value) =>
+            Set(key, value, null);
+
+        public static void Set(string key, long value) =>
+            Set(key, value, null);
+
+        // shared -> platform
 
         public static bool ContainsKey(string key, string sharedName) =>
             PlatformContainsKey(key, sharedName);
 
-        public static void Remove(string key) =>
-            PlatformRemove(key, null);
-
         public static void Remove(string key, string sharedName) =>
             PlatformRemove(key, sharedName);
 
-        public static void Clear() =>
-            PlatformClear(null);
-
         public static void Clear(string sharedName) =>
             PlatformClear(sharedName);
-
-        public static string Get(string key, string defaultValue) =>
-            PlatformGet<string>(key, defaultValue, null);
-
-        public static bool Get(string key, bool defaultValue) =>
-            PlatformGet<bool>(key, defaultValue, null);
-
-        public static int Get(string key, int defaultValue) =>
-            PlatformGet<int>(key, defaultValue, null);
-
-        public static double Get(string key, double defaultValue) =>
-            PlatformGet<double>(key, defaultValue, null);
-
-        public static float Get(string key, float defaultValue) =>
-            PlatformGet<float>(key, defaultValue, null);
-
-        public static long Get(string key, long defaultValue) =>
-            PlatformGet<long>(key, defaultValue, null);
-
-        public static void Set(string key, string value) =>
-            PlatformSet<string>(key, value, null);
-
-        public static void Set(string key, bool value) =>
-            PlatformSet<bool>(key, value, null);
-
-        public static void Set(string key, int value) =>
-            PlatformSet<int>(key, value, null);
-
-        public static void Set(string key, double value) =>
-            PlatformSet<double>(key, value, null);
-
-        public static void Set(string key, float value) =>
-            PlatformSet<float>(key, value, null);
-
-        public static void Set(string key, long value) =>
-            PlatformSet<long>(key, value, null);
 
         public static string Get(string key, string defaultValue, string sharedName) =>
             PlatformGet<string>(key, defaultValue, sharedName);
@@ -94,5 +100,19 @@
 
         public static void Set(string key, long value, string sharedName) =>
             PlatformSet<long>(key, value, sharedName);
+
+        // DateTime
+
+        public static DateTime Get(string key, DateTime defaultValue) =>
+            Get(key, defaultValue, null);
+
+        public static void Set(string key, DateTime value) =>
+            Set(key, value, null);
+
+        public static DateTime Get(string key, DateTime defaultValue, string sharedName) =>
+            DateTime.FromBinary(PlatformGet<long>(key, defaultValue.ToBinary(), sharedName));
+
+        public static void Set(string key, DateTime value, string sharedName) =>
+            PlatformSet<long>(key, value.ToBinary(), sharedName);
     }
 }

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -285,6 +285,8 @@
       <Member Id="M:Xamarin.Essentials.Preferences.ContainsKey(System.String,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Boolean)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Boolean,System.String)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Double)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Double,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Int32)" />
@@ -299,6 +301,8 @@
       <Member Id="M:Xamarin.Essentials.Preferences.Remove(System.String,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Boolean)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Boolean,System.String)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Double)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Double,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Int32)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -282,6 +282,8 @@
       <Member Id="M:Xamarin.Essentials.Preferences.ContainsKey(System.String,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Boolean)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Boolean,System.String)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Double)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Double,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Int32)" />
@@ -296,6 +298,8 @@
       <Member Id="M:Xamarin.Essentials.Preferences.Remove(System.String,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Boolean)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Boolean,System.String)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Double)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Double,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Int32)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -282,6 +282,8 @@
       <Member Id="M:Xamarin.Essentials.Preferences.ContainsKey(System.String,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Boolean)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Boolean,System.String)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Double)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Double,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Int32)" />
@@ -296,6 +298,8 @@
       <Member Id="M:Xamarin.Essentials.Preferences.Remove(System.String,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Boolean)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Boolean,System.String)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Double)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Double,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Int32)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -282,6 +282,8 @@
       <Member Id="M:Xamarin.Essentials.Preferences.ContainsKey(System.String,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Boolean)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Boolean,System.String)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Double)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Double,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Get(System.String,System.Int32)" />
@@ -296,6 +298,8 @@
       <Member Id="M:Xamarin.Essentials.Preferences.Remove(System.String,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Boolean)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Boolean,System.String)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime)" />
+      <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Double)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Double,System.String)" />
       <Member Id="M:Xamarin.Essentials.Preferences.Set(System.String,System.Int32)" />

--- a/docs/en/Xamarin.Essentials/Preferences.xml
+++ b/docs/en/Xamarin.Essentials/Preferences.xml
@@ -138,6 +138,30 @@
       </Docs>
     </Member>
     <Member MemberName="Get">
+      <MemberSignature Language="C#" Value="public static DateTime Get (string key, DateTime defaultValue);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype System.DateTime Get(string key, valuetype System.DateTime defaultValue) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.DateTime</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="key" Type="System.String" />
+        <Parameter Name="defaultValue" Type="System.DateTime" />
+      </Parameters>
+      <Docs>
+        <param name="key">Preference key.</param>
+        <param name="defaultValue">Default value to return if the key does not exist.</param>
+        <summary>Gets the value for a given key, or the default specified if the key does not exist.</summary>
+        <returns>Value for the given key, or the default if it does not exist.</returns>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Get">
       <MemberSignature Language="C#" Value="public static double Get (string key, double defaultValue);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig float64 Get(string key, float64 defaultValue) cil managed" />
       <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Preferences.Get(System.String,System.Double)" />
@@ -272,6 +296,34 @@
       <Parameters>
         <Parameter Name="key" Type="System.String" />
         <Parameter Name="defaultValue" Type="System.Boolean" />
+        <Parameter Name="sharedName" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="key">Preference key.</param>
+        <param name="defaultValue">Default value to return if the key does not exist.</param>
+        <param name="sharedName">Shared container key.</param>
+        <summary>Gets the value for a given key, or the default specified if the key does not exist.</summary>
+        <returns>Value for the given key, or the default if it does not exist.</returns>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Get">
+      <MemberSignature Language="C#" Value="public static DateTime Get (string key, DateTime defaultValue, string sharedName);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype System.DateTime Get(string key, valuetype System.DateTime defaultValue, string sharedName) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Preferences.Get(System.String,System.DateTime,System.String)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.DateTime</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="key" Type="System.String" />
+        <Parameter Name="defaultValue" Type="System.DateTime" />
         <Parameter Name="sharedName" Type="System.String" />
       </Parameters>
       <Docs>
@@ -487,6 +539,31 @@
       </Docs>
     </Member>
     <Member MemberName="Set">
+      <MemberSignature Language="C#" Value="public static void Set (string key, DateTime value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Set(string key, valuetype System.DateTime value) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="key" Type="System.String" />
+        <Parameter Name="value" Type="System.DateTime" />
+      </Parameters>
+      <Docs>
+        <param name="key">Preference key.</param>
+        <param name="value">Preference value.</param>
+        <summary>Sets a value for a given key.</summary>
+        <remarks>
+          <para />
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Set">
       <MemberSignature Language="C#" Value="public static void Set (string key, double value);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Set(string key, float64 value) cil managed" />
       <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Preferences.Set(System.String,System.Double)" />
@@ -626,6 +703,31 @@
       <Parameters>
         <Parameter Name="key" Type="System.String" />
         <Parameter Name="value" Type="System.Boolean" />
+        <Parameter Name="sharedName" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="key">Preference key.</param>
+        <param name="value">Preference value.</param>
+        <param name="sharedName">Shared container name.</param>
+        <summary>Sets a value for a given key.</summary>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Set">
+      <MemberSignature Language="C#" Value="public static void Set (string key, DateTime value, string sharedName);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Set(string key, valuetype System.DateTime value, string sharedName) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Preferences.Set(System.String,System.DateTime,System.String)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="key" Type="System.String" />
+        <Parameter Name="value" Type="System.DateTime" />
         <Parameter Name="sharedName" Type="System.String" />
       </Parameters>
       <Docs>


### PR DESCRIPTION
### Description of Change ###

Added overloads to get and set `DateTime` values. The backing field is just a `long`, obtained from`DateTime.ToBinary`

### Bugs Fixed ###

- Related to issue #192

### API Changes ###

```csharp
public static partial class Preferences
{
    public static DateTime Get(string key, DateTime defaultValue);
    public static void Set(string key, DateTime value);
    public static DateTime Get(string key, DateTime defaultValue, string sharedName);
    public static void Set(string key, DateTime value, string sharedName);
}
```

### Behavioral Changes ###

None.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
