### PR TITLE
[secure-storage] iOS: broaden record query

### DIFF
--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -54,9 +54,7 @@ namespace Xamarin.Essentials
             return new SecRecord(SecKind.GenericPassword)
             {
                 Account = key,
-                Service = service,
-                Label = key,
-                Accessible = accessible
+                Service = service
             };
         }
 


### PR DESCRIPTION
### Description of Change ###

On iOS in KeyChain, we were querying for existing records matching the expected `Account` and `Service` (good), but also the `Label` (questionably ok), and the `Accessible` (bad).

What happened was, in v0.6.0 we never set the `Accessible` property, and when an app was upgraded to v0.7.0.17 where we started setting that value, we also started looking up existing records having the new default `Accessible` value, however the record didn’t match, even though one existed with the given key, and a runtime error occurred.

Upon further investigation it looks like `Service` and `Account` are the true ‘unique’ identifying values for a given `SecRecord`, and so those are the only fields we should be using when querying for existing records.

This change removes the other fields from the existing record lookup query.

### Bugs Fixed ###

- #317 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

None.

### Behavioral Changes ###

Fixes incorrect behaviour mentioned above.

### PR Checklist ###

- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))