### PR TITLE
GH-368: Allow for unicode in host names and escape query

### DIFF
--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -6,7 +6,7 @@
 var TARGET = Argument("target", "Default");
 
 var IOS_SIM_NAME = EnvironmentVariable("IOS_SIM_NAME") ?? "iPhone X";
-var IOS_SIM_RUNTIME = EnvironmentVariable("IOS_SIM_RUNTIME") ?? "iOS 11.3";
+var IOS_SIM_RUNTIME = EnvironmentVariable("IOS_SIM_RUNTIME") ?? "iOS 11.4";
 var IOS_PROJ = "./DeviceTests.iOS/DeviceTests.iOS.csproj";
 var IOS_BUNDLE_ID = "com.xamarin.essentials.devicetests";
 var IOS_IPA_PATH = "./DeviceTests.iOS/bin/iPhoneSimulator/Release/Xamarin.EssentialsDeviceTestsiOS.app";
@@ -108,6 +108,7 @@ Task ("test-ios-emu")
     // Look for a matching simulator on the system
     var sim = ListAppleSimulators ()
         .First (s => (s.Availability.Contains("available") || s.Availability.Contains("booted"))
+                && !s.Availability.Contains("unavailable")
                 && s.Name == IOS_SIM_NAME && s.Runtime == IOS_SIM_RUNTIME);
 
     // Boot the simulator

--- a/Tests/Browser_Tests.cs
+++ b/Tests/Browser_Tests.cs
@@ -26,10 +26,11 @@ namespace Tests
         [Theory]
         [InlineData("https://xamarin.com", "https://xamarin.com")]
         [InlineData("http://xamarin.com", "http://xamarin.com")]
-        [InlineData("https://mañana.com", "https://xn--maana-pta.com")]
-        [InlineData("http://mañana.com", "http://xn--maana-pta.com")]
-        [InlineData("https://mañana.com/?test=mañana", "https://xn--maana-pta.com/?test=ma%C3%B1ana")]
-        [InlineData("http://mañana.com/?test=mañana", "http://xn--maana-pta.com/?test=ma%C3%B1ana")]
+        [InlineData("https://xamariñ.com", "https://xn--xamari-1wa.com")]
+        [InlineData("http://xamariñ.com", "http://xn--xamari-1wa.com")]
+        [InlineData("https://xamariñ.com/?test=xamariñ", "https://xn--xamari-1wa.com/?test=xamari%C3%B1")]
+        [InlineData("http://xamariñ.com/?test=xamariñ", "http://xn--xamari-1wa.com/?test=xamari%C3%B1")]
+        [InlineData("http://xamariñ.com/?test=xamariñ xamariñ", "http://xn--xamari-1wa.com/?test=xamari%C3%B1%20xamari%C3%B1")]
         public void Escape_Uri(string uri, string escaped)
         {
             var escapedUri = Browser.EscapeUri(new Uri(uri));

--- a/Tests/Browser_Tests.cs
+++ b/Tests/Browser_Tests.cs
@@ -22,5 +22,19 @@ namespace Tests
         [Fact]
         public async Task Open_Uri_Launch_NetStandard() =>
             await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Browser.OpenAsync(new Uri("http://xamarin.com"), BrowserLaunchType.SystemPreferred));
+
+        [Theory]
+        [InlineData("https://xamarin.com", "https://xamarin.com")]
+        [InlineData("http://xamarin.com", "http://xamarin.com")]
+        [InlineData("https://mañana.com", "https://xn--maana-pta.com")]
+        [InlineData("http://mañana.com", "http://xn--maana-pta.com")]
+        [InlineData("https://mañana.com/?test=mañana", "https://xn--maana-pta.com/?test=ma%C3%B1ana")]
+        [InlineData("http://mañana.com/?test=mañana", "http://xn--maana-pta.com/?test=ma%C3%B1ana")]
+        public void Escape_Uri(string uri, string escaped)
+        {
+            var escapedUri = Browser.EscapeUri(new Uri(uri));
+
+            Assert.Equal(escaped, escapedUri.AbsoluteUri.TrimEnd('/'));
+        }
     }
 }

--- a/Xamarin.Essentials/Browser/Browser.android.cs
+++ b/Xamarin.Essentials/Browser/Browser.android.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Essentials
             if (uri == null)
                 throw new ArgumentNullException(nameof(uri));
 
-            var nativeUri = AndroidUri.Parse(uri.OriginalString);
+            var nativeUri = AndroidUri.Parse(uri.AbsoluteUri);
 
             switch (launchType)
             {

--- a/Xamarin.Essentials/Browser/Browser.ios.cs
+++ b/Xamarin.Essentials/Browser/Browser.ios.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Essentials
             if (uri == null)
                 throw new ArgumentNullException(nameof(uri));
 
-            var nativeUrl = new NSUrl(uri.OriginalString);
+            var nativeUrl = new NSUrl(uri.AbsoluteUri);
 
             switch (launchType)
             {

--- a/Xamarin.Essentials/Browser/Browser.shared.cs
+++ b/Xamarin.Essentials/Browser/Browser.shared.cs
@@ -21,8 +21,15 @@ namespace Xamarin.Essentials
         public static Task OpenAsync(Uri uri) =>
           OpenAsync(uri, BrowserLaunchType.SystemPreferred);
 
-        public static Task OpenAsync(Uri uri, BrowserLaunchType launchType) =>
-            PlatformOpenAsync(uri, launchType);
+        public static Task OpenAsync(Uri uri, BrowserLaunchType launchType)
+        {
+#if NETSTANDARD1_0
+            return PlatformOpenAsync(uri, launchType);
+#else
+            var idn = new System.Globalization.IdnMapping();
+            return PlatformOpenAsync(new Uri(uri.Scheme + "://" + idn.GetAscii(uri.DnsSafeHost) + uri.PathAndQuery), launchType);
+#endif
+        }
     }
 
     public enum BrowserLaunchType

--- a/Xamarin.Essentials/Browser/Browser.shared.cs
+++ b/Xamarin.Essentials/Browser/Browser.shared.cs
@@ -21,13 +21,16 @@ namespace Xamarin.Essentials
         public static Task OpenAsync(Uri uri) =>
           OpenAsync(uri, BrowserLaunchType.SystemPreferred);
 
-        public static Task OpenAsync(Uri uri, BrowserLaunchType launchType)
+        public static Task OpenAsync(Uri uri, BrowserLaunchType launchType) =>
+            PlatformOpenAsync(EscapeUri(uri), launchType);
+
+        internal static Uri EscapeUri(Uri uri)
         {
 #if NETSTANDARD1_0
-            return PlatformOpenAsync(uri, launchType);
+            return uri;
 #else
             var idn = new System.Globalization.IdnMapping();
-            return PlatformOpenAsync(new Uri(uri.Scheme + "://" + idn.GetAscii(uri.DnsSafeHost) + uri.PathAndQuery), launchType);
+            return new Uri(uri.Scheme + "://" + idn.GetAscii(uri.DnsSafeHost) + uri.PathAndQuery);
 #endif
         }
     }


### PR DESCRIPTION
### Description of Change ###

Previously we were passing the the url as is to each platform and letting it deal with how to parse into the platform specific url.

This handles unicode domain names (IDN Mapping aka PunyCode) for the domain, but also reconstructs the url based on the parsed System.Uri from the original string, and so the PathAndQuery will be the % escaped version which will account for unicode characters in it as well.

Finally, on iOS and Android we are using AbsoluteUri to end up with the fully IDN mapped and % encoded URL to pass to the system URL types.

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #368

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

None

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
