### PR TITLE
Removed duplicated/unnecessary argument validation.

### DIFF
--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -15,10 +15,10 @@ namespace Xamarin.Essentials
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
-            
+
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-            
+
             var kc = new KeyChain(accessible);
             kc.SetValueForKey(value, key, Alias);
 

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -13,6 +13,12 @@ namespace Xamarin.Essentials
 
         public static Task SetAsync(string key, string value, SecAccessible accessible)
         {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+            
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            
             var kc = new KeyChain(accessible);
             kc.SetValueForKey(value, key, Alias);
 

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -13,12 +13,6 @@ namespace Xamarin.Essentials
 
         public static Task SetAsync(string key, string value, SecAccessible accessible)
         {
-            if (string.IsNullOrWhiteSpace(key))
-                throw new ArgumentNullException(nameof(key));
-
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
-
             var kc = new KeyChain(accessible);
             kc.SetValueForKey(value, key, Alias);
 
@@ -27,9 +21,6 @@ namespace Xamarin.Essentials
 
         static Task<string> PlatformGetAsync(string key)
         {
-            if (string.IsNullOrWhiteSpace(key))
-                throw new ArgumentNullException(nameof(key));
-
             var kc = new KeyChain(DefaultAccessible);
             var value = kc.ValueForKey(key, Alias);
 


### PR DESCRIPTION
The argument validation is being done under `SecureStorage.shared.cs` [here](https://github.com/xamarin/Essentials/blob/master/Xamarin.Essentials/SecureStorage/SecureStorage.shared.cs#L13) and [here](https://github.com/xamarin/Essentials/blob/master/Xamarin.Essentials/SecureStorage/SecureStorage.shared.cs#L21). There no need to repeat it in `SecureStorage.ios.cs`