### PR TITLE
Fix build error due to preprocessor directive

### DIFF
--- a/Xamarin.Essentials/Vibration/Vibration.android.cs
+++ b/Xamarin.Essentials/Vibration/Vibration.android.cs
@@ -19,14 +19,13 @@ namespace Xamarin.Essentials
             if (Platform.HasApiLevel(BuildVersionCodes.O))
             {
                 Platform.Vibrator.Vibrate(VibrationEffect.CreateOneShot(time, VibrationEffect.DefaultAmplitude));
+                return;
             }
 #endif
-            else
-            {
+
 #pragma warning disable CS0618 // Type or member is obsolete
-                Platform.Vibrator.Vibrate(time);
+            Platform.Vibrator.Vibrate(time);
 #pragma warning restore CS0618 // Type or member is obsolete
-            }
         }
 
         static void PlatformCancel()


### PR DESCRIPTION
### Description of Change ###

Build was broken due to a change with the preprocessor directive excluding a part of the if statement.

### PR Checklist ###

- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
