### PR TITLE
Use SharedPreferences.Editor.Apply to perform disk writes asynchronously 

### DIFF
--- a/Xamarin.Essentials/Preferences/Preferences.android.cs
+++ b/Xamarin.Essentials/Preferences/Preferences.android.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Essentials
                 using (var sharedPreferences = GetSharedPreferences(sharedName))
                 using (var editor = sharedPreferences.Edit())
                 {
-                    editor.Remove(key).Commit();
+                    editor.Remove(key).Apply();
                 }
             }
         }
@@ -40,7 +40,7 @@ namespace Xamarin.Essentials
                 using (var sharedPreferences = GetSharedPreferences(sharedName))
                 using (var editor = sharedPreferences.Edit())
                 {
-                    editor.Clear().Commit();
+                    editor.Clear().Apply();
                 }
             }
         }


### PR DESCRIPTION
### Description of Change ###
- Related to issue #636

Changes Android's Preference implementation of `PlatformRemove` and `PlatformClear` to be performed asynchronously.

### Behavioral Changes ###
`Preferences.Remove` and `Preferences.Clear` will write to disk asynchronously. 

