### PR TITLE
GH-309: Fixes #309, update to set activity on init and oncreate, never null.

### DIFF
--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -29,8 +29,11 @@ namespace Xamarin.Essentials
             application.RegisterActivityLifecycleCallbacks(lifecycleListener);
         }
 
-        public static void Init(Activity activity, Bundle bundle) =>
-           Init(activity.Application);
+        public static void Init(Activity activity, Bundle bundle)
+        {
+            Init(activity.Application);
+            lifecycleListener.Activity = activity;
+        }
 
         public static void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults) =>
             Permissions.OnRequestPermissionsResult(requestCode, permissions, grantResults);
@@ -110,26 +113,24 @@ namespace Xamarin.Essentials
         internal Context Context =>
             Activity ?? Application.Context;
 
-        internal Activity Activity =>
-            currentActivity.TryGetTarget(out var a) ? a : null;
-
-        void Application.IActivityLifecycleCallbacks.OnActivityCreated(Activity activity, Bundle savedInstanceState)
+        internal Activity Activity
         {
+           get => currentActivity.TryGetTarget(out var a) ? a : null;
+           set => currentActivity.SetTarget(value);
         }
+
+        void Application.IActivityLifecycleCallbacks.OnActivityCreated(Activity activity, Bundle savedInstanceState) =>
+            Activity = activity;
 
         void Application.IActivityLifecycleCallbacks.OnActivityDestroyed(Activity activity)
         {
         }
 
-        void Application.IActivityLifecycleCallbacks.OnActivityPaused(Activity activity)
-        {
-            currentActivity.SetTarget(null);
-        }
+        void Application.IActivityLifecycleCallbacks.OnActivityPaused(Activity activity) =>
+            Activity = activity;
 
-        void Application.IActivityLifecycleCallbacks.OnActivityResumed(Activity activity)
-        {
-            currentActivity.SetTarget(activity);
-        }
+        void Application.IActivityLifecycleCallbacks.OnActivityResumed(Activity activity) =>
+            Activity = activity;
 
         void Application.IActivityLifecycleCallbacks.OnActivitySaveInstanceState(Activity activity, Bundle outState)
         {


### PR DESCRIPTION
### Description of Change ###

Fixes up handling activity changes. Helpful in fragments and sets activity right away.

### Bugs Fixed ###

- Related to issue #309 & #289 


### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
