### PR TITLE
Add sample of backup rools, and handl AEADBadTagException

### DIFF
--- a/Samples/Samples.Android/Properties/AndroidManifest.xml
+++ b/Samples/Samples.Android/Properties/AndroidManifest.xml
@@ -12,5 +12,11 @@
   <uses-feature android:name="android.hardware.location" android:required="false" />
   <uses-feature android:name="android.hardware.location.gps" android:required="false" />
   <uses-feature android:name="android.hardware.location.network" android:required="false" />
-  <application android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/MainTheme"></application>
+  <application android:label="@string/app_name" 
+               android:icon="@mipmap/ic_launcher" 
+               android:roundIcon="@mipmap/ic_launcher_round" 
+               android:theme="@style/MainTheme"
+               android:fullBackupContent="@xml/my_backup_rules">
+    
+  </application>
 </manifest>

--- a/Samples/Samples.Android/Resources/xml/my_backup_rules.xml
+++ b/Samples/Samples.Android/Resources/xml/my_backup_rules.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="sharedpref" path="."/>
+    <exclude domain="sharedpref" path="${applicationId}.xamarinessentials.xml"/>
+</full-backup-content>

--- a/Samples/Samples.Android/Samples.Android.csproj
+++ b/Samples/Samples.Android/Samples.Android.csproj
@@ -116,10 +116,17 @@
     <AndroidResource Include="Resources\values\strings.xml" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Properties\AndroidManifest.xml" />
+    <None Include="Properties\AndroidManifest.xml">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\FileSystemTemplate.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\xml\my_backup_rules.xml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\CodeStyles.targets" />

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -26,7 +26,15 @@ namespace Xamarin.Essentials
             {
                 var encData = Convert.FromBase64String(encStr);
                 var ks = new AndroidKeyStore(context, Alias, AlwaysUseAsymmetricKeyStorage);
-                decryptedData = ks.Decrypt(encData);
+                try
+                {
+                    decryptedData = ks.Decrypt(encData);
+                }
+                catch (AEADBadTagException)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Unable to decrpt key {key} likely due to uninstall, removing old key.");
+                    PlatformRemove(key);
+                }
             }
 
             return Task.FromResult(decryptedData);


### PR DESCRIPTION
### Description of Change ###

Test out custom xml for not backing up specific data to google as sample. Also handle the AEADBadTagException and just remove the key and return null.

### Bugs Fixed ###

- Related to issue #448

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

None

### Behavioral Changes ###

Before an exception would be thrown, but now it will be handled correctly and remove the key.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
