### PR TITLE
Sync Sensor Speeds & Reset UWP to 0

### DIFF
--- a/Xamarin.Essentials/Accelerometer/Accelerometer.android.cs
+++ b/Xamarin.Essentials/Accelerometer/Accelerometer.android.cs
@@ -13,23 +13,7 @@ namespace Xamarin.Essentials
 
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
-            var delay = SensorDelay.Normal;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Normal:
-                    delay = SensorDelay.Normal;
-                    break;
-                case SensorSpeed.Fastest:
-                    delay = SensorDelay.Fastest;
-                    break;
-                case SensorSpeed.Game:
-                    delay = SensorDelay.Game;
-                    break;
-                case SensorSpeed.UI:
-                    delay = SensorDelay.Ui;
-                    break;
-            }
-
+            var delay = sensorSpeed.ToPlatform();
             listener = new AccelerometerListener();
             accelerometer = Platform.SensorManager.GetDefaultSensor(SensorType.Accelerometer);
             Platform.SensorManager.RegisterListener(listener, accelerometer, delay);

--- a/Xamarin.Essentials/Accelerometer/Accelerometer.ios.cs
+++ b/Xamarin.Essentials/Accelerometer/Accelerometer.ios.cs
@@ -5,35 +5,13 @@ namespace Xamarin.Essentials
 {
     public static partial class Accelerometer
     {
-        // Timing intervales to match android sensor speeds in seconds
-        // https://stackoverflow.com/questions/10044158/android-sensors
-        internal const double FastestInterval = .02;
-        internal const double GameInterval = .04;
-        internal const double UIInterval = .08;
-        internal const double NormalInterval = .225;
-
         internal static bool IsSupported =>
             Platform.MotionManager?.AccelerometerAvailable ?? false;
 
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
             var manager = Platform.MotionManager;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Fastest:
-                    manager.AccelerometerUpdateInterval = FastestInterval;
-                    break;
-                case SensorSpeed.Game:
-                    manager.AccelerometerUpdateInterval = GameInterval;
-                    break;
-                case SensorSpeed.Normal:
-                    manager.AccelerometerUpdateInterval = NormalInterval;
-                    break;
-                case SensorSpeed.UI:
-                    manager.AccelerometerUpdateInterval = UIInterval;
-                    break;
-            }
-
+            manager.AccelerometerUpdateInterval = sensorSpeed.ToPlatform();
             manager.StartAccelerometerUpdates(Platform.GetCurrentQueue(), DataUpdated);
         }
 

--- a/Xamarin.Essentials/Accelerometer/Accelerometer.uwp.cs
+++ b/Xamarin.Essentials/Accelerometer/Accelerometer.uwp.cs
@@ -5,11 +5,6 @@ namespace Xamarin.Essentials
 {
     public static partial class Accelerometer
     {
-        // Magic numbers from https://docs.microsoft.com/en-us/uwp/api/windows.devices.sensors.compass.reportinterval#Windows_Devices_Sensors_Compass_ReportInterval
-        internal const uint FastestInterval = 8;
-        internal const uint GameInterval = 22;
-        internal const uint NormalInterval = 33;
-
         // keep around a reference so we can stop this same instance
         static WindowsAccelerometer sensor;
 
@@ -23,17 +18,7 @@ namespace Xamarin.Essentials
         {
             sensor = DefaultSensor;
 
-            var interval = NormalInterval;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Fastest:
-                    interval = FastestInterval;
-                    break;
-                case SensorSpeed.Game:
-                    interval = GameInterval;
-                    break;
-            }
-
+            var interval = sensorSpeed.ToPlatform();
             sensor.ReportInterval = sensor.MinimumReportInterval >= interval ? sensor.MinimumReportInterval : interval;
 
             sensor.ReadingChanged += DataUpdated;

--- a/Xamarin.Essentials/Accelerometer/Accelerometer.uwp.cs
+++ b/Xamarin.Essentials/Accelerometer/Accelerometer.uwp.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Essentials
         internal static void PlatformStop()
         {
             sensor.ReadingChanged -= DataUpdated;
+            sensor.ReportInterval = 0;
         }
     }
 }

--- a/Xamarin.Essentials/Compass/Compass.android.cs
+++ b/Xamarin.Essentials/Compass/Compass.android.cs
@@ -16,23 +16,7 @@ namespace Xamarin.Essentials
 
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
-            var delay = SensorDelay.Normal;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Normal:
-                    delay = SensorDelay.Normal;
-                    break;
-                case SensorSpeed.Fastest:
-                    delay = SensorDelay.Fastest;
-                    break;
-                case SensorSpeed.Game:
-                    delay = SensorDelay.Game;
-                    break;
-                case SensorSpeed.UI:
-                    delay = SensorDelay.Ui;
-                    break;
-            }
-
+            var delay = sensorSpeed.ToPlatform();
             accelerometer = Platform.SensorManager.GetDefaultSensor(SensorType.Accelerometer);
             magnetometer = Platform.SensorManager.GetDefaultSensor(SensorType.MagneticField);
             listener = new SensorListener(accelerometer.Name, magnetometer.Name, delay);

--- a/Xamarin.Essentials/Compass/Compass.uwp.cs
+++ b/Xamarin.Essentials/Compass/Compass.uwp.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Essentials
         internal static void PlatformStop()
         {
             sensor.ReadingChanged -= CompassReportedInterval;
+            sensor.ReportInterval = 0;
         }
     }
 }

--- a/Xamarin.Essentials/Gyroscope/Gyroscope.android.cs
+++ b/Xamarin.Essentials/Gyroscope/Gyroscope.android.cs
@@ -13,22 +13,7 @@ namespace Xamarin.Essentials
 
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
-            var delay = SensorDelay.Normal;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Normal:
-                    delay = SensorDelay.Normal;
-                    break;
-                case SensorSpeed.Fastest:
-                    delay = SensorDelay.Fastest;
-                    break;
-                case SensorSpeed.Game:
-                    delay = SensorDelay.Game;
-                    break;
-                case SensorSpeed.UI:
-                    delay = SensorDelay.Ui;
-                    break;
-            }
+            var delay = sensorSpeed.ToPlatform();
 
             listener = new GyroscopeListener();
             gyroscope = Platform.SensorManager.GetDefaultSensor(SensorType.Gyroscope);

--- a/Xamarin.Essentials/Gyroscope/Gyroscope.ios.cs
+++ b/Xamarin.Essentials/Gyroscope/Gyroscope.ios.cs
@@ -5,35 +5,13 @@ namespace Xamarin.Essentials
 {
     public static partial class Gyroscope
     {
-        // Timing intervales to match android sensor speeds in seconds
-        // https://stackoverflow.com/questions/10044158/android-sensors
-        internal const double FastestInterval = .02;
-        internal const double GameInterval = .04;
-        internal const double UIInterval = .08;
-        internal const double NormalInterval = .225;
-
         internal static bool IsSupported =>
             Platform.MotionManager?.GyroAvailable ?? false;
 
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
             var manager = Platform.MotionManager;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Fastest:
-                    manager.GyroUpdateInterval = FastestInterval;
-                    break;
-                case SensorSpeed.Game:
-                    manager.GyroUpdateInterval = GameInterval;
-                    break;
-                case SensorSpeed.Normal:
-                    manager.GyroUpdateInterval = NormalInterval;
-                    break;
-                case SensorSpeed.UI:
-                    manager.GyroUpdateInterval = UIInterval;
-                    break;
-            }
-
+            manager.GyroUpdateInterval = sensorSpeed.ToPlatform();
             manager.StartGyroUpdates(Platform.GetCurrentQueue(), DataUpdated);
         }
 

--- a/Xamarin.Essentials/Gyroscope/Gyroscope.uwp.cs
+++ b/Xamarin.Essentials/Gyroscope/Gyroscope.uwp.cs
@@ -5,11 +5,6 @@ namespace Xamarin.Essentials
 {
     public static partial class Gyroscope
     {
-        // Magic numbers from https://docs.microsoft.com/en-us/uwp/api/windows.devices.sensors.compass.reportinterval#Windows_Devices_Sensors_Compass_ReportInterval
-        internal const uint FastestInterval = 8;
-        internal const uint GameInterval = 22;
-        internal const uint NormalInterval = 33;
-
         // keep around a reference so we can stop this same instance
         static WindowsGyro sensor;
 
@@ -23,17 +18,7 @@ namespace Xamarin.Essentials
         {
             sensor = DefaultSensor;
 
-            var interval = NormalInterval;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Fastest:
-                    interval = FastestInterval;
-                    break;
-                case SensorSpeed.Game:
-                    interval = GameInterval;
-                    break;
-            }
-
+            var interval = sensorSpeed.ToPlatform();
             sensor.ReportInterval = sensor.MinimumReportInterval >= interval ? sensor.MinimumReportInterval : interval;
 
             sensor.ReadingChanged += DataUpdated;

--- a/Xamarin.Essentials/Gyroscope/Gyroscope.uwp.cs
+++ b/Xamarin.Essentials/Gyroscope/Gyroscope.uwp.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Essentials
         internal static void PlatformStop()
         {
             sensor.ReadingChanged -= DataUpdated;
+            sensor.ReportInterval = 0;
         }
     }
 }

--- a/Xamarin.Essentials/Magnetometer/Magnetometer.android.cs
+++ b/Xamarin.Essentials/Magnetometer/Magnetometer.android.cs
@@ -13,22 +13,7 @@ namespace Xamarin.Essentials
 
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
-            var delay = SensorDelay.Normal;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Normal:
-                    delay = SensorDelay.Normal;
-                    break;
-                case SensorSpeed.Fastest:
-                    delay = SensorDelay.Fastest;
-                    break;
-                case SensorSpeed.Game:
-                    delay = SensorDelay.Game;
-                    break;
-                case SensorSpeed.UI:
-                    delay = SensorDelay.Ui;
-                    break;
-            }
+            var delay = sensorSpeed.ToPlatform();
 
             listener = new MagnetometerListener();
             magnetometer = Platform.SensorManager.GetDefaultSensor(SensorType.MagneticField);

--- a/Xamarin.Essentials/Magnetometer/Magnetometer.ios.cs
+++ b/Xamarin.Essentials/Magnetometer/Magnetometer.ios.cs
@@ -5,35 +5,13 @@ namespace Xamarin.Essentials
 {
     public static partial class Magnetometer
     {
-        // Timing intervales to match android sensor speeds in seconds
-        // https://stackoverflow.com/questions/10044158/android-sensors
-        internal const double FastestInterval = .02;
-        internal const double GameInterval = .04;
-        internal const double UIInterval = .08;
-        internal const double NormalInterval = .225;
-
         internal static bool IsSupported =>
             Platform.MotionManager?.MagnetometerAvailable ?? false;
 
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
             var manager = Platform.MotionManager;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Fastest:
-                    manager.MagnetometerUpdateInterval = FastestInterval;
-                    break;
-                case SensorSpeed.Game:
-                    manager.MagnetometerUpdateInterval = GameInterval;
-                    break;
-                case SensorSpeed.Normal:
-                    manager.MagnetometerUpdateInterval = NormalInterval;
-                    break;
-                case SensorSpeed.UI:
-                    manager.MagnetometerUpdateInterval = UIInterval;
-                    break;
-            }
-
+            manager.MagnetometerUpdateInterval = sensorSpeed.ToPlatform();
             manager.StartMagnetometerUpdates(Platform.GetCurrentQueue(), DataUpdated);
         }
 

--- a/Xamarin.Essentials/Magnetometer/Magnetometer.uwp.cs
+++ b/Xamarin.Essentials/Magnetometer/Magnetometer.uwp.cs
@@ -50,6 +50,7 @@ namespace Xamarin.Essentials
         internal static void PlatformStop()
         {
             sensor.ReadingChanged -= DataUpdated;
+            sensor.ReportInterval = 0;
         }
     }
 }

--- a/Xamarin.Essentials/Magnetometer/Magnetometer.uwp.cs
+++ b/Xamarin.Essentials/Magnetometer/Magnetometer.uwp.cs
@@ -6,11 +6,6 @@ namespace Xamarin.Essentials
 {
     public static partial class Magnetometer
     {
-        // Magic numbers from https://docs.microsoft.com/en-us/uwp/api/windows.devices.sensors.compass.reportinterval#Windows_Devices_Sensors_Compass_ReportInterval
-        internal const uint FastestInterval = 8;
-        internal const uint GameInterval = 22;
-        internal const uint NormalInterval = 33;
-
         // keep around a reference so we can stop this same instance
         static WindowsMagnetometer sensor;
 
@@ -24,17 +19,7 @@ namespace Xamarin.Essentials
         {
             sensor = DefaultSensor;
 
-            var interval = NormalInterval;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Fastest:
-                    interval = FastestInterval;
-                    break;
-                case SensorSpeed.Game:
-                    interval = GameInterval;
-                    break;
-            }
-
+            var interval = sensorSpeed.ToPlatform();
             sensor.ReportInterval = sensor.MinimumReportInterval >= interval ? sensor.MinimumReportInterval : interval;
 
             sensor.ReadingChanged += DataUpdated;

--- a/Xamarin.Essentials/OrientationSensor/OrientationSensor.android.cs
+++ b/Xamarin.Essentials/OrientationSensor/OrientationSensor.android.cs
@@ -13,22 +13,7 @@ namespace Xamarin.Essentials
 
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
-            var delay = SensorDelay.Normal;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Normal:
-                    delay = SensorDelay.Normal;
-                    break;
-                case SensorSpeed.Fastest:
-                    delay = SensorDelay.Fastest;
-                    break;
-                case SensorSpeed.Game:
-                    delay = SensorDelay.Game;
-                    break;
-                case SensorSpeed.UI:
-                    delay = SensorDelay.Ui;
-                    break;
-            }
+            var delay = sensorSpeed.ToPlatform();
 
             listener = new OrientationSensorListener();
             orientationSensor = Platform.SensorManager.GetDefaultSensor(SensorType.RotationVector);

--- a/Xamarin.Essentials/OrientationSensor/OrientationSensor.ios.cs
+++ b/Xamarin.Essentials/OrientationSensor/OrientationSensor.ios.cs
@@ -5,35 +5,13 @@ namespace Xamarin.Essentials
 {
     public static partial class OrientationSensor
     {
-        // Timing intervales to match android sensor speeds in seconds
-        // https://stackoverflow.com/questions/10044158/android-sensors
-        internal const double FastestInterval = .02;
-        internal const double GameInterval = .04;
-        internal const double UIInterval = .08;
-        internal const double NormalInterval = .225;
-
         internal static bool IsSupported =>
             Platform.MotionManager?.DeviceMotionAvailable ?? false;
 
         internal static void PlatformStart(SensorSpeed sensorSpeed)
         {
             var manager = Platform.MotionManager;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Fastest:
-                    manager.DeviceMotionUpdateInterval = FastestInterval;
-                    break;
-                case SensorSpeed.Game:
-                    manager.DeviceMotionUpdateInterval = GameInterval;
-                    break;
-                case SensorSpeed.Normal:
-                    manager.DeviceMotionUpdateInterval = NormalInterval;
-                    break;
-                case SensorSpeed.UI:
-                    manager.DeviceMotionUpdateInterval = UIInterval;
-                    break;
-            }
-
+            manager.DeviceMotionUpdateInterval = sensorSpeed.ToPlatform();
             manager.StartDeviceMotionUpdates(Platform.GetCurrentQueue(), DataUpdated);
         }
 

--- a/Xamarin.Essentials/OrientationSensor/OrientationSensor.uwp.cs
+++ b/Xamarin.Essentials/OrientationSensor/OrientationSensor.uwp.cs
@@ -5,11 +5,6 @@ namespace Xamarin.Essentials
 {
     public static partial class OrientationSensor
     {
-        // Magic numbers from https://docs.microsoft.com/en-us/uwp/api/windows.devices.sensors.compass.reportinterval#Windows_Devices_Sensors_Compass_ReportInterval
-        internal const uint FastestInterval = 8;
-        internal const uint GameInterval = 22;
-        internal const uint NormalInterval = 33;
-
         // keep around a reference so we can stop this same instance
         static WindowsOrientationSensor sensor;
 
@@ -23,16 +18,7 @@ namespace Xamarin.Essentials
         {
             sensor = DefaultSensor;
 
-            var interval = NormalInterval;
-            switch (sensorSpeed)
-            {
-                case SensorSpeed.Fastest:
-                    interval = FastestInterval;
-                    break;
-                case SensorSpeed.Game:
-                    interval = GameInterval;
-                    break;
-            }
+            var interval = sensorSpeed.ToPlatform();
 
             sensor.ReportInterval = sensor.MinimumReportInterval >= interval ? sensor.MinimumReportInterval : interval;
 

--- a/Xamarin.Essentials/OrientationSensor/OrientationSensor.uwp.cs
+++ b/Xamarin.Essentials/OrientationSensor/OrientationSensor.uwp.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Essentials
         internal static void PlatformStop()
         {
             sensor.ReadingChanged -= DataUpdated;
+            sensor.ReportInterval = 0;
         }
     }
 }

--- a/Xamarin.Essentials/Types/SensorSpeed.android.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.android.cs
@@ -1,0 +1,22 @@
+﻿using Android.Hardware;
+
+namespace Xamarin.Essentials
+{
+    static class SensorSpeedExtensions
+    {
+        internal static SensorDelay ToPlatform(this SensorSpeed sensorSpeed)
+        {
+            switch (sensorSpeed)
+            {
+                case SensorSpeed.Fastest:
+                    return SensorDelay.Fastest;
+                case SensorSpeed.Game:
+                    return SensorDelay.Game;
+                case SensorSpeed.UI:
+                    return SensorDelay.Ui;
+            }
+
+            return SensorDelay.Normal;
+        }
+    }
+}

--- a/Xamarin.Essentials/Types/SensorSpeed.ios.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.ios.cs
@@ -1,0 +1,20 @@
+﻿namespace Xamarin.Essentials
+{
+    static class SensorSpeedExtensions
+    {
+        internal static double ToPlatform(this SensorSpeed sensorSpeed)
+        {
+            switch (sensorSpeed)
+            {
+                case SensorSpeed.Fastest:
+                    return .02;
+                case SensorSpeed.Game:
+                    return .04;
+                case SensorSpeed.UI:
+                    return .08;
+            }
+
+            return .225;
+        }
+    }
+}

--- a/Xamarin.Essentials/Types/SensorSpeed.uwp.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.uwp.cs
@@ -1,0 +1,20 @@
+﻿namespace Xamarin.Essentials
+{
+    static class SensorSpeedExtensions
+    {
+        internal static uint ToPlatform(this SensorSpeed sensorSpeed)
+        {
+            switch (sensorSpeed)
+            {
+                case SensorSpeed.Fastest:
+                    return 20;
+                case SensorSpeed.Game:
+                    return 40;
+                case SensorSpeed.UI:
+                    return 80;
+            }
+
+            return 225;
+        }
+    }
+}


### PR DESCRIPTION
Restore the default report interval to release resources while the sensor is not in use
