### PR TITLE
Fix parameters order bug on Location. CalculateDistance() call.

### DIFF
--- a/Xamarin.Essentials/Types/Location.shared.cs
+++ b/Xamarin.Essentials/Types/Location.shared.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Essentials
         public double? Accuracy { get; set; }
 
         public static double CalculateDistance(Location locationStart, Location locationEnd, DistanceUnits units) =>
-            CalculateDistance(locationStart.Latitude, locationStart.Longitude, locationEnd.Latitude, locationEnd.Longitude, units);
+            CalculateDistance(locationStart.Latitude, locationEnd.Latitude, locationStart.Longitude, locationEnd.Longitude, units);
 
         public static double CalculateDistance(
             double latitudeStart,


### PR DESCRIPTION
### Description of Change ###
I've simply changed the order of the parameters in the call of the CalculateDistance(…).

### Bugs Fixed ###
Now the CalculateDistance(Location locationStart, Location locationEnd, DistanceUnits units) returns correct values.

- Related to issue #306

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests: not needed, it's a straightforward bug fix
- [x] Has samples: not needed
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation: no documentation change needed