### PR TITLE
[Secure storage] iOS don't throw exception when removing key that doesn't exist

### DIFF
--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -141,8 +141,8 @@ namespace Xamarin.Essentials
         bool RemoveRecord(SecRecord record)
         {
             var result = SecKeyChain.Remove(record);
-            if (result != SecStatusCode.Success)
-                throw new Exception(string.Format($"Error removing record: {result}"));
+            if (result != SecStatusCode.Success && result != SecStatusCode.ItemNotFound)
+                throw new Exception($"Error removing record: {result}");
 
             return true;
         }


### PR DESCRIPTION
### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #561

### Behavioral Changes ###

Secure storage in iOS won't throw exception when removing key that doesn't exist

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation

