### PR TITLE
Use nameof for all ToString overrides

### DIFF
--- a/Xamarin.Essentials/Accelerometer/Accelerometer.shared.cs
+++ b/Xamarin.Essentials/Accelerometer/Accelerometer.shared.cs
@@ -101,6 +101,8 @@ namespace Xamarin.Essentials
             Acceleration.GetHashCode();
 
         public override string ToString() =>
-            $"X: {Acceleration.X}, Y: {Acceleration.Y}, Z: {Acceleration.Z}";
+            $"{nameof(Acceleration.X)}: {Acceleration.X}, " +
+            $"{nameof(Acceleration.Y)}: {Acceleration.Y}, " +
+            $"{nameof(Acceleration.Z)}: {Acceleration.Z}";
     }
 }

--- a/Xamarin.Essentials/Barometer/Barometer.shared.cs
+++ b/Xamarin.Essentials/Barometer/Barometer.shared.cs
@@ -95,6 +95,6 @@ namespace Xamarin.Essentials
         public override int GetHashCode() =>
             Pressure.GetHashCode();
 
-        public override string ToString() => $"Pressure: {Pressure}";
+        public override string ToString() => $"{nameof(Pressure)}: {Pressure}";
     }
 }

--- a/Xamarin.Essentials/Battery/Battery.shared.cs
+++ b/Xamarin.Essentials/Battery/Battery.shared.cs
@@ -102,6 +102,8 @@ namespace Xamarin.Essentials
         public BatteryPowerSource PowerSource { get; }
 
         public override string ToString() =>
-            $"ChargeLevel: {ChargeLevel}, State: {State}, PowerSource: {PowerSource}";
+            $"{nameof(ChargeLevel)}: {ChargeLevel}, " +
+            $"{nameof(State)}: {State}, " +
+            $"{nameof(PowerSource)}: {PowerSource}";
     }
 }

--- a/Xamarin.Essentials/Compass/Compass.shared.cs
+++ b/Xamarin.Essentials/Compass/Compass.shared.cs
@@ -98,6 +98,6 @@ namespace Xamarin.Essentials
             HeadingMagneticNorth.GetHashCode();
 
         public override string ToString() =>
-            $"HeadingMagneticNorth: {HeadingMagneticNorth}";
+            $"{nameof(HeadingMagneticNorth)}: {HeadingMagneticNorth}";
     }
 }

--- a/Xamarin.Essentials/Connectivity/Connectivity.shared.cs
+++ b/Xamarin.Essentials/Connectivity/Connectivity.shared.cs
@@ -78,6 +78,7 @@ namespace Xamarin.Essentials
         public IEnumerable<ConnectionProfile> Profiles { get; }
 
         public override string ToString() =>
-            $"NetworkAccess: {NetworkAccess}, Profiles: [{string.Join(", ", Profiles)}]";
+            $"{nameof(NetworkAccess)}: {NetworkAccess}, " +
+            $"{nameof(Profiles)}: [{string.Join(", ", Profiles)}]";
     }
 }

--- a/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.shared.cs
+++ b/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.shared.cs
@@ -102,7 +102,9 @@ namespace Xamarin.Essentials
             (Height, Width, Density, Orientation, Rotation).GetHashCode();
 
         public override string ToString() =>
-            $"Height: {Height}, Width: {Width}, Density: {Density}, Orientation: {Orientation}, Rotation: {Rotation}";
+            $"{nameof(Height)}: {Height}, {nameof(Width)}: {Width}, " +
+            $"{nameof(Density)}: {Density}, {nameof(Orientation)}: {Orientation}, " +
+            $"{nameof(Rotation)}: {Rotation}";
     }
 
     public enum ScreenOrientation

--- a/Xamarin.Essentials/Geolocation/GeolocationRequest.shared.cs
+++ b/Xamarin.Essentials/Geolocation/GeolocationRequest.shared.cs
@@ -55,6 +55,6 @@ namespace Xamarin.Essentials
         public GeolocationAccuracy DesiredAccuracy { get; set; }
 
         public override string ToString() =>
-            $"DesiredAccuracy: {DesiredAccuracy}, Timeout: {Timeout}";
+            $"{nameof(DesiredAccuracy)}: {DesiredAccuracy}, {nameof(Timeout)}: {Timeout}";
     }
 }

--- a/Xamarin.Essentials/Gyroscope/Gyroscope.shared.cs
+++ b/Xamarin.Essentials/Gyroscope/Gyroscope.shared.cs
@@ -102,6 +102,8 @@ namespace Xamarin.Essentials
             AngularVelocity.GetHashCode();
 
         public override string ToString() =>
-            $"X: {AngularVelocity.X}, Y: {AngularVelocity.Y}, Z: {AngularVelocity.Z}";
+            $"{nameof(AngularVelocity.X)}: {AngularVelocity.X}, " +
+            $"{nameof(AngularVelocity.Y)}: {AngularVelocity.Y}, " +
+            $"{nameof(AngularVelocity.Z)}: {AngularVelocity.Z}";
     }
 }

--- a/Xamarin.Essentials/Magnetometer/Magnetometer.shared.cs
+++ b/Xamarin.Essentials/Magnetometer/Magnetometer.shared.cs
@@ -102,6 +102,8 @@ namespace Xamarin.Essentials
             MagneticField.GetHashCode();
 
         public override string ToString() =>
-            $"X: {MagneticField.X}, Y: {MagneticField.Y}, Z: {MagneticField.Z}";
+            $"{nameof(MagneticField.X)}: {MagneticField.X}, " +
+            $"{nameof(MagneticField.Y)}: {MagneticField.Y}, " +
+            $"{nameof(MagneticField.Z)}: {MagneticField.Z}";
     }
 }

--- a/Xamarin.Essentials/OrientationSensor/OrientationSensor.shared.cs
+++ b/Xamarin.Essentials/OrientationSensor/OrientationSensor.shared.cs
@@ -102,6 +102,9 @@ namespace Xamarin.Essentials
             Orientation.GetHashCode();
 
         public override string ToString() =>
-            $"X: {Orientation.X}, Y: {Orientation.Y}, Z: {Orientation.Z}, W: {Orientation.W}";
+            $"{nameof(Orientation.X)}: {Orientation.X}, " +
+            $"{nameof(Orientation.Y)}: {Orientation.Y}, " +
+            $"{nameof(Orientation.Z)}: {Orientation.Z}, " +
+            $"{nameof(Orientation.W)}: {Orientation.W}";
     }
 }

--- a/Xamarin.Essentials/Types/Placemark.shared.cs
+++ b/Xamarin.Essentials/Types/Placemark.shared.cs
@@ -51,5 +51,13 @@ namespace Xamarin.Essentials
         public string AdminArea { get; set; }
 
         public string SubAdminArea { get; set; }
+
+        public override string ToString() =>
+            $"{nameof(Location)}: {Location}, {nameof(CountryCode)}: {CountryCode}, " +
+            $"{nameof(CountryName)}: {CountryName}, {nameof(FeatureName)}: {FeatureName}, " +
+            $"{nameof(PostalCode)}: {PostalCode}, {nameof(SubLocality)}: {SubLocality}, " +
+            $"{nameof(Thoroughfare)}: {Thoroughfare}, {nameof(SubThoroughfare)}: {SubThoroughfare}, " +
+            $"{nameof(Locality)}: {Locality}, {nameof(AdminArea)}: {AdminArea}, " +
+            $"{nameof(SubAdminArea)}: {SubAdminArea}";
     }
 }


### PR DESCRIPTION
### Description of Change ###

Simply update to use nameof() incase of refactorings :)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
