### PR TITLE
Fixes #181 Allowing setting of calibration for heading.

### DIFF
--- a/Xamarin.Essentials/Compass/Compass.ios.cs
+++ b/Xamarin.Essentials/Compass/Compass.ios.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Essentials
         internal const double NormalFilter = 1;
         internal const double UiFilter = 2;
 
+        public static bool ShouldDisplayHeadingCalibration { get; set; } = false;
+
         internal static bool IsSupported =>
             CLLocationManager.HeadingAvailable;
 
@@ -18,6 +20,7 @@ namespace Xamarin.Essentials
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
             locationManager = new CLLocationManager();
+            locationManager.ShouldDisplayHeadingCalibration += LocationManagerShouldDisplayHeadingCalibration;
             switch (sensorSpeed)
             {
                 case SensorSpeed.Fastest:
@@ -42,6 +45,8 @@ namespace Xamarin.Essentials
             locationManager.StartUpdatingHeading();
         }
 
+        static bool LocationManagerShouldDisplayHeadingCalibration(CLLocationManager manager) => ShouldDisplayHeadingCalibration;
+
         static void LocationManagerUpdatedHeading(object sender, CLHeadingUpdatedEventArgs e)
         {
             var data = new CompassData(e.NewHeading.MagneticHeading);
@@ -53,6 +58,7 @@ namespace Xamarin.Essentials
             if (locationManager == null)
                 return;
 
+            locationManager.ShouldDisplayHeadingCalibration -= LocationManagerShouldDisplayHeadingCalibration;
             locationManager.UpdatedHeading -= LocationManagerUpdatedHeading;
             locationManager.StopUpdatingHeading();
             locationManager.Dispose();

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -67,6 +67,7 @@
       <Member Id="M:Xamarin.Essentials.Compass.Start(Xamarin.Essentials.SensorSpeed)" />
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
+      <Member Id="P:Xamarin.Essentials.Compass.ShouldDisplayHeadingCalibration" />
     </Type>
     <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
       <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />

--- a/docs/en/Xamarin.Essentials/Compass.xml
+++ b/docs/en/Xamarin.Essentials/Compass.xml
@@ -56,6 +56,24 @@
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="ShouldDisplayHeadingCalibration">
+      <MemberSignature Language="C#" Value="public static bool ShouldDisplayHeadingCalibration { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property bool ShouldDisplayHeadingCalibration" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.Compass.ShouldDisplayHeadingCalibration" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Determines if the calibration screen should be displayed.</summary>
+        <value>Gets or sets if this should be displayed when started.</value>
+        <remarks>Only available on iOS</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Start">
       <MemberSignature Language="C#" Value="public static void Start (Xamarin.Essentials.SensorSpeed sensorSpeed);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Start(valuetype Xamarin.Essentials.SensorSpeed sensorSpeed) cil managed" />


### PR DESCRIPTION
### Description of Change ###

Added new ShouldDisplayHeadingCalibration for iOS and setup the listener for IOS on compass

### Bugs Fixed ###

- Related to issue #281

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- bool - bool Compass.ShouldDisplayHeadingCalibration { get; set; } 



### Behavioral Changes ###

Now defaults to not showing calibration screen.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
