### PR TITLE
[Secure-Storage] Return null everywhere for key with no value

### DIFF
--- a/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
@@ -34,5 +34,18 @@ namespace DeviceTests
 
             Assert.Equal(data, c);
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Non_Existent_Key_Returns_Null(bool emulatePreApi23)
+        {
+#if __ANDROID__
+            SecureStorage.AlwaysUseAsymmetricKeyStorage = emulatePreApi23;
+#endif
+            var v = await SecureStorage.GetAsync("THIS_KEY_SHOULD_NOT_EXIST");
+
+            Assert.Null(v);
+        }
     }
 }

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Essentials
             if (resultCode == SecStatusCode.Success)
                 return NSString.FromData(match.ValueData, NSStringEncoding.UTF8);
             else
-                return string.Empty;
+                return null;
         }
 
         internal void SetValueForKey(string value, string key, string service)


### PR DESCRIPTION
### Description of Change ###

Android and UWP return `null` from `SecureStorage.GetAsync(..)` where the `key` is for a record that doesn't exist.  iOS was returning `string.Empty`, and this makes iOS consistent with the other platforms.

### Bugs Fixed ###

- #316 

### API Changes ###

None

### Behavioral Changes ###

`SecureStorage.GetAsync("SOME_KEY_THAT_DOESNT_EXIST")` now returns `null` on iOS.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
