### PR TITLE
Fix for #343

### DIFF
--- a/Xamarin.Essentials/Types/LocationExtensions.ios.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.ios.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Essentials
             {
                 Latitude = location.Coordinate.Latitude,
                 Longitude = location.Coordinate.Longitude,
-                Altitude = location.Altitude,
+                Altitude = location.VerticalAccuracy < 0 ? null : location.Altitude,
                 Accuracy = location.HorizontalAccuracy,
                 TimestampUtc = location.Timestamp.ToDateTime()
             };


### PR DESCRIPTION
Only set altitude if it's available (VerticalAccuracy is negative when it isn't according to iOS doc)
### Bugs Fixed ###
#343 
### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
