### PR TITLE
GH-569: Fixed up Clipboard API! Updated everything SetTextAsync.

### DIFF
--- a/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
+++ b/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
@@ -65,7 +65,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="27.0.2.1" />
@@ -74,8 +74,8 @@
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="27.0.2.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.devices" Version="2.4.48" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.devices" Version="2.5.20" />
     <PackageReference Include="UnitTests.HeadlessRunner" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/DeviceTests/DeviceTests.Shared/Clipboard_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Clipboard_Tests.cs
@@ -13,10 +13,7 @@ namespace DeviceTests
         {
             return Utils.OnMainThread(async () =>
             {
-                Clipboard.SetText(text);
-
-                await Task.Delay(100);
-
+                await Clipboard.SetTextAsync(text);
                 Assert.True(Clipboard.HasText);
             });
         }
@@ -28,7 +25,7 @@ namespace DeviceTests
         {
             return Utils.OnMainThread(async () =>
             {
-                Clipboard.SetText(text);
+                await Clipboard.SetTextAsync(text);
                 var clipText = await Clipboard.GetTextAsync();
 
                 Assert.NotNull(clipText);

--- a/DeviceTests/DeviceTests.Shared/DeviceTests.Shared.csproj
+++ b/DeviceTests/DeviceTests.Shared/DeviceTests.Shared.csproj
@@ -29,17 +29,17 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.60" PrivateAssets="All" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.devices" Version="2.4.48" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.devices" Version="2.5.20" />
     <PackageReference Include="UnitTests.HeadlessRunner" Version="2.0.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <ProjectReference Include="..\..\Xamarin.Essentials\Xamarin.Essentials.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
     <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>

--- a/DeviceTests/DeviceTests.UWP/DeviceTests.UWP.csproj
+++ b/DeviceTests/DeviceTests.UWP/DeviceTests.UWP.csproj
@@ -127,10 +127,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="UnitTests.HeadlessRunner" Version="2.0.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.devices" Version="2.4.48" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.devices" Version="2.5.20" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/DeviceTests/DeviceTests.iOS/DeviceTests.iOS.csproj
+++ b/DeviceTests/DeviceTests.iOS/DeviceTests.iOS.csproj
@@ -110,9 +110,9 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.devices" Version="2.4.48" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.devices" Version="2.5.20" />
     <PackageReference Include="UnitTests.HeadlessRunner" Version="2.0.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>

--- a/Samples/Samples.Android/Samples.Android.csproj
+++ b/Samples/Samples.Android/Samples.Android.csproj
@@ -86,7 +86,7 @@
     <PackageReference Include="Microsoft.AppCenter.Distribute">
       <Version>1.10.0</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="27.0.2.1" />

--- a/Samples/Samples.UWP/Samples.UWP.csproj
+++ b/Samples/Samples.UWP/Samples.UWP.csproj
@@ -138,7 +138,7 @@
     <PackageReference Include="Microsoft.AppCenter.Distribute">
       <Version>1.10.0</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>

--- a/Samples/Samples.iOS/Samples.iOS.csproj
+++ b/Samples/Samples.iOS/Samples.iOS.csproj
@@ -110,7 +110,7 @@
     <PackageReference Include="Microsoft.AppCenter.Distribute">
       <Version>1.10.0</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/Samples/Samples.csproj
+++ b/Samples/Samples/Samples.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="1.10.0" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="1.10.0" />
     <PackageReference Include="Microsoft.AppCenter.Distribute" Version="1.10.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/Samples/Samples/ViewModel/ClipboardViewModel.cs
+++ b/Samples/Samples/ViewModel/ClipboardViewModel.cs
@@ -24,7 +24,7 @@ namespace Samples.ViewModel
             set => SetProperty(ref fieldValue, value);
         }
 
-        void OnCopy() => Clipboard.SetText(FieldValue);
+        async void OnCopy() => await Clipboard.SetTextAsync(FieldValue);
 
         async void OnPaste()
         {

--- a/Tests/Clipboard_Tests.cs
+++ b/Tests/Clipboard_Tests.cs
@@ -7,21 +7,15 @@ namespace Tests
     public class Clipboard_Tests
     {
         [Fact]
-        public void Clipboard_SetText_Fail_On_NetStandard()
-        {
-            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Clipboard.SetText("Text"));
-        }
+        public async Task Clipboard_SetText_Fail_On_NetStandard() =>
+            await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Clipboard.SetTextAsync("Text"));
 
         [Fact]
-        public void Clipboard_HasText_Fail_On_NetStandard()
-        {
+        public void Clipboard_HasText_Fail_On_NetStandard() =>
             Assert.Throws<NotImplementedInReferenceAssemblyException>(() => Clipboard.HasText);
-        }
 
         [Fact]
-        public async Task Clipboard_GetText_Fail_On_NetStandard()
-        {
+        public async Task Clipboard_GetText_Fail_On_NetStandard() =>
             await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Clipboard.GetTextAsync());
-        }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -9,8 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/Xamarin.Essentials/Clipboard/Clipboard.android.cs
+++ b/Xamarin.Essentials/Clipboard/Clipboard.android.cs
@@ -5,8 +5,11 @@ namespace Xamarin.Essentials
 {
     public static partial class Clipboard
     {
-        static void PlatformSetText(string text)
-            => Platform.ClipboardManager.PrimaryClip = ClipData.NewPlainText("Text", text);
+        static Task PlatformSetTextAsync(string text)
+        {
+            Platform.ClipboardManager.PrimaryClip = ClipData.NewPlainText("Text", text);
+            return Task.CompletedTask;
+        }
 
         static bool PlatformHasText
             => Platform.ClipboardManager.HasPrimaryClip;

--- a/Xamarin.Essentials/Clipboard/Clipboard.ios.cs
+++ b/Xamarin.Essentials/Clipboard/Clipboard.ios.cs
@@ -5,8 +5,11 @@ namespace Xamarin.Essentials
 {
     public static partial class Clipboard
     {
-        static void PlatformSetText(string text)
-            => UIPasteboard.General.String = text;
+        static Task PlatformSetTextAsync(string text)
+        {
+            UIPasteboard.General.String = text;
+            return Task.CompletedTask;
+        }
 
         static bool PlatformHasText
             => UIPasteboard.General.HasStrings;

--- a/Xamarin.Essentials/Clipboard/Clipboard.netstandard.cs
+++ b/Xamarin.Essentials/Clipboard/Clipboard.netstandard.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Clipboard
     {
-        static void PlatformSetText(string text)
+        static Task PlatformSetTextAsync(string text)
             => throw new NotImplementedInReferenceAssemblyException();
 
         static bool PlatformHasText

--- a/Xamarin.Essentials/Clipboard/Clipboard.shared.cs
+++ b/Xamarin.Essentials/Clipboard/Clipboard.shared.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Xamarin.Essentials
 {
     public static partial class Clipboard
     {
-        public static void SetText(string text)
-            => PlatformSetText(text);
+        public static Task SetTextAsync(string text)
+            => PlatformSetTextAsync(text);
 
         public static bool HasText
             => PlatformHasText;

--- a/Xamarin.Essentials/Clipboard/Clipboard.uwp.cs
+++ b/Xamarin.Essentials/Clipboard/Clipboard.uwp.cs
@@ -2,25 +2,26 @@
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 
-using static Windows.ApplicationModel.DataTransfer.Clipboard;
+using WindowsClipboard = Windows.ApplicationModel.DataTransfer.Clipboard;
 
 namespace Xamarin.Essentials
 {
     public static partial class Clipboard
     {
-        static void PlatformSetText(string text)
+        static Task PlatformSetTextAsync(string text)
         {
             var dataPackage = new DataPackage();
             dataPackage.SetText(text);
-            SetContent(dataPackage);
+            WindowsClipboard.SetContent(dataPackage);
+            return Task.CompletedTask;
         }
 
         static bool PlatformHasText
-            => GetContent().Contains(StandardDataFormats.Text);
+            => WindowsClipboard.GetContent().Contains(StandardDataFormats.Text);
 
         static Task<string> PlatformGetTextAsync()
         {
-            var clipboardContent = GetContent();
+            var clipboardContent = WindowsClipboard.GetContent();
             return clipboardContent.Contains(StandardDataFormats.Text)
                 ? clipboardContent.GetTextAsync().AsTask()
                 : Task.FromResult<string>(null);

--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -55,7 +55,7 @@
   <ItemGroup>
     <None Include="..\nugetreadme.txt" PackagePath="readme.txt" Pack="true" />
     <PackageReference Include="mdoc" Version="5.7.4" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.60" PrivateAssets="All" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <Compile Include="**\*.shared.cs" />
     <Compile Include="**\*.shared.*.cs" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -83,7 +83,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.Clipboard" Id="T:Xamarin.Essentials.Clipboard">
       <Member Id="M:Xamarin.Essentials.Clipboard.GetTextAsync" />
-      <Member Id="M:Xamarin.Essentials.Clipboard.SetText(System.String)" />
+      <Member Id="M:Xamarin.Essentials.Clipboard.SetTextAsync(System.String)" />
       <Member Id="P:Xamarin.Essentials.Clipboard.HasText" />
     </Type>
     <Type Name="Xamarin.Essentials.Compass" Id="T:Xamarin.Essentials.Compass">

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -83,7 +83,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.Clipboard" Id="T:Xamarin.Essentials.Clipboard">
       <Member Id="M:Xamarin.Essentials.Clipboard.GetTextAsync" />
-      <Member Id="M:Xamarin.Essentials.Clipboard.SetText(System.String)" />
+      <Member Id="M:Xamarin.Essentials.Clipboard.SetTextAsync(System.String)" />
       <Member Id="P:Xamarin.Essentials.Clipboard.HasText" />
     </Type>
     <Type Name="Xamarin.Essentials.Compass" Id="T:Xamarin.Essentials.Compass">

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -83,7 +83,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.Clipboard" Id="T:Xamarin.Essentials.Clipboard">
       <Member Id="M:Xamarin.Essentials.Clipboard.GetTextAsync" />
-      <Member Id="M:Xamarin.Essentials.Clipboard.SetText(System.String)" />
+      <Member Id="M:Xamarin.Essentials.Clipboard.SetTextAsync(System.String)" />
       <Member Id="P:Xamarin.Essentials.Clipboard.HasText" />
     </Type>
     <Type Name="Xamarin.Essentials.Compass" Id="T:Xamarin.Essentials.Compass">

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -83,7 +83,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.Clipboard" Id="T:Xamarin.Essentials.Clipboard">
       <Member Id="M:Xamarin.Essentials.Clipboard.GetTextAsync" />
-      <Member Id="M:Xamarin.Essentials.Clipboard.SetText(System.String)" />
+      <Member Id="M:Xamarin.Essentials.Clipboard.SetTextAsync(System.String)" />
       <Member Id="P:Xamarin.Essentials.Clipboard.HasText" />
     </Type>
     <Type Name="Xamarin.Essentials.Compass" Id="T:Xamarin.Essentials.Compass">

--- a/docs/en/Xamarin.Essentials/Clipboard.xml
+++ b/docs/en/Xamarin.Essentials/Clipboard.xml
@@ -61,16 +61,16 @@
       </Docs>
     </Member>
     <Member MemberName="SetText">
-      <MemberSignature Language="C#" Value="public static void SetText (string text);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetText(string text) cil managed" />
-      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Clipboard.SetText(System.String)" />
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task SetTextAsync (string text);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig System.Threading.Tasks.Task SetTextAsync(string text) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Clipboard.SetTextAsync(System.String)" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
         <AssemblyName>Xamarin.Essentials</AssemblyName>
       </AssemblyInfo>
       <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
+        <ReturnType>System.Threading.Tasks.Task</ReturnType>
       </ReturnValue>
       <Parameters>
         <Parameter Name="text" Type="System.String" />


### PR DESCRIPTION
### Description of Change ###

Fix Clipboard API.

### Bugs Fixed ###

- Related to issue #569 


### API Changes ###

Changed:

 - void Clipboard.SetText(string) -> Task Clipboard.SetTextAsync(string)

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
