### PR TITLE
GH-373: Permissions Must Be Invoked on MainThread else Throw Exception

### DIFF
--- a/DeviceTests/DeviceTests.Shared/Permissions_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Permissions_Tests.cs
@@ -37,5 +37,14 @@ namespace DeviceTests
 
             Assert.Equal(expectedStatus, status);
         }
+
+        [Fact]
+        public async Task Request_NotMainThread()
+        {
+            await Task.Run(async () =>
+            {
+                await Assert.ThrowsAsync<PermissionException>(() => Permissions.RequestAsync(PermissionType.LocationWhenInUse));
+            });
+        }
     }
 }

--- a/Xamarin.Essentials/Permissions/Permissions.shared.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.cs
@@ -12,8 +12,13 @@ namespace Xamarin.Essentials
         internal static Task<PermissionStatus> CheckStatusAsync(PermissionType permission) =>
             PlatformCheckStatusAsync(permission);
 
-        internal static Task<PermissionStatus> RequestAsync(PermissionType permission) =>
-            PlatformRequestAsync(permission);
+        internal static Task<PermissionStatus> RequestAsync(PermissionType permission)
+        {
+            if (!MainThread.IsMainThread)
+                throw new PermissionException("Permission request must be invoked on main thread.");
+
+            return PlatformRequestAsync(permission);
+        }
 
         internal static async Task RequireAsync(PermissionType permission)
         {


### PR DESCRIPTION
### Description of Change ###

Before prompting for permission we should check for mainthread and throw an exception.

### Bugs Fixed ###

- Related to issue #373 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.


### Behavioral Changes ###

Would possibly hang or crash the app :( now will throw exception which is documented.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
