### PR TITLE
GH-337 Android Low Pass Filter

### DIFF
--- a/Samples/Samples/View/CompassPage.xaml
+++ b/Samples/Samples/View/CompassPage.xaml
@@ -11,6 +11,8 @@
     <StackLayout>
         <Label Text="Monitor compass for changes." FontAttributes="Bold" Margin="12" />
 
+        <Switch IsToggled="{Binding CompassApplyLowPassFilter}" />
+        
         <ScrollView>
             <Grid Padding="12,0,12,12">
                 <Grid.RowDefinitions>

--- a/Samples/Samples/View/CompassPage.xaml
+++ b/Samples/Samples/View/CompassPage.xaml
@@ -11,8 +11,12 @@
     <StackLayout>
         <Label Text="Monitor compass for changes." FontAttributes="Bold" Margin="12" />
 
-        <Switch IsToggled="{Binding CompassApplyLowPassFilter}" />
-        
+        <Switch IsToggled="{Binding CompassApplyLowPassFilter}" >
+            <Switch.IsVisible>
+                <OnPlatform x:TypeArguments="x:Boolean" Android="True" Default="False"/>
+            </Switch.IsVisible>
+        </Switch>
+
         <ScrollView>
             <Grid Padding="12,0,12,12">
                 <Grid.RowDefinitions>

--- a/Samples/Samples/ViewModel/CompassViewModel.cs
+++ b/Samples/Samples/ViewModel/CompassViewModel.cs
@@ -10,6 +10,7 @@ namespace Samples.ViewModel
     {
         bool compass1IsActive;
         bool compass2IsActive;
+        bool compassApplyLowPassFilter;
         double compass1;
         double compass2;
         int speed1 = 2;
@@ -41,6 +42,16 @@ namespace Samples.ViewModel
         {
             get => compass2IsActive;
             set => SetProperty(ref compass2IsActive, value);
+        }
+
+        public bool CompassApplyLowPassFilter
+        {
+            get => compassApplyLowPassFilter;
+            set
+            {
+                SetProperty(ref compassApplyLowPassFilter, value);
+                Compass.ApplyLowPassFilter = value;
+            }
         }
 
         public double Compass1

--- a/Xamarin.Essentials/Compass/Compass.android.cs
+++ b/Xamarin.Essentials/Compass/Compass.android.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Android.Hardware;
 using Android.Runtime;
 
@@ -50,40 +49,6 @@ namespace Xamarin.Essentials
             Platform.SensorManager.UnregisterListener(listener, magnetometer);
             listener.Dispose();
             listener = null;
-        }
-    }
-
-    class LowPassFilter
-    {
-        const int length = 10;
-
-        float sin;
-        float cos;
-        Queue<float> history = new Queue<float>(length);
-
-        public void Add(float radians)
-        {
-            sin += (float)Math.Sin(radians);
-
-            cos += (float)Math.Cos(radians);
-
-            history.Enqueue(radians);
-
-            if (history.Count > length)
-            {
-                var old = history.Dequeue();
-
-                sin -= (float)Math.Sin(old);
-
-                cos -= (float)Math.Cos(old);
-            }
-        }
-
-        public float Average()
-        {
-            var size = history.Count;
-
-            return (float)Math.Atan2(sin / size, cos / size);
         }
     }
 

--- a/Xamarin.Essentials/Compass/Compass.shared.cs
+++ b/Xamarin.Essentials/Compass/Compass.shared.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 
 namespace Xamarin.Essentials
 {

--- a/Xamarin.Essentials/Compass/Compass.shared.cs
+++ b/Xamarin.Essentials/Compass/Compass.shared.cs
@@ -11,6 +11,8 @@ namespace Xamarin.Essentials
 
         public static bool IsMonitoring { get; private set; }
 
+        public static bool ApplyLowPassFilter { get; set; }
+
         public static void Start(SensorSpeed sensorSpeed)
         {
             if (!IsSupported)

--- a/Xamarin.Essentials/Compass/LowPassFilter.shared.cs
+++ b/Xamarin.Essentials/Compass/LowPassFilter.shared.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xamarin.Essentials
+{
+    class LowPassFilter
+    {
+        const int length = 10;
+
+        float sin;
+        float cos;
+        Queue<float> history = new Queue<float>(length);
+
+        internal void Add(float radians)
+        {
+            sin += (float)Math.Sin(radians);
+
+            cos += (float)Math.Cos(radians);
+
+            history.Enqueue(radians);
+
+            if (history.Count > length)
+            {
+                var old = history.Dequeue();
+
+                sin -= (float)Math.Sin(old);
+
+                cos -= (float)Math.Cos(old);
+            }
+        }
+
+        internal float Average()
+        {
+            var size = history.Count;
+
+            return (float)Math.Atan2(sin / size, cos / size);
+        }
+    }
+}

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -67,6 +67,7 @@
       <Member Id="E:Xamarin.Essentials.Compass.ReadingChanged" />
       <Member Id="M:Xamarin.Essentials.Compass.Start(Xamarin.Essentials.SensorSpeed)" />
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
+      <Member Id="P:Xamarin.Essentials.Compass.ApplyLowPassFilter" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
     </Type>
     <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -67,6 +67,7 @@
       <Member Id="E:Xamarin.Essentials.Compass.ReadingChanged" />
       <Member Id="M:Xamarin.Essentials.Compass.Start(Xamarin.Essentials.SensorSpeed)" />
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
+      <Member Id="P:Xamarin.Essentials.Compass.ApplyLowPassFilter" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
       <Member Id="P:Xamarin.Essentials.Compass.ShouldDisplayHeadingCalibration" />
     </Type>

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -67,6 +67,7 @@
       <Member Id="E:Xamarin.Essentials.Compass.ReadingChanged" />
       <Member Id="M:Xamarin.Essentials.Compass.Start(Xamarin.Essentials.SensorSpeed)" />
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
+      <Member Id="P:Xamarin.Essentials.Compass.ApplyLowPassFilter" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
     </Type>
     <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -67,6 +67,7 @@
       <Member Id="E:Xamarin.Essentials.Compass.ReadingChanged" />
       <Member Id="M:Xamarin.Essentials.Compass.Start(Xamarin.Essentials.SensorSpeed)" />
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
+      <Member Id="P:Xamarin.Essentials.Compass.ApplyLowPassFilter" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
     </Type>
     <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">

--- a/docs/en/Xamarin.Essentials/Compass.xml
+++ b/docs/en/Xamarin.Essentials/Compass.xml
@@ -17,6 +17,26 @@
     </remarks>
   </Docs>
   <Members>
+    <Member MemberName="ApplyLowPassFilter">
+      <MemberSignature Language="C#" Value="public static bool ApplyLowPassFilter { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property bool ApplyLowPassFilter" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.Compass.ApplyLowPassFilter" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Applies a moving average filter on the Android implementation. Unused on other platforms</summary>
+        <value>If a low pass filter is applied</value>
+        <remarks>
+          <para></para>
+        </remarks>
+      </Docs>
+    </Member>
     <Member MemberName="IsMonitoring">
       <MemberSignature Language="C#" Value="public static bool IsMonitoring { get; }" />
       <MemberSignature Language="ILAsm" Value=".property bool IsMonitoring" />


### PR DESCRIPTION
### Description of Change ###
Compass api extended by  ApplyLowPassFilter property. Internally it uses a moving average filter. No unit tests were added, as there were no Platform specific unit tests.

### Bugs Fixed ###
None
- Related to issue #337 

### API Changes ###
Added: 
 
- bool - Compass.ApplyLowPassFilter { get; set; } 

Changed:
None

### Behavioral Changes ###

Low pass filter is initially disabled by default. @Redth suggested applying it by default, but this would be a behavioural change

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation