### PR TITLE
Catch FeatureNotSupportedException when navigating back for Barometer

### DIFF
--- a/Samples/Samples/ViewModel/BarometerViewModel.cs
+++ b/Samples/Samples/ViewModel/BarometerViewModel.cs
@@ -83,9 +83,16 @@ namespace Samples.ViewModel
 
         void OnStop()
         {
-            IsActive = false;
-            Barometer.Stop();
-            Barometer.ReadingChanged -= OnBarometerReadingChanged;
+            try
+            {
+                IsActive = false;
+                Barometer.Stop();
+                Barometer.ReadingChanged -= OnBarometerReadingChanged;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"An exception occured: {ex.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
### Added a try catch block to catch the FeatureNotSupportedException ###

### Bugs Fixed ###

If barometer was not supported when navigating back from the Barometer page in the Samples app, FeatureNotSupportedException was thrown and navigation was not possible.