### PR TITLE
GH-464 Dispose of any SecRecord inside of the keychain

### DIFF
--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -72,57 +72,68 @@ namespace Xamarin.Essentials
 
         internal string ValueForKey(string key, string service)
         {
-            var record = ExistingRecordForKey(key, service);
-            var match = SecKeyChain.QueryAsRecord(record, out var resultCode);
-
-            if (resultCode == SecStatusCode.Success)
-                return NSString.FromData(match.ValueData, NSStringEncoding.UTF8);
-            else
-                return null;
+            using (var record = ExistingRecordForKey(key, service))
+            {
+                using (var match = SecKeyChain.QueryAsRecord(record, out var resultCode))
+                {
+                    if (resultCode == SecStatusCode.Success)
+                        return NSString.FromData(match.ValueData, NSStringEncoding.UTF8);
+                    else
+                        return null;
+                }
+            }
         }
 
         internal void SetValueForKey(string value, string key, string service)
         {
-            var record = ExistingRecordForKey(key, service);
-            if (string.IsNullOrEmpty(value))
+            using (var record = ExistingRecordForKey(key, service))
             {
+                if (string.IsNullOrEmpty(value))
+                {
+                    if (!string.IsNullOrEmpty(ValueForKey(key, service)))
+                        RemoveRecord(record);
+
+                    return;
+                }
+
+                // if the key already exists, remove it
                 if (!string.IsNullOrEmpty(ValueForKey(key, service)))
                     RemoveRecord(record);
-
-                return;
             }
 
-            // if the key already exists, remove it
-            if (!string.IsNullOrEmpty(ValueForKey(key, service)))
-                RemoveRecord(record);
-
-            var result = SecKeyChain.Add(CreateRecordForNewKeyValue(key, value, service));
-            if (result != SecStatusCode.Success)
-                throw new Exception($"Error adding record: {result}");
+            using (var newRecord = CreateRecordForNewKeyValue(key, value, service))
+            {
+                var result = SecKeyChain.Add(newRecord);
+                if (result != SecStatusCode.Success)
+                    throw new Exception($"Error adding record: {result}");
+            }
         }
 
         internal bool Remove(string key, string service)
         {
-            var record = ExistingRecordForKey(key, service);
-            var match = SecKeyChain.QueryAsRecord(record, out var resultCode);
-
-            if (resultCode == SecStatusCode.Success)
+            using (var record = ExistingRecordForKey(key, service))
             {
-                RemoveRecord(record);
-                return true;
+                using (var match = SecKeyChain.QueryAsRecord(record, out var resultCode))
+                {
+                    if (resultCode == SecStatusCode.Success)
+                    {
+                        RemoveRecord(record);
+                        return true;
+                    }
+                }
+                return false;
             }
-
-            return false;
         }
 
         internal void RemoveAll(string service)
         {
-            var query = new SecRecord(SecKind.GenericPassword)
+            using (var query = new SecRecord(SecKind.GenericPassword)
             {
                 Service = service
-            };
-
-            SecKeyChain.Remove(query);
+            })
+            {
+                SecKeyChain.Remove(query);
+            }
         }
 
         SecRecord CreateRecordForNewKeyValue(string key, string value, string service)


### PR DESCRIPTION
### Description of Change ###

Cleanup any SecRecord by wrapping in using. I did not touch NSString as they are returned as string and not stored around.

### Bugs Fixed ###

- Related to issue #464

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

None

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
