### PR TITLE
Added the notifications API

### DIFF
--- a/Samples/Samples/View/NotificationsPage.xaml
+++ b/Samples/Samples/View/NotificationsPage.xaml
@@ -1,0 +1,31 @@
+﻿<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:views="clr-namespace:Samples.View"
+                xmlns:viewmodels="clr-namespace:Samples.ViewModel"
+                x:Class="Samples.View.NotificationsPage"
+                Title="Notifications">
+    <views:BasePage.BindingContext>
+        <viewmodels:NotificationsViewModel />
+    </views:BasePage.BindingContext>
+
+    <StackLayout>
+        <Label Text="Quickly and easily show app notifications." FontAttributes="Bold" Margin="12" />
+
+        <ScrollView>
+            <StackLayout Padding="12,0,12,12" Spacing="6">
+                <Label Text="Title:" />
+                <Entry Placeholder="&lt;no title&gt;" Text="{Binding Title}" />
+
+                <Label Text="Description:" />
+                <Editor Text="{Binding Description}" Keyboard="Chat"
+                        VerticalOptions="FillAndExpand" HeightRequest="200" />
+
+                <Button Text="Show New" Command="{Binding ShowCommand}" />
+                <Button Text="Update Last" Command="{Binding UpdateCommand}" />
+                <Button Text="Cancel Last" Command="{Binding CancelCommand}" />
+                <Button Text="Cancel All" Command="{Binding ClearCommand}" />
+            </StackLayout>
+        </ScrollView>
+    </StackLayout>
+
+</views:BasePage>

--- a/Samples/Samples/View/NotificationsPage.xaml.cs
+++ b/Samples/Samples/View/NotificationsPage.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Samples.View
+{
+    public partial class NotificationsPage : BasePage
+    {
+        public NotificationsPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Samples/Samples/ViewModel/HomeViewModel.cs
+++ b/Samples/Samples/ViewModel/HomeViewModel.cs
@@ -133,6 +133,12 @@ namespace Samples.ViewModel
                     "Detect device's orientation relative to Earth's magnetic field.",
                     new[] { "compass", "magnetometer", "sensors", "hardware", "device" }),
                 new SampleItem(
+                    "🔔",
+                    "Notifications",
+                    typeof(NotificationsPage),
+                    "Quickly and easily show app notifications.",
+                    new[] { "notifications", "alerts", "popups" }),
+                new SampleItem(
                     "📍",
                     "Launch Maps",
                     typeof(MapsPage),

--- a/Samples/Samples/ViewModel/NotificationsViewModel.cs
+++ b/Samples/Samples/ViewModel/NotificationsViewModel.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Windows.Input;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+
+namespace Samples.ViewModel
+{
+    class NotificationsViewModel : BaseViewModel
+    {
+        int lastId = 0;
+        string title = AppInfo.Name;
+        string description = "This is a notification description right here!";
+
+        public NotificationsViewModel()
+        {
+            ShowCommand = new Command(OnShow);
+            UpdateCommand = new Command(OnUpdate);
+            CancelCommand = new Command(OnCancel);
+            ClearCommand = new Command(OnClear);
+        }
+
+        public ICommand ShowCommand { get; }
+
+        public ICommand UpdateCommand { get; }
+
+        public ICommand CancelCommand { get; }
+
+        public ICommand ClearCommand { get; }
+
+        public string Title
+        {
+            get => title;
+            set => SetProperty(ref title, value);
+        }
+
+        public string Description
+        {
+            get => description;
+            set => SetProperty(ref description, value);
+        }
+
+        void OnShow()
+        {
+            var notification = new Notification
+            {
+                Id = ++lastId,
+                Title = Title,
+                Description = Description
+            };
+
+            try
+            {
+                Notifications.Show(notification);
+            }
+            catch (Exception ex)
+            {
+                DisplayAlertAsync($"Unable to show notification: {ex.Message}");
+            }
+        }
+
+        void OnUpdate()
+        {
+            var notification = new Notification
+            {
+                Id = lastId,
+                Title = Title,
+                Description = Description
+            };
+
+            try
+            {
+                Notifications.Show(notification);
+            }
+            catch (Exception ex)
+            {
+                DisplayAlertAsync($"Unable to update notification: {ex.Message}");
+            }
+        }
+
+        void OnCancel()
+        {
+            try
+            {
+                Notifications.Cancel(lastId);
+            }
+            catch (Exception ex)
+            {
+                DisplayAlertAsync($"Unable to cancel notification: {ex.Message}");
+            }
+        }
+
+        void OnClear()
+        {
+            try
+            {
+                Notifications.CancelAll();
+            }
+            catch (Exception ex)
+            {
+                DisplayAlertAsync($"Unable to cancel notifications: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Xamarin.Essentials/Notifications/Notifications.android.cs
+++ b/Xamarin.Essentials/Notifications/Notifications.android.cs
@@ -1,0 +1,101 @@
+﻿using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Support.V4.App;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Notifications
+    {
+        const int defaultSmallIcon = global::Android.Resource.Drawable.IcDialogInfo;
+#if __ANDROID_26__
+        const string defaultChannelName = "Notifications";
+        const string channelId = "xamarinessentials";
+#endif
+
+        public static int SmallIconResource { get; set; }
+
+        public static string ChannelName { get; set; }
+
+        public static string ChannelDescription { get; set; }
+
+        static void PlatformShow(Notification notification)
+        {
+            // get the values we can understand
+            var title = string.IsNullOrEmpty(notification.Title)
+                ? null
+                : notification.Title;
+            var description = string.IsNullOrEmpty(notification.Description)
+                ? null
+                : notification.Description;
+
+            // start building
+            var builder = new NotificationCompat.Builder(Platform.AppContext);
+            builder.SetPriority(NotificationCompat.PriorityDefault);
+
+            // lauch the app when the notification is tapped
+            var launchIntent = Platform.AppContext.PackageManager.GetLaunchIntentForPackage(Platform.AppContext.PackageName);
+            if (launchIntent != null)
+            {
+                var pendingIntent = PendingIntent.GetActivity(
+                    Platform.AppContext, notification.Id, launchIntent, PendingIntentFlags.CancelCurrent);
+                builder.SetContentIntent(pendingIntent);
+            }
+
+            // set the small icon
+            if (SmallIconResource == 0)
+                builder.SetSmallIcon(defaultSmallIcon);
+            else
+                builder.SetSmallIcon(SmallIconResource);
+
+#if __ANDROID_26__
+            // create the channel for the newer OS versions
+            if (Platform.HasApiLevel(BuildVersionCodes.O))
+            {
+                var nativeManager = NotificationManager.FromContext(Platform.AppContext);
+                if (nativeManager.GetNotificationChannel(channelId) == null)
+                {
+                    var channelName = string.IsNullOrEmpty(ChannelName)
+                        ? defaultChannelName
+                        : ChannelName;
+
+                    var channel = new NotificationChannel(channelId, channelName, NotificationImportance.Default);
+
+                    if (!string.IsNullOrEmpty(ChannelDescription))
+                        channel.Description = ChannelDescription;
+
+                    nativeManager.CreateNotificationChannel(channel);
+                }
+
+                builder.SetChannelId(channelId);
+            }
+#endif
+
+            // add the content
+            if (title != null)
+                builder.SetContentTitle(title);
+            if (description != null)
+                builder.SetContentText(description);
+
+            // show the notification
+            var nativeNotification = builder.Build();
+            var manager = NotificationManagerCompat.From(Platform.AppContext);
+            manager.Notify(notification.Id, nativeNotification);
+        }
+
+        static void PlatformCancel(int notificationId)
+        {
+            var manager = NotificationManagerCompat.From(Platform.AppContext);
+            manager.Cancel(notificationId);
+        }
+
+        static void PlatformCancel(Notification notification) =>
+            PlatformCancel(notification.Id);
+
+        static void PlatformCancelAll()
+        {
+            var manager = NotificationManagerCompat.From(Platform.AppContext);
+            manager.CancelAll();
+        }
+    }
+}

--- a/Xamarin.Essentials/Notifications/Notifications.ios.cs
+++ b/Xamarin.Essentials/Notifications/Notifications.ios.cs
@@ -1,0 +1,91 @@
+﻿using UIKit;
+using UserNotifications;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Notifications
+    {
+        internal static bool AlwaysUseUILocalNotification { get; set; } = false;
+
+        static void PlatformShow(Notification notification)
+        {
+            Permissions.CheckStatusAsync(PermissionType.Notifications);
+
+            // get the values we can understand
+            var title = string.IsNullOrEmpty(notification.Title)
+                ? null
+                : notification.Title;
+            var description = string.IsNullOrEmpty(notification.Description)
+                ? null
+                : notification.Description;
+
+            if (Platform.HasOSVersion(10, 0) && !AlwaysUseUILocalNotification)
+            {
+            }
+            else
+            {
+                // cancel the previous notification
+                PlatformCancel(notification);
+
+                // create the new notification
+                var nativeNotification = new UILocalNotification
+                {
+                    SoundName = UILocalNotification.DefaultSoundName,
+                    AlertTitle = title,
+                    AlertBody = description
+                };
+
+                // show it
+                MainThread.BeginInvokeOnMainThread(() => UIApplication.SharedApplication.PresentLocalNotificationNow(nativeNotification));
+            }
+        }
+
+        static void PlatformCancel(Notification notification)
+        {
+            if (Platform.HasOSVersion(10, 0) && !AlwaysUseUILocalNotification)
+            {
+                var id = GetNativeId(notification.Id);
+                UNUserNotificationCenter.Current.RemoveDeliveredNotifications(new[] { id });
+            }
+            else
+            {
+                // cancel the native notification if we can
+                var native = notification.NativeNotification;
+                if (native != null)
+                    MainThread.BeginInvokeOnMainThread(() => UIApplication.SharedApplication.CancelLocalNotification(native));
+            }
+        }
+
+        static void PlatformCancel(int notificationId)
+        {
+            if (Platform.HasOSVersion(10, 0) && !AlwaysUseUILocalNotification)
+            {
+                var id = GetNativeId(notificationId);
+                UNUserNotificationCenter.Current.RemoveDeliveredNotifications(new[] { id });
+            }
+            else
+            {
+                // TODO: not supported
+            }
+        }
+
+        static void PlatformCancelAll()
+        {
+            if (Platform.HasOSVersion(10, 0) && !AlwaysUseUILocalNotification)
+            {
+                UNUserNotificationCenter.Current.RemoveAllDeliveredNotifications();
+            }
+            else
+            {
+                MainThread.BeginInvokeOnMainThread(() => UIApplication.SharedApplication.CancelAllLocalNotifications());
+            }
+        }
+
+        static string GetNativeId(int notificationId) => notificationId.ToString();
+    }
+
+    public partial class Notification
+    {
+        internal UILocalNotification NativeNotification { get; set; }
+    }
+}

--- a/Xamarin.Essentials/Notifications/Notifications.ios.cs
+++ b/Xamarin.Essentials/Notifications/Notifications.ios.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Essentials
 
         static void PlatformShow(Notification notification)
         {
-            Permissions.CheckStatusAsync(PermissionType.Notifications);
+            Permissions.CheckStatusAsync(PermissionType.LocalNotifications);
 
             // get the values we can understand
             var title = string.IsNullOrEmpty(notification.Title)

--- a/Xamarin.Essentials/Notifications/Notifications.netstandard.cs
+++ b/Xamarin.Essentials/Notifications/Notifications.netstandard.cs
@@ -1,0 +1,17 @@
+﻿namespace Xamarin.Essentials
+{
+    public static partial class Notifications
+    {
+        static void PlatformShow(Notification notification) =>
+            throw new NotImplementedInReferenceAssemblyException();
+
+        static void PlatformCancel(int notificationId) =>
+            throw new NotImplementedInReferenceAssemblyException();
+
+        static void PlatformCancel(Notification notification) =>
+            throw new NotImplementedInReferenceAssemblyException();
+
+        static void PlatformCancelAll() =>
+            throw new NotImplementedInReferenceAssemblyException();
+    }
+}

--- a/Xamarin.Essentials/Notifications/Notifications.shared.cs
+++ b/Xamarin.Essentials/Notifications/Notifications.shared.cs
@@ -1,0 +1,70 @@
+﻿using System;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Notifications
+    {
+        public static void Show(string description) =>
+            Show(new Notification(description));
+
+        public static void Show(string title, string description) =>
+            Show(new Notification(title, description));
+
+        public static void Show(int id, string title, string description) =>
+            Show(new Notification(id, title, description));
+
+        public static void Show(Notification notification)
+        {
+            if (notification == null)
+                throw new ArgumentNullException(nameof(notification));
+
+            if (!notification.HasContent)
+                throw new ArgumentException("The notification does not have any content.", nameof(notification));
+
+            PlatformShow(notification);
+        }
+
+        public static void Cancel(int notificationId) =>
+            PlatformCancel(notificationId);
+
+        public static void Cancel(Notification notification) =>
+            PlatformCancel(notification);
+
+        public static void CancelAll() =>
+            PlatformCancelAll();
+    }
+
+    public partial class Notification
+    {
+        public Notification()
+            : this(0, null, null)
+        {
+        }
+
+        public Notification(string description)
+            : this(0, null, description)
+        {
+        }
+
+        public Notification(string title, string description)
+            : this(0, title, description)
+        {
+        }
+
+        public Notification(int id, string title, string description)
+        {
+            Id = id;
+            Title = title;
+            Description = description;
+        }
+
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+
+        public string Description { get; set; }
+
+        internal bool HasContent =>
+            !string.IsNullOrEmpty(Title) || !string.IsNullOrEmpty(Description);
+    }
+}

--- a/Xamarin.Essentials/Notifications/Notifications.uwp.cs
+++ b/Xamarin.Essentials/Notifications/Notifications.uwp.cs
@@ -1,0 +1,66 @@
+﻿using Windows.UI.Notifications;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Notifications
+    {
+        static void PlatformShow(Notification notification)
+        {
+            // remove any existing notification with this id
+            PlatformCancel(notification.Id);
+
+            // get the values we can understand
+            var title = string.IsNullOrEmpty(notification.Title)
+                ? null
+                : notification.Title;
+            var description = string.IsNullOrEmpty(notification.Description)
+                ? null
+                : notification.Description;
+
+            // determine what template we want
+            var template = title == null || description == null
+                ? ToastTemplateType.ToastText01 // 1x title + 2x description
+                : ToastTemplateType.ToastText02; // 3x description
+
+            // get the template elements
+            var toastContent = ToastNotificationManager.GetTemplateContent(template);
+            var text1 = toastContent.SelectSingleNode("//text[@id='1']");
+            var text2 = toastContent.SelectSingleNode("//text[@id='2']");
+
+            // set toast text
+            if (title == null || description == null)
+            {
+                text1.InnerText = title ?? description;
+            }
+            else
+            {
+                text1.InnerText = title;
+                text2.InnerText = description;
+            }
+
+            // show the toast
+            var toastNotifier = ToastNotificationManager.CreateToastNotifier();
+            var toast = new ToastNotification(toastContent);
+            toast.Tag = GetNativeId(notification.Id);
+            toastNotifier.Show(toast);
+        }
+
+        static void PlatformCancel(int notificationId)
+        {
+            var tag = GetNativeId(notificationId);
+            var history = ToastNotificationManager.History;
+            history.Remove(tag);
+        }
+
+        static void PlatformCancel(Notification notification) =>
+            PlatformCancel(notification.Id);
+
+        static void PlatformCancelAll()
+        {
+            var history = ToastNotificationManager.History;
+            history.Clear();
+        }
+
+        static string GetNativeId(int notificationId) => notificationId.ToString();
+    }
+}

--- a/Xamarin.Essentials/Permissions/Permissions.shared.enums.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.enums.cs
@@ -27,5 +27,6 @@
         LocationWhenInUse,
         NetworkState,
         Vibrate,
+        LocalNotifications,
     }
 }


### PR DESCRIPTION
### Description of Change ###

Was bored so I whipped this up this weekend. I think Android is correct as it works on my v5.0 and my v8.1. UWP is finished. I just coded the iOS so it builds.

The API just came to me, so it will need a total review from scratch.

### Bugs Fixed ###

- Related to issues #238 #516 

### API Changes ###

```csharp
public static class Notifications {
    // show
    public static void Show(string description);
    public static void Show(string title, string description);
    public static void Show(int id, string title, string description);
    public static void Show(Notification notification);

    // cancel
    public static void Cancel(int notificationId);
    public static void Cancel(Notification notification);
    public static void CancelAll();
}
```

```csharp
public class Notification {
    public Notification();
    public Notification(string description);
    public Notification(string title, string description);
    public Notification(int id, string title, string description);

    public int Id { get; set; }
    public string Title { get; set; }
    public string Description { get; set; }

#if __ANDROID__
    // required, but falls back to "ic_dialog_info"
    public static int SmallIconResource { get; set; }

    // required for API 26, but falls back to "xamarinessentials"
    public static string ChannelName { get; set; }

    // optional for API 26
    public static string ChannelDescription { get; set; }
#endif
}
```

### Behavioral Changes ###

New API.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
