### PR TITLE
GH-239 Add Culture/Localization APIs

### DIFF
--- a/Xamarin.Essentials/Culture/Culture.android.cs
+++ b/Xamarin.Essentials/Culture/Culture.android.cs
@@ -1,0 +1,87 @@
+﻿using System.Globalization;
+using System.Threading;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Culture
+    {
+        public static void PlatformSetLocale(CultureInfo cultureInfo)
+        {
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+        }
+
+        public static CultureInfo PlatformCurrent
+        {
+            get
+            {
+                var netLanguage = "en";
+                var androidLocale = Java.Util.Locale.Default;
+                netLanguage = ToDotnetLanguage(androidLocale.ToString().Replace("_", "-"));
+
+                // this gets called a lot - try/catch can be expensive so consider caching or something
+                CultureInfo ci = null;
+                try
+                {
+                    ci = new CultureInfo(netLanguage);
+                }
+                catch (CultureNotFoundException)
+                {
+                    // iOS locale not valid .NET culture (eg. "en-ES" : English in Spain)
+                    // fallback to first characters, in this case "en"
+                    try
+                    {
+                        var fallback = ToDotnetFallbackLanguage(new PlatformCulture(netLanguage));
+                        ci = new CultureInfo(fallback);
+                    }
+                    catch (CultureNotFoundException)
+                    {
+                        // iOS language not valid .NET culture, falling back to English
+                        ci = new CultureInfo("en");
+                    }
+                }
+                return ci;
+            }
+        }
+
+        static string ToDotnetLanguage(string androidLanguage)
+        {
+            var netLanguage = androidLanguage;
+
+            // certain languages need to be converted to CultureInfo equivalent
+            switch (androidLanguage)
+            {
+                case "ms-BN": // "Malaysian (Brunei)" not supported .NET culture
+                case "ms-MY": // "Malaysian (Malaysia)" not supported .NET culture
+                case "ms-SG": // "Malaysian (Singapore)" not supported .NET culture
+                    netLanguage = "ms"; // closest supported
+                    break;
+                case "in-ID": // "Indonesian (Indonesia)" has different code in  .NET
+                    netLanguage = "id-ID"; // correct code for .NET
+                    break;
+                case "gsw-CH": // "Schwiizertüütsch (Swiss German)" not supported .NET culture
+                    netLanguage = "de-CH"; // closest supported
+                    break;
+
+                    // add more application-specific cases here (if required)
+                    // ONLY use cultures that have been tested and known to work
+            }
+            return netLanguage;
+        }
+
+        static string ToDotnetFallbackLanguage(PlatformCulture platCulture)
+        {
+            var netLanguage = platCulture.LanguageCode; // use the first part of the identifier (two chars, usually);
+            switch (platCulture.LanguageCode)
+            {
+                case "gsw":
+                    netLanguage = "de-CH"; // equivalent to German (Switzerland) for this app
+                    break;
+
+                    // add more application-specific cases here (if required)
+                    // ONLY use cultures that have been tested and known to work
+            }
+            return netLanguage;
+        }
+    }
+}

--- a/Xamarin.Essentials/Culture/Culture.android.cs
+++ b/Xamarin.Essentials/Culture/Culture.android.cs
@@ -66,6 +66,9 @@ namespace Xamarin.Essentials
                 case "gsw-CH": // "Schwiizertüütsch (Swiss German)" not supported .NET culture
                     netLanguage = "de-CH"; // closest supported
                     break;
+                case "iw-IL": // Hebrew
+                    netLanguage = "he-IL";
+                    break;
 
                     // add more application-specific cases here (if required)
                     // ONLY use cultures that have been tested and known to work
@@ -80,6 +83,9 @@ namespace Xamarin.Essentials
             {
                 case "gsw":
                     netLanguage = "de-CH"; // equivalent to German (Switzerland) for this app
+                    break;
+                case "iw":
+                    netLanguage = "he"; // Hebrew
                     break;
 
                     // add more application-specific cases here (if required)

--- a/Xamarin.Essentials/Culture/Culture.ios.cs
+++ b/Xamarin.Essentials/Culture/Culture.ios.cs
@@ -1,0 +1,91 @@
+﻿using System.Globalization;
+using System.Threading;
+using Foundation;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Culture
+    {
+        public static void PlatformSetLocale(CultureInfo cultureInfo)
+        {
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+        }
+
+        public static CultureInfo PlatformCurrent
+        {
+            get
+            {
+                var netLanguage = "en";
+                if (NSLocale.PreferredLanguages.Length > 0)
+                {
+                    var pref = NSLocale.PreferredLanguages[0];
+                    netLanguage = ToDotnetLanguage(pref);
+                }
+
+                // this gets called a lot - try/catch can be expensive so consider caching or something
+                CultureInfo ci = null;
+                try
+                {
+                    ci = new CultureInfo(netLanguage);
+                }
+                catch (CultureNotFoundException)
+                {
+                    // iOS locale not valid .NET culture (eg. "en-ES" : English in Spain)
+                    // fallback to first characters, in this case "en"
+                    try
+                    {
+                        var fallback = ToDotnetFallbackLanguage(new PlatformCulture(netLanguage));
+                        ci = new CultureInfo(fallback);
+                    }
+                    catch (CultureNotFoundException)
+                    {
+                        // iOS language not valid .NET culture, falling back to English
+                        ci = new CultureInfo("en");
+                    }
+                }
+                return ci;
+            }
+        }
+
+        static string ToDotnetLanguage(string iOSLanguage)
+        {
+            var netLanguage = iOSLanguage;
+
+            // certain languages need to be converted to CultureInfo equivalent
+
+            switch (iOSLanguage)
+            {
+                case "ms-MY": // "Malaysian (Malaysia)" not supported .NET culture
+                case "ms-SG": // "Malaysian (Singapore)" not supported .NET culture
+                    netLanguage = "ms"; // closest supported
+                    break;
+                case "gsw-CH": // "Schwiizertüütsch (Swiss German)" not supported .NET culture
+                    netLanguage = "de-CH"; // closest supported
+                    break;
+
+                    // add more application-specific cases here (if required)
+                    // ONLY use cultures that have been tested and known to work
+            }
+            return netLanguage;
+        }
+
+        static string ToDotnetFallbackLanguage(PlatformCulture platCulture)
+        {
+            var netLanguage = platCulture.LanguageCode; // use the first part of the identifier (two chars, usually);
+            switch (platCulture.LanguageCode)
+            {
+                case "pt":
+                    netLanguage = "pt-PT"; // fallback to Portuguese (Portugal)
+                    break;
+                case "gsw":
+                    netLanguage = "de-CH"; // equivalent to German (Switzerland) for this app
+                    break;
+
+                    // add more application-specific cases here (if required)
+                    // ONLY use cultures that have been tested and known to work
+            }
+            return netLanguage;
+        }
+    }
+}

--- a/Xamarin.Essentials/Culture/Culture.netstandard.cs
+++ b/Xamarin.Essentials/Culture/Culture.netstandard.cs
@@ -1,0 +1,13 @@
+﻿using System.Globalization;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Culture
+    {
+        internal static CultureInfo PlatformCurrent =>
+            throw new NotImplementedInReferenceAssemblyException();
+
+        internal static CultureInfo PlatformSetLocale(CultureInfo cultureInfo) =>
+            throw new NotImplementedInReferenceAssemblyException();
+    }
+}

--- a/Xamarin.Essentials/Culture/Culture.netstandard.cs
+++ b/Xamarin.Essentials/Culture/Culture.netstandard.cs
@@ -1,13 +1,20 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 
 namespace Xamarin.Essentials
 {
     public static partial class Culture
     {
-        internal static CultureInfo PlatformCurrent =>
+        internal static string PlatformInstalledUICulture =>
             throw new NotImplementedInReferenceAssemblyException();
 
-        internal static CultureInfo PlatformSetLocale(CultureInfo cultureInfo) =>
+        internal static CultureInfo PlatformGetCurrentUICulture() =>
+            throw new NotImplementedInReferenceAssemblyException();
+
+        internal static CultureInfo PlatformGetCurrentUICulture(Func<string, CultureInfo> mappingOverride) =>
+            throw new NotImplementedInReferenceAssemblyException();
+
+        internal static void PlatformSetCurrentUICulture(CultureInfo cultureInfo) =>
             throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Xamarin.Essentials/Culture/Culture.shared.cs
+++ b/Xamarin.Essentials/Culture/Culture.shared.cs
@@ -5,19 +5,25 @@ namespace Xamarin.Essentials
 {
     public static partial class Culture
     {
-        public static CultureInfo Current =>
-            PlatformCurrent;
+        public static string InstalledUICulture =>
+            PlatformInstalledUICulture;
 
-        public static void SetLocale(CultureInfo cultureInfo) =>
-            PlatformSetLocale(cultureInfo);
+        public static CultureInfo GetCurrentUICulture() =>
+            PlatformGetCurrentUICulture(null);
 
-        internal class PlatformCulture
+        public static CultureInfo GetCurrentUICulture(Func<string, CultureInfo> mappingOverride) =>
+            PlatformGetCurrentUICulture(mappingOverride);
+
+        public static void SetCurrentUICulture(CultureInfo cultureInfo) =>
+            PlatformSetCurrentUICulture(cultureInfo);
+
+        internal class InternalCulture
         {
-            internal PlatformCulture(string platformCultureString)
+            internal InternalCulture(string platformCultureString)
             {
                 if (string.IsNullOrEmpty(platformCultureString))
                 {
-                    throw new ArgumentException("Expected culture identifier", "platformCultureString"); // in C# 6 use nameof(platformCultureString)
+                    throw new ArgumentException("Expected culture identifier", nameof(platformCultureString));
                 }
                 PlatformString = platformCultureString.Replace("_", "-"); // .NET expects dash, not underscore
                 var dashIndex = PlatformString.IndexOf("-", StringComparison.Ordinal);
@@ -34,11 +40,11 @@ namespace Xamarin.Essentials
                 }
             }
 
-            public string PlatformString { get; private set; }
+            public string PlatformString { get; }
 
-            public string LanguageCode { get; private set; }
+            public string LanguageCode { get; }
 
-            public string LocaleCode { get; private set; }
+            public string LocaleCode { get; }
 
             public override string ToString() => PlatformString;
         }

--- a/Xamarin.Essentials/Culture/Culture.shared.cs
+++ b/Xamarin.Essentials/Culture/Culture.shared.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Globalization;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Culture
+    {
+        public static CultureInfo Current =>
+            PlatformCurrent;
+
+        public static void SetLocale(CultureInfo cultureInfo) =>
+            PlatformSetLocale(cultureInfo);
+
+        internal class PlatformCulture
+        {
+            internal PlatformCulture(string platformCultureString)
+            {
+                if (string.IsNullOrEmpty(platformCultureString))
+                {
+                    throw new ArgumentException("Expected culture identifier", "platformCultureString"); // in C# 6 use nameof(platformCultureString)
+                }
+                PlatformString = platformCultureString.Replace("_", "-"); // .NET expects dash, not underscore
+                var dashIndex = PlatformString.IndexOf("-", StringComparison.Ordinal);
+                if (dashIndex > 0)
+                {
+                    var parts = PlatformString.Split('-');
+                    LanguageCode = parts[0];
+                    LocaleCode = parts[1];
+                }
+                else
+                {
+                    LanguageCode = PlatformString;
+                    LocaleCode = string.Empty;
+                }
+            }
+
+            public string PlatformString { get; private set; }
+
+            public string LanguageCode { get; private set; }
+
+            public string LocaleCode { get; private set; }
+
+            public override string ToString() => PlatformString;
+        }
+    }
+}

--- a/Xamarin.Essentials/Culture/Culture.uwp.cs
+++ b/Xamarin.Essentials/Culture/Culture.uwp.cs
@@ -1,0 +1,19 @@
+﻿using System.Globalization;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Culture
+    {
+        public static CultureInfo PlatformCurrent =>
+            CultureInfo.CurrentUICulture;
+
+        public static void PlatformSetLocale(CultureInfo cultureInfo)
+        {
+            CultureInfo.CurrentCulture = cultureInfo;
+            CultureInfo.CurrentUICulture = cultureInfo;
+            Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = cultureInfo.Name;
+            Windows.ApplicationModel.Resources.Core.ResourceContext.GetForCurrentView().Reset();
+            Windows.ApplicationModel.Resources.Core.ResourceContext.GetForViewIndependentUse().Reset();
+        }
+    }
+}

--- a/Xamarin.Essentials/Culture/Culture.uwp.cs
+++ b/Xamarin.Essentials/Culture/Culture.uwp.cs
@@ -1,13 +1,17 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 
 namespace Xamarin.Essentials
 {
     public static partial class Culture
     {
-        public static CultureInfo PlatformCurrent =>
+        static string PlatformInstalledUICulture =>
+            CultureInfo.InstalledUICulture.Name;
+
+        static CultureInfo PlatformGetCurrentUICulture(Func<string, CultureInfo> mappingOverride) =>
             CultureInfo.CurrentUICulture;
 
-        public static void PlatformSetLocale(CultureInfo cultureInfo)
+        static void PlatformSetCurrentUICulture(CultureInfo cultureInfo)
         {
             CultureInfo.CurrentCulture = cultureInfo;
             CultureInfo.CurrentUICulture = cultureInfo;


### PR DESCRIPTION
### Description of Change ###

This implements a way to get the current culture information and also set the locale which would be used from resx files. This helps app developers localize their application. Base implementations to handle platform differences and guidance was taken from @conceptdev and the current documentation: https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/localization/text?tabs=vswin

### Isses Fixed ###

- Related to issue #239


### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- CultureInfo - CultureInfo Culture.Current { get; } 
- void Culture.SetLocale();


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
