### PR TITLE
Add .OnlineServices project for easy access to online services

### DIFF
--- a/Xamarin.Essentials.OnlineServices/Azure/BingSearchService.cs
+++ b/Xamarin.Essentials.OnlineServices/Azure/BingSearchService.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Xamarin.Essentials.OnlineServices.Azure
+{
+    public static class BingSearchService
+    {
+        // Verify the endpoint URI.  At this writing, only one endpoint is used for Bing
+        // search APIs.  In the future, regional endpoints may be available.  If you
+        // encounter unexpected authorization errors, double-check this value against
+        // the endpoint for your Bing Web search instance in your Azure dashboard.
+        const string searchUriBase = "https://api.cognitive.microsoft.com/bing/v7.0/search";
+        const string imageSearchUriBase = "https://api.cognitive.microsoft.com/bing/v7.0/images/search";
+        const string newsSearchUriBase = "https://api.cognitive.microsoft.com/bing/v7.0/news/search";
+        const string videoSearchUriBase = "https://api.cognitive.microsoft.com/bing/v7.0/videos/search";
+
+        static async Task<string> InternalSearchAsync (string uriBase, string subscriptionKey, string searchTerm)
+        {
+            var query = uriBase + "?q=" + Uri.EscapeDataString (searchTerm);
+            var request = WebRequest.Create (query);
+            request.Headers["Ocp-Apim-Subscription-Key"] = subscriptionKey;
+            var response = await request.GetResponseAsync ();
+            string json = new StreamReader (response.GetResponseStream ()).ReadToEnd ();
+
+            return json;
+        }
+
+        /// <summary>
+        /// Searchs the Web for pages matching the search term.
+        /// </summary>
+        /// <returns>The search results.</returns>
+        /// <param name="subscriptionKey">Subscription key.</param>
+        /// <param name="searchTerm">Search term.</param>
+        public static Task<string> SearchAsync (string subscriptionKey, string searchTerm) => InternalSearchAsync (searchUriBase, subscriptionKey, searchTerm);
+
+        /// <summary>
+        /// Searchs the Web for images matching the search term.
+        /// <returns>The search results.</returns>
+        /// <param name="subsciptionKey">Subsciption key.</param>
+        /// <param name="searchTerm">Search term.</param>
+        public static Task<string> SearchImagesAsync (string subsciptionKey, string searchTerm) => InternalSearchAsync (imageSearchUriBase, subsciptionKey, searchTerm);
+
+        /// <summary>
+        /// Searchs the Web for news matching the search term.
+        /// </summary>
+        /// <returns>The news async.</returns>
+        /// <param name="subscriptionKey">Subscription key.</param>
+        /// <param name="searchTerm">Search term.</param>
+        public static Task<string> SearchNewsAsync (string subscriptionKey, string searchTerm) => InternalSearchAsync (newsSearchUriBase, subscriptionKey, searchTerm);
+
+        /// <summary>
+        /// Searchs the Web for videos matching the search term.
+        /// </summary>
+        /// <returns>The videos async.</returns>
+        /// <param name="subscriptionKey">Subscription key.</param>
+        /// <param name="searchTerm">Search term.</param>
+        public static Task<string> SearchVideosAsync (string subscriptionKey, string searchTerm) => InternalSearchAsync (videoSearchUriBase, subscriptionKey, searchTerm);
+    }
+}

--- a/Xamarin.Essentials.OnlineServices/Azure/ImageAnalysisService.cs
+++ b/Xamarin.Essentials.OnlineServices/Azure/ImageAnalysisService.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Azure.CognitiveServices.Vision.ComputerVision;
+using Microsoft.Azure.CognitiveServices.Vision.ComputerVision.Models;
+
+namespace Xamarin.Essentials.OnlineServices.Azure
+{
+    public static class ImageAnalysisService
+    {
+        static ComputerVisionAPI GetComputerVisionAPI (string subscriptionKey, AzureRegions region) => new ComputerVisionAPI (
+                new ApiKeyServiceClientCredentials (subscriptionKey),
+                new System.Net.Http.DelegatingHandler[] { })
+        {
+            AzureRegion = region
+        };
+
+        /// <summary>
+        /// Analyzes the image file async.
+        /// </summary>
+        /// <returns>The image file async.</returns>
+        /// <param name="subscriptionKey">Subscription key.</param>
+        /// <param name="region">Region.</param>
+        /// <param name="imageFilePath">Image file path.</param>
+        /// <param name="features">Features.</param>
+        public static async Task<ImageAnalysis> AnalyzeImageFileAsync (string subscriptionKey, AzureRegions region, string imageFilePath, IList<VisualFeatureTypes> features)
+        {
+            if (!File.Exists (imageFilePath)) {
+                return null;
+            }
+
+            using (Stream imageStream = File.OpenRead (imageFilePath)) {
+                return await GetComputerVisionAPI (subscriptionKey, region)
+                    .AnalyzeImageInStreamAsync (imageStream, features);
+            }
+        }
+
+        /// <summary>
+        /// Analyzes the image URLA sync.
+        /// </summary>
+        /// <returns>The image URLA sync.</returns>
+        /// <param name="subscriptionKey">Subscription key.</param>
+        /// <param name="region">Region.</param>
+        /// <param name="imageUrl">Image URL.</param>
+        /// <param name="features">Features.</param>
+        public static async Task<ImageAnalysis> AnalyzeImageURLAsync (string subscriptionKey, AzureRegions region, string imageUrl, IList<VisualFeatureTypes> features)
+        {
+            if (!Uri.IsWellFormedUriString (imageUrl, UriKind.Absolute)) {
+                return null;
+            }
+
+            return await GetComputerVisionAPI (subscriptionKey, region)
+                .AnalyzeImageAsync (imageUrl, features);
+        }
+    }
+}

--- a/Xamarin.Essentials.OnlineServices/Azure/SpeechRecognitionService.cs
+++ b/Xamarin.Essentials.OnlineServices/Azure/SpeechRecognitionService.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using Microsoft.CognitiveServices.Speech;
+
+namespace Xamarin.Essentials.OnlineServices.Azure
+{
+    public static class SpeechRecognitionService
+    {
+        /// <summary>
+        /// Recognizes the once async.
+        /// </summary>
+        /// <returns>The once async.</returns>
+        /// <param name="subscriptionKey">Subscription key.</param>
+        /// <param name="serviceRegion">Service region.</param>
+        public static async Task<string> RecognizeOnceAsync (string subscriptionKey, string serviceRegion)
+        {
+            var factory = SpeechFactory.FromSubscription (subscriptionKey, serviceRegion);
+            using (var recognizer = factory.CreateSpeechRecognizer ()) {
+                var result = await recognizer.RecognizeAsync ();
+
+                return result.RecognitionStatus != RecognitionStatus.Recognized ? string.Empty : result.Text;
+            }
+        }
+    }
+
+}

--- a/Xamarin.Essentials.OnlineServices/Azure/TextAnalyticsService.cs
+++ b/Xamarin.Essentials.OnlineServices/Azure/TextAnalyticsService.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.CognitiveServices.Language.TextAnalytics;
+using Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Models;
+using Microsoft.Rest;
+using System.Net;
+
+namespace Xamarin.Essentials.OnlineServices.Azure
+{
+    class ApiKeyServiceClientCredentials : ServiceClientCredentials
+    {
+        readonly string subscriptionKey;
+
+        public ApiKeyServiceClientCredentials (string subscriptionKey) => this.subscriptionKey = subscriptionKey;
+
+        public override Task ProcessHttpRequestAsync (HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.Add ("Ocp-Apim-Subscription-Key", subscriptionKey);
+            return base.ProcessHttpRequestAsync (request, cancellationToken);
+        }
+    }
+
+    public static class TextAnalyticsService
+    {
+        static TextAnalyticsAPI GetTextAnalyticsAPI (string subscriptionKey, AzureRegions region) => new TextAnalyticsAPI (new ApiKeyServiceClientCredentials (subscriptionKey)) {
+            AzureRegion = region
+        };
+
+        /// <summary>
+        /// Detects the language async.
+        /// </summary>
+        /// <returns>The language async.</returns>
+        /// <param name="subscriptionKey">Subscription key.</param>
+        /// <param name="region">Region.</param>
+        /// <param name="inputText">Input text.</param>
+        public static async Task<string> DetectLanguageAsync (string subscriptionKey, AzureRegions region, string inputText)
+        {
+            var result = await GetTextAnalyticsAPI (subscriptionKey, region)
+                .DetectLanguageAsync (new BatchInput (
+                    new List<Input> () { new Input (inputText) }
+                ));
+            return result?.Documents?[0].DetectedLanguages?[0].Name;
+        }
+
+        /// <summary>
+        /// Extracts the key phrases async.
+        /// </summary>
+        /// <returns>The key phrases of the provided text.</returns>
+        /// <param name="subscriptionKey">Subscription key.</param>
+        /// <param name="region">Region.</param>
+        /// <param name="inputText">Input text.</param>
+        /// <param name="language">Language.</param>
+        public static async Task<IList<string>> ExtractKeyPhrasesAsync (string subscriptionKey, AzureRegions region, string inputText, string language)
+        {
+            var result = await GetTextAnalyticsAPI (subscriptionKey, region)
+                .KeyPhrasesAsync (new MultiLanguageBatchInput (
+                    new List<MultiLanguageInput> () { new MultiLanguageInput (language, "1", inputText) }
+                ));
+            return result?.Documents?[0].KeyPhrases;
+        }
+
+        /// <summary>
+        /// Analyzes the sentiment async.
+        /// </summary>
+        /// <returns>The sentiment score.</returns>
+        /// <param name="subscriptionKey">Subscription key.</param>
+        /// <param name="region">Region.</param>
+        /// <param name="inputText">Input text.</param>
+        /// <param name="language">Language.</param>
+        public static async Task<double?> AnalyzeSentimentAsync (string subscriptionKey, AzureRegions region, string inputText, string language)
+        {
+            var result = await GetTextAnalyticsAPI (subscriptionKey, region)
+                .SentimentAsync (new MultiLanguageBatchInput (
+                    new List<MultiLanguageInput> () { new MultiLanguageInput (language, "1", inputText) }
+                ));
+            return result?.Documents?[0].Score;
+        }
+    }
+}

--- a/Xamarin.Essentials.OnlineServices/Xamarin.Essentials.OnlineServices.csproj
+++ b/Xamarin.Essentials.OnlineServices/Xamarin.Essentials.OnlineServices.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Azure\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="0.5.0" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
+  </ItemGroup>
+</Project>

--- a/Xamarin.Essentials.sln
+++ b/Xamarin.Essentials.sln
@@ -16,13 +16,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{A14D061F-382D-4609-A3B0-E1D0BF7AB6AC}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Essentials", "Xamarin.Essentials\Xamarin.Essentials.csproj", "{63A4F6A1-48BF-4D32-AED7-82F605EDB042}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Essentials", "Xamarin.Essentials\Xamarin.Essentials.csproj", "{63A4F6A1-48BF-4D32-AED7-82F605EDB042}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{77C2F93D-6EB7-49F7-A74A-C80499EC206A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{77C2F93D-6EB7-49F7-A74A-C80499EC206A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{706C0487-6930-4E55-8720-C17D9FE6CA91}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples", "Samples\Samples\Samples.csproj", "{2550ED91-8AE1-4E9A-A964-C11515C8FA28}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples", "Samples\Samples\Samples.csproj", "{2550ED91-8AE1-4E9A-A964-C11515C8FA28}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Android", "Samples\Samples.Android\Samples.Android.csproj", "{C1CD30D3-52CA-4F8E-8499-BE88567CA2F8}"
 EndProject
@@ -38,7 +38,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeviceTests.iOS", "DeviceTe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeviceTests.UWP", "DeviceTests\DeviceTests.UWP\DeviceTests.UWP.csproj", "{4BD0D88F-7E7A-4C3B-9E34-BF3717A8FF4B}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceTests.Shared", "DeviceTests\DeviceTests.Shared\DeviceTests.Shared.csproj", "{BE0DE9A3-D92C-47C5-9EC4-DFB546BBDF77}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeviceTests.Shared", "DeviceTests\DeviceTests.Shared\DeviceTests.Shared.csproj", "{BE0DE9A3-D92C-47C5-9EC4-DFB546BBDF77}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Essentials.OnlineServices", "Xamarin.Essentials.OnlineServices\Xamarin.Essentials.OnlineServices.csproj", "{6D287A50-962E-470B-85D3-51673A109260}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -474,6 +476,42 @@ Global
 		{BE0DE9A3-D92C-47C5-9EC4-DFB546BBDF77}.Samples|x64.Build.0 = Samples|Any CPU
 		{BE0DE9A3-D92C-47C5-9EC4-DFB546BBDF77}.Samples|x86.ActiveCfg = Samples|Any CPU
 		{BE0DE9A3-D92C-47C5-9EC4-DFB546BBDF77}.Samples|x86.Build.0 = Samples|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|ARM.Build.0 = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|x64.Build.0 = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Debug|x86.Build.0 = Debug|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|ARM.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|ARM.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|iPhone.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|x64.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|x64.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|x86.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Release|x86.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|Any CPU.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|Any CPU.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|ARM.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|ARM.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|iPhone.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|iPhone.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|iPhoneSimulator.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|x64.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|x64.Build.0 = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|x86.ActiveCfg = Release|Any CPU
+		{6D287A50-962E-470B-85D3-51673A109260}.Samples|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Description of Change ###

As part of the hack week, I was working on adding better AI/Machine Learning support to Visual Studio for Mac, which resulted in a too ambitious project which needs more than a week. But, as part of that, I wanted to provide a library with easy to use APIs for accessing Azure ML services (Cognitive Services mainly), and my initial thought was to have it as part of the VSfM AI/ML extension I was writing, but after some thinking, maybe it makes sense in a widely used library, like Xamarin.Essentials?

This is just a quick API, and is missing a lot of services, but wanted to open the PR for initial discussions.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))