### PR TITLE
GH-523: Handle the case when a key does not exist in the iOS Info.plist

### DIFF
--- a/Xamarin.Essentials/AppInfo/AppInfo.ios.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.ios.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Essentials
         static string PlatformGetBuild() => GetBundleValue("CFBundleVersion");
 
         static string GetBundleValue(string key)
-           => NSBundle.MainBundle.ObjectForInfoDictionary(key).ToString();
+           => NSBundle.MainBundle.ObjectForInfoDictionary(key)?.ToString();
 
         static void PlatformOpenSettings() =>
             UIApplication.SharedApplication.OpenUrl(new NSUrl(UIApplication.OpenSettingsUrlString));


### PR DESCRIPTION
### Description of Change ###

Fixes the case when a key does not exist in the Info.plist, but still tries to convert it to a string.

### Bugs Fixed ###

- Related to issue ##523

### API Changes ###

None.

### Behavioral Changes ###

No exception.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
