### PR TITLE
GH-450 Browser - Fix for authority to make sure we get the port.

### DIFF
--- a/Tests/Browser_Tests.cs
+++ b/Tests/Browser_Tests.cs
@@ -25,6 +25,8 @@ namespace Tests
 
         [Theory]
         [InlineData("https://xamarin.com", "https://xamarin.com")]
+        [InlineData("https://xamarin.com/test.html", "https://xamarin.com/test.html")]
+        [InlineData("https://xamarin.com:56/test.html", "https://xamarin.com:56/test.html")]
         [InlineData("http://xamarin.com", "http://xamarin.com")]
         [InlineData("https://xamariñ.com", "https://xn--xamari-1wa.com")]
         [InlineData("http://xamariñ.com", "http://xn--xamari-1wa.com")]

--- a/Xamarin.Essentials/Browser/Browser.shared.cs
+++ b/Xamarin.Essentials/Browser/Browser.shared.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Essentials
             return uri;
 #else
             var idn = new System.Globalization.IdnMapping();
-            return new Uri(uri.Scheme + "://" + idn.GetAscii(uri.DnsSafeHost) + uri.PathAndQuery);
+            return new Uri(uri.Scheme + "://" + idn.GetAscii(uri.Authority) + uri.PathAndQuery);
 #endif
         }
     }


### PR DESCRIPTION
### Description of Change ###

Make sure we use Authority. Via: https://stackoverflow.com/questions/2142910/whats-the-difference-between-uri-host-and-uri-authority

Authority = Host Name + Port No

And if URL protocol is using a default port, say port 80 for http URL, then only in that case Authority = Host Name (Port No is assumed to be 80),

Whereas Host Name is either Domain Name or I.P Address

Example:

http://www.example.com/ 

Authority = www.example.com
Host Name = www.example.com

http://255.255.255.255:8080/

Authority = 255.255.255.255:8080
Host Name = 255.255.255.255

### Bugs Fixed ###

- Related to issue #450

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.


### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
