### PR TITLE
GH-564 Handle Key Unwrap Exception

### DIFF
--- a/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
@@ -6,6 +6,11 @@ namespace DeviceTests
 {
     public class SecureStorage_Tests
     {
+        public SecureStorage_Tests()
+        {
+            SecureStorage.RemoveAll();
+        }
+
         [Theory]
         [InlineData("test.txt", "data", true, true)]
         [InlineData("noextension", "data2", true, false)]
@@ -39,6 +44,32 @@ namespace DeviceTests
 
             Assert.Equal(data, c);
         }
+
+#if __ANDROID__
+        [Theory]
+        [InlineData("test.txt", "data")]
+        public async Task Fix_Corrupt_Key(string key, string data)
+        {
+            // set a valid key
+            SecureStorage.AlwaysUseAsymmetricKeyStorage = true;
+            await SecureStorage.SetAsync(key, data);
+
+            // simulate corrupt the key
+            var prefKey = "SecureStorageKey";
+            var mainKey = "B2PfJSNdEDjM+422tpu7FqFcVQQbO3ti/DvnDnIqrq9CFwaBi6NdXYcicjvMW6nF7X/Clpto5xerM41U1H4qtWJDO0Ijc5QNTHGZl9tDSbXJ6yDCDDnEDryj2uTa8DiHoNcNX68QtcV3at4kkJKXXAwZXSC88a73/xDdh1u5gUdCeXJzVc5vOY6QpAGUH0bjR5NHrqEQNNGDdquFGN9n2ZJPsEK6C9fx0QwCIL+uldpAYSWrpmUIr+/0X7Y0mJpN84ldygEVxHLBuVrzB4Bbu5XGLUN/0Sr2plWcKm7XhM6wp3JRW6Eae2ozys42p1YLeM0HXWrhTqP6FRPkS6mOtw==";
+
+            Preferences.Set(prefKey, mainKey, SecureStorage.Alias);
+
+            var c = await SecureStorage.GetAsync(key);
+            Assert.Null(c);
+
+            // try to reset and get again
+            await SecureStorage.SetAsync(key, data);
+            c = await SecureStorage.GetAsync(key);
+
+            Assert.Equal(data, c);
+        }
+#endif
 
         [Theory]
         [InlineData(true)]

--- a/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
@@ -56,7 +56,7 @@ namespace DeviceTests
 
             // simulate corrupt the key
             var prefKey = "SecureStorageKey";
-            var mainKey = "B2PfJSNdEDjM+422tpu7FqFcVQQbO3ti/DvnDnIqrq9CFwaBi6NdXYcicjvMW6nF7X/Clpto5xerM41U1H4qtWJDO0Ijc5QNTHGZl9tDSbXJ6yDCDDnEDryj2uTa8DiHoNcNX68QtcV3at4kkJKXXAwZXSC88a73/xDdh1u5gUdCeXJzVc5vOY6QpAGUH0bjR5NHrqEQNNGDdquFGN9n2ZJPsEK6C9fx0QwCIL+uldpAYSWrpmUIr+/0X7Y0mJpN84ldygEVxHLBuVrzB4Bbu5XGLUN/0Sr2plWcKm7XhM6wp3JRW6Eae2ozys42p1YLeM0HXWrhTqP6FRPkS6mOtw==";
+            var mainKey = "A2PfJSNdEDjM+422tpu7FqFcVQQbO3ti/DvnDnIqrq9CFwaBi6NdXYcicjvMW6nF7X/Clpto5xerM41U1H4qtWJDO0Ijc5QNTHGZl9tDSbXJ6yDCDDnEDryj2uTa8DiHoNcNX68QtcV3at4kkJKXXAwZXSC88a73/xDdh1u5gUdCeXJzVc5vOY6QpAGUH0bjR5NHrqEQNNGDdquFGN9n2ZJPsEK6C9fx0QwCIL+uldpAYSWrpmUIr+/0X7Y0mJpN84ldygEVxHLBuVrzB4Bbu5XGLUN/0Sr2plWcKm7XhM6wp3JRW6Eae2ozys42p1YLeM0HXWrhTqP6FRPkS6mOtw==";
 
             Preferences.Set(prefKey, mainKey, SecureStorage.Alias);
 

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -131,6 +131,10 @@ namespace Xamarin.Essentials
 
                     return kp;
                 }
+                catch (InvalidKeyException ikEx)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Unable to unwrap key: Invalid Key. This may be caused by system backup or upgrades. All secure storage items will now be removed. {ikEx.Message}");
+                }
                 catch (IllegalBlockSizeException ibsEx)
                 {
                     System.Diagnostics.Debug.WriteLine($"Unable to unwrap key: Illegal Block Size. This may be caused by system backup or upgrades. All secure storage items will now be removed. {ibsEx.Message}");


### PR DESCRIPTION
### Description of Change ###

Need to properly handle issues when key can't be unwrapped.

### Bugs Fixed ###

- Related to issue #564 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### Behavioral Changes ###

If the key can not be unwrapped then tear down the entire secure storage stack. This needs to be documented. It should not happen ideally ever.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
