### PR TITLE
GH-612: Remove iOS Dependency on telephony

### DIFF
--- a/Xamarin.Essentials/PhoneDialer/PhoneDialer.ios.cs
+++ b/Xamarin.Essentials/PhoneDialer/PhoneDialer.ios.cs
@@ -9,22 +9,7 @@ namespace Xamarin.Essentials
     {
         const string noNetworkProviderCode = "65535";
 
-        internal static bool IsSupported
-        {
-            get
-            {
-                var isDialerInstalled = UIApplication.SharedApplication.CanOpenUrl(CreateNsUrl(new string('0', 10)));
-
-                if (!isDialerInstalled)
-                    return false;
-
-                using (var netInfo = new CTTelephonyNetworkInfo())
-                {
-                    var mnc = netInfo.SubscriberCellularProvider?.MobileNetworkCode;
-                    return !string.IsNullOrEmpty(mnc) && mnc != noNetworkProviderCode;
-                }
-            }
-        }
+        internal static bool IsSupported => UIApplication.SharedApplication.CanOpenUrl(CreateNsUrl(new string('0', 10)));
 
         static void PlatformOpen(string number)
         {


### PR DESCRIPTION
### Description of Change ###

We shouldn't have a need for telephony as we don't check it on others and restricts VOIP apps.

### Bugs Fixed ###

- Related to issue #612

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### Behavioral Changes ###

If no sim and just wifi will work (iPad)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
