### PR TITLE
change original to absolute url

### DIFF
--- a/Xamarin.Essentials/Browser/Browser.ios.cs
+++ b/Xamarin.Essentials/Browser/Browser.ios.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Essentials
             if (uri == null)
                 throw new ArgumentNullException(nameof(uri));
 
-            var nativeUrl = new NSUrl(uri.OriginalString);
+            var nativeUrl = new NSUrl(uri.AbsoluteUri);
 
             switch (launchType)
             {


### PR DESCRIPTION
according to this issue
https://forums.xamarin.com/discussion/25515/forms-app-device-openuri-system-exception-in-ios
the fix I found here
https://stackoverflow.com/questions/36685160/unicode-url-could-not-initialize-an-instance-of-the-type-foundation-nsurl-t

### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- string - string Class.Property { get; set; } 
- void Class.Method();

Changed:

 - object Cell.OldPropertyName => object Cell.NewPropertyName

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
