### PR TITLE
Properly check for thread access on UWP

### DIFF
--- a/Xamarin.Essentials/Platform/Platform.uwp.cs
+++ b/Xamarin.Essentials/Platform/Platform.uwp.cs
@@ -7,13 +7,13 @@ namespace Xamarin.Essentials
     public static partial class Platform
     {
         static bool PlatformIsMainThread =>
-            CoreApplication.MainView.CoreWindow.Dispatcher == null;
+            CoreApplication.MainView.CoreWindow.Dispatcher.HasThreadAccess;
 
         static void PlatformBeginInvokeOnMainThread(Action action)
         {
             var dispatcher = CoreApplication.MainView.CoreWindow.Dispatcher;
 
-            if (dispatcher != null)
+            if (!dispatcher.HasThreadAccess)
                 dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action()).WatchForError();
             else
                 action();

--- a/Xamarin.Essentials/Platform/Platform.uwp.cs
+++ b/Xamarin.Essentials/Platform/Platform.uwp.cs
@@ -7,11 +7,14 @@ namespace Xamarin.Essentials
     public static partial class Platform
     {
         static bool PlatformIsMainThread =>
-            CoreApplication.MainView.CoreWindow.Dispatcher.HasThreadAccess;
+            CoreApplication.MainView.CoreWindow?.Dispatcher?.HasThreadAccess ?? false;
 
         static void PlatformBeginInvokeOnMainThread(Action action)
         {
-            var dispatcher = CoreApplication.MainView.CoreWindow.Dispatcher;
+            var dispatcher = CoreApplication.MainView.CoreWindow?.Dispatcher;
+
+            if (dispatcher == null)
+                throw new InvalidOperationException("Unable to find main thread.");
 
             if (!dispatcher.HasThreadAccess)
                 dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action()).WatchForError();


### PR DESCRIPTION
### Description of Change ###

Fix the logic that determines whether or not on the UI thread.

### Bugs Fixed ###

None.

### API Changes ###

None.

### Behavioral Changes ###

Previously, the check was `CoreApplication.MainView.CoreWindow.Dispatcher == null` for background threads, but this is incorrect. The window will always have a thread since it was created on a thread at some point. To check if the thread is the UI thread (or if the current thread is the same as the thread as the window), use the [`HasThreadAccess` property](https://docs.microsoft.com/en-us/uwp/api/windows.ui.core.coredispatcher.hasthreadaccess).

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
