### PR TITLE
Update iOS DeviceInfo.Model to return specific hw.machine 

### DIFF
--- a/DeviceTests/DeviceTests.Shared/DeviceInfo_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/DeviceInfo_Tests.cs
@@ -26,6 +26,31 @@ namespace DeviceTests
         }
 
         [Fact]
+        public void DeviceModel_Is_Correct()
+        {
+#if WINDOWS_UWP
+            // Nothing right now.
+#elif __IOS__
+            if (DeviceInfo.DeviceType == DeviceType.Virtual)
+            {
+                Assert.Equal("x86_64", DeviceInfo.Model);
+            }
+#elif __ANDROID__
+
+            if (DeviceInfo.DeviceType == DeviceType.Virtual)
+            {
+                var isEmulator = DeviceInfo.Model.Contains("google_sdk") ||
+                    DeviceInfo.Model.Contains("Emulator") ||
+                    DeviceInfo.Model.Contains("Android SDK built for x86");
+
+                Assert.True(isEmulator);
+            }
+#else
+            throw new PlatformNotSupportedException();
+#endif
+        }
+
+        [Fact]
         public void AppPackageName_Is_Correct()
         {
 #if WINDOWS_UWP

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.ios.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.ios.cs
@@ -1,4 +1,5 @@
-﻿using Foundation;
+﻿using System;
+using System.Diagnostics;
 using ObjCRuntime;
 using UIKit;
 
@@ -6,7 +7,18 @@ namespace Xamarin.Essentials
 {
     public static partial class DeviceInfo
     {
-        static string GetModel() => UIDevice.CurrentDevice.Model;
+        static string GetModel()
+        {
+            try
+            {
+                return Essentials.Platform.GetSystemLibraryProperty("hw.machine");
+            }
+            catch (Exception)
+            {
+                Debug.WriteLine("Unable to query hardware model, returning current device model.");
+            }
+            return UIDevice.CurrentDevice.Model;
+        }
 
         static string GetManufacturer() => "Apple";
 

--- a/Xamarin.Essentials/Platform/Platform.ios.cs
+++ b/Xamarin.Essentials/Platform/Platform.ios.cs
@@ -1,13 +1,42 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using CoreMotion;
 using Foundation;
+using ObjCRuntime;
 using UIKit;
 
 namespace Xamarin.Essentials
 {
     public static partial class Platform
     {
+        [DllImport(Constants.SystemLibrary, EntryPoint = "sysctlbyname")]
+        internal static extern int SysctlByName([MarshalAs(UnmanagedType.LPStr)] string property, IntPtr output, IntPtr oldLen, IntPtr newp, uint newlen);
+
+        internal static string GetSystemLibraryProperty(string property)
+        {
+            var lengthPtr = Marshal.AllocHGlobal(sizeof(int));
+            SysctlByName(property, IntPtr.Zero, lengthPtr, IntPtr.Zero, 0);
+
+            var propertyLength = Marshal.ReadInt32(lengthPtr);
+
+            if (propertyLength == 0)
+            {
+                Marshal.FreeHGlobal(lengthPtr);
+                throw new InvalidOperationException("Unable to read length of property.");
+            }
+
+            var valuePtr = Marshal.AllocHGlobal(propertyLength);
+            SysctlByName(property, valuePtr, lengthPtr, IntPtr.Zero, 0);
+
+            var returnValue = Marshal.PtrToStringAnsi(valuePtr);
+
+            Marshal.FreeHGlobal(lengthPtr);
+            Marshal.FreeHGlobal(valuePtr);
+
+            return returnValue;
+        }
+
         internal static bool HasOSVersion(int major, int minor) =>
             UIDevice.CurrentDevice.CheckSystemVersion(major, minor);
 


### PR DESCRIPTION
via:
https://github.com/xamarin/xamarin-macios/blob/bc492585d137d8c3d3a2ffc827db3cdaae3cc869/tests/linker/ios/link%20sdk/LinkSdkRegressionTest.cs#L603-L631

Added tests

### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #366

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

None

### Behavioral Changes ###

Instead of just returning iPhone/iPad will return model number such as iPad6,3

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
