### PR TITLE
GH-621 Only throw UI Exception when actually invoking permissions.

### DIFF
--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -41,8 +41,6 @@ namespace Xamarin.Essentials
 
         static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission)
         {
-            EnsureDeclared(permission);
-
             // If there are no android permissions for the given permission type
             // just return granted since we have none to ask for
             var androidPermissions = permission.ToAndroidPermissions(onlyRuntimePermissions: true);
@@ -72,10 +70,6 @@ namespace Xamarin.Essentials
 
         static async Task<PermissionStatus> PlatformRequestAsync(PermissionType permission)
         {
-            // Check status before requesting first
-            if (await PlatformCheckStatusAsync(permission) == PermissionStatus.Granted)
-                return PermissionStatus.Granted;
-
             TaskCompletionSource<PermissionStatus> tcs;
             var doRequest = true;
 
@@ -100,6 +94,9 @@ namespace Xamarin.Essentials
 
             if (!doRequest)
                 return await tcs.Task;
+
+            if (!MainThread.IsMainThread)
+                throw new PermissionException("Permission request must be invoked on main thread.");
 
             var androidPermissions = permission.ToAndroidPermissions(onlyRuntimePermissions: true).ToArray();
 

--- a/Xamarin.Essentials/Permissions/Permissions.ios.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.ios.cs
@@ -19,8 +19,6 @@ namespace Xamarin.Essentials
 
         static Task<PermissionStatus> PlatformCheckStatusAsync(PermissionType permission)
         {
-            EnsureDeclared(permission);
-
             switch (permission)
             {
                 case PermissionType.LocationWhenInUse:
@@ -73,6 +71,9 @@ namespace Xamarin.Essentials
 
         static Task<PermissionStatus> RequestLocationAsync()
         {
+            if (!MainThread.IsMainThread)
+                throw new PermissionException("Permission request must be invoked on main thread.");
+
             locationManager = new CLLocationManager();
 
             var tcs = new TaskCompletionSource<PermissionStatus>(locationManager);

--- a/Xamarin.Essentials/Permissions/Permissions.shared.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Xamarin.Essentials
 {
@@ -12,13 +10,8 @@ namespace Xamarin.Essentials
         internal static Task<PermissionStatus> CheckStatusAsync(PermissionType permission) =>
             PlatformCheckStatusAsync(permission);
 
-        internal static Task<PermissionStatus> RequestAsync(PermissionType permission)
-        {
-            if (!MainThread.IsMainThread)
-                throw new PermissionException("Permission request must be invoked on main thread.");
-
-            return PlatformRequestAsync(permission);
-        }
+        internal static Task<PermissionStatus> RequestAsync(PermissionType permission) =>
+            PlatformRequestAsync(permission);
 
         internal static async Task RequireAsync(PermissionType permission)
         {

--- a/Xamarin.Essentials/Permissions/Permissions.uwp.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.uwp.cs
@@ -51,6 +51,9 @@ namespace Xamarin.Essentials
 
         static async Task<PermissionStatus> CheckLocationAsync()
         {
+            if (!MainThread.IsMainThread)
+                throw new PermissionException("Permission request must be invoked on main thread.");
+
             var accessStatus = await Geolocator.RequestAccessAsync();
             switch (accessStatus)
             {


### PR DESCRIPTION
### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #621

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.


### Behavioral Changes ###
Logic was wrong here and we were always checking to throw even when not invoking permissions and now we only do it when we need to.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
