### PR TITLE
GH-621: Ensure we only check is main thread when prompting 

### DIFF
--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -101,6 +101,9 @@ namespace Xamarin.Essentials
             if (!doRequest)
                 return await tcs.Task;
 
+            if (!MainThread.IsMainThread)
+                throw new PermissionException("Permission request must be invoked on main thread.");
+
             var androidPermissions = permission.ToAndroidPermissions(onlyRuntimePermissions: true).ToArray();
 
             ActivityCompat.RequestPermissions(Platform.GetCurrentActivity(true), androidPermissions, requestCode);

--- a/Xamarin.Essentials/Permissions/Permissions.ios.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.ios.cs
@@ -42,6 +42,10 @@ namespace Xamarin.Essentials
             switch (permission)
             {
                 case PermissionType.LocationWhenInUse:
+
+                    if (!MainThread.IsMainThread)
+                        throw new PermissionException("Permission request must be invoked on main thread.");
+
                     return await RequestLocationAsync();
                 default:
                     return PermissionStatus.Granted;

--- a/Xamarin.Essentials/Permissions/Permissions.shared.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.cs
@@ -12,13 +12,8 @@ namespace Xamarin.Essentials
         internal static Task<PermissionStatus> CheckStatusAsync(PermissionType permission) =>
             PlatformCheckStatusAsync(permission);
 
-        internal static Task<PermissionStatus> RequestAsync(PermissionType permission)
-        {
-            if (!MainThread.IsMainThread)
-                throw new PermissionException("Permission request must be invoked on main thread.");
-
-            return PlatformRequestAsync(permission);
-        }
+        internal static Task<PermissionStatus> RequestAsync(PermissionType permission) =>
+            PlatformRequestAsync(permission);
 
         internal static async Task RequireAsync(PermissionType permission)
         {

--- a/Xamarin.Essentials/Permissions/Permissions.uwp.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.uwp.cs
@@ -51,6 +51,9 @@ namespace Xamarin.Essentials
 
         static async Task<PermissionStatus> CheckLocationAsync()
         {
+            if (!MainThread.IsMainThread)
+                throw new PermissionException("Permission request must be invoked on main thread.");
+
             var accessStatus = await Geolocator.RequestAccessAsync();
             switch (accessStatus)
             {


### PR DESCRIPTION
UWP needs it all the time :(

### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #621

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- string - string Class.Property { get; set; } 
- void Class.Method();

Changed:

 - object Cell.OldPropertyName => object Cell.NewPropertyName

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
