### PR TITLE
GH-196 Browser Customization

### DIFF
--- a/Xamarin.Essentials/Browser/Browser.android.cs
+++ b/Xamarin.Essentials/Browser/Browser.android.cs
@@ -10,21 +10,21 @@ namespace Xamarin.Essentials
 {
     public static partial class Browser
     {
-        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchMode, BrowserLaunchOptions options)
+        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchOptions options)
         {
             var nativeUri = AndroidUri.Parse(uri.AbsoluteUri);
 
-            switch (launchMode)
+            switch (options.LaunchMode)
             {
                 case BrowserLaunchMode.SystemPreferred:
                     var tabsBuilder = new CustomTabsIntent.Builder();
                     tabsBuilder.SetShowTitle(true);
                     if (options.PreferredTitleColor.HasValue)
-                        tabsBuilder.SetToolbarColor((int)options.PreferredTitleColor.Value);
+                        tabsBuilder.SetToolbarColor((int)options.PreferredTitleColor.Value.ToInt());
                     if (options.PrefferedControlColor.HasValue)
-                        tabsBuilder.SetSecondaryToolbarColor((int)options.PrefferedControlColor.Value);
-                    if (options.ShouldShowTitle.HasValue)
-                        tabsBuilder.SetShowTitle(options.ShouldShowTitle.Value);
+                        tabsBuilder.SetSecondaryToolbarColor((int)options.PrefferedControlColor.Value.ToInt());
+                    if (options.TitleMode != BrowserTitleMode.Default)
+                        tabsBuilder.SetShowTitle(options.TitleMode == BrowserTitleMode.Show);
                     var tabsIntent = tabsBuilder.Build();
                     tabsIntent.Intent.SetFlags(ActivityFlags.ClearTop);
                     tabsIntent.Intent.SetFlags(ActivityFlags.NewTask);
@@ -44,10 +44,5 @@ namespace Xamarin.Essentials
 
             return Task.FromResult(true);
         }
-    }
-
-    public readonly partial struct EssentialsColor
-    {
-        public static explicit operator int(EssentialsColor x) => x.A | x.R << 8 | x.G << 16 | x.B << 24;
     }
 }

--- a/Xamarin.Essentials/Browser/Browser.android.cs
+++ b/Xamarin.Essentials/Browser/Browser.android.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Browser
     {
-        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchMode)
+        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchMode, BrowserLaunchOptions options)
         {
             var nativeUri = AndroidUri.Parse(uri.AbsoluteUri);
 
@@ -19,6 +19,12 @@ namespace Xamarin.Essentials
                 case BrowserLaunchMode.SystemPreferred:
                     var tabsBuilder = new CustomTabsIntent.Builder();
                     tabsBuilder.SetShowTitle(true);
+                    if (options.PreferredTitleColor.HasValue)
+                        tabsBuilder.SetToolbarColor((int)options.PreferredTitleColor.Value);
+                    if (options.PrefferedControlColor.HasValue)
+                        tabsBuilder.SetSecondaryToolbarColor((int)options.PrefferedControlColor.Value);
+                    if (options.ShouldShowTitle.HasValue)
+                        tabsBuilder.SetShowTitle(options.ShouldShowTitle.Value);
                     var tabsIntent = tabsBuilder.Build();
                     tabsIntent.Intent.SetFlags(ActivityFlags.ClearTop);
                     tabsIntent.Intent.SetFlags(ActivityFlags.NewTask);
@@ -38,5 +44,10 @@ namespace Xamarin.Essentials
 
             return Task.FromResult(true);
         }
+    }
+
+    public readonly partial struct EssentialsColor
+    {
+        public static explicit operator int(EssentialsColor x) => x.A | x.R << 8 | x.G << 16 | x.B << 24;
     }
 }

--- a/Xamarin.Essentials/Browser/Browser.ios.cs
+++ b/Xamarin.Essentials/Browser/Browser.ios.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Browser
     {
-        static async Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchMode)
+        static async Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchMode, BrowserLaunchOptions options)
         {
             var nativeUrl = new NSUrl(uri.AbsoluteUri);
 
@@ -17,6 +17,12 @@ namespace Xamarin.Essentials
                 case BrowserLaunchMode.SystemPreferred:
                     var sfViewController = new SFSafariViewController(nativeUrl, false);
                     var vc = Platform.GetCurrentViewController();
+
+                    if (options.PreferredTitleColor.HasValue)
+                        sfViewController.PreferredBarTintColor = (UIColor)options.PreferredTitleColor;
+
+                    if (options.PrefferedControlColor.HasValue)
+                        sfViewController.PreferredControlTintColor = (UIColor)options.PrefferedControlColor;
 
                     if (sfViewController.PopoverPresentationController != null)
                     {
@@ -30,5 +36,10 @@ namespace Xamarin.Essentials
 
             return true;
         }
+    }
+
+    public readonly partial struct EssentialsColor
+    {
+        public static explicit operator UIColor(EssentialsColor x) => new UIColor(x.R, x.G, x.B, x.A);
     }
 }

--- a/Xamarin.Essentials/Browser/Browser.ios.cs
+++ b/Xamarin.Essentials/Browser/Browser.ios.cs
@@ -8,21 +8,21 @@ namespace Xamarin.Essentials
 {
     public static partial class Browser
     {
-        static async Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchMode, BrowserLaunchOptions options)
+        static async Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchOptions options)
         {
             var nativeUrl = new NSUrl(uri.AbsoluteUri);
 
-            switch (launchMode)
+            switch (options.LaunchMode)
             {
                 case BrowserLaunchMode.SystemPreferred:
                     var sfViewController = new SFSafariViewController(nativeUrl, false);
                     var vc = Platform.GetCurrentViewController();
 
                     if (options.PreferredTitleColor.HasValue)
-                        sfViewController.PreferredBarTintColor = (UIColor)options.PreferredTitleColor;
+                        sfViewController.PreferredBarTintColor = options.PreferredTitleColor.Value.ToPlatformColor();
 
                     if (options.PrefferedControlColor.HasValue)
-                        sfViewController.PreferredControlTintColor = (UIColor)options.PrefferedControlColor;
+                        sfViewController.PreferredControlTintColor = options.PrefferedControlColor.Value.ToPlatformColor();
 
                     if (sfViewController.PopoverPresentationController != null)
                     {
@@ -36,10 +36,5 @@ namespace Xamarin.Essentials
 
             return true;
         }
-    }
-
-    public readonly partial struct EssentialsColor
-    {
-        public static explicit operator UIColor(EssentialsColor x) => new UIColor(x.R, x.G, x.B, x.A);
     }
 }

--- a/Xamarin.Essentials/Browser/Browser.netstandard.cs
+++ b/Xamarin.Essentials/Browser/Browser.netstandard.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Browser
     {
-        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchMode, BrowserLaunchOptions options) =>
+        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchOptions options) =>
             throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Xamarin.Essentials/Browser/Browser.netstandard.cs
+++ b/Xamarin.Essentials/Browser/Browser.netstandard.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Browser
     {
-        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchMode) =>
+        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchMode, BrowserLaunchOptions options) =>
             throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Xamarin.Essentials/Browser/Browser.shared.cs
+++ b/Xamarin.Essentials/Browser/Browser.shared.cs
@@ -5,10 +5,10 @@ namespace Xamarin.Essentials
 {
     public static partial class Browser
     {
-        public static Task OpenAsync(string uri) =>
-            OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
+        public static Task OpenAsync(string uri, BrowserLaunchOptions options = default) =>
+            OpenAsync(uri, BrowserLaunchMode.SystemPreferred, options);
 
-        public static Task OpenAsync(string uri, BrowserLaunchMode launchMode)
+        public static Task OpenAsync(string uri, BrowserLaunchMode launchMode, BrowserLaunchOptions options = default)
         {
             if (string.IsNullOrWhiteSpace(uri))
             {
@@ -18,11 +18,11 @@ namespace Xamarin.Essentials
             return OpenAsync(new Uri(uri), launchMode);
         }
 
-        public static Task OpenAsync(Uri uri) =>
-          OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
+        public static Task OpenAsync(Uri uri, BrowserLaunchOptions options = default) =>
+          OpenAsync(uri, BrowserLaunchMode.SystemPreferred, options);
 
-        public static Task<bool> OpenAsync(Uri uri, BrowserLaunchMode launchMode) =>
-            PlatformOpenAsync(EscapeUri(uri), launchMode);
+        public static Task<bool> OpenAsync(Uri uri, BrowserLaunchMode launchMode, BrowserLaunchOptions options = default) =>
+            PlatformOpenAsync(EscapeUri(uri), launchMode, options);
 
         internal static Uri EscapeUri(Uri uri)
         {
@@ -33,6 +33,60 @@ namespace Xamarin.Essentials
             return new Uri(uri.Scheme + "://" + idn.GetAscii(uri.Authority) + uri.PathAndQuery);
 #endif
         }
+    }
+
+    public readonly partial struct BrowserLaunchOptions : IEquatable<BrowserLaunchOptions>
+    {
+        public BrowserLaunchOptions(EssentialsColor? prefferedControlColor, EssentialsColor? preferredBackgroundColor, EssentialsColor? preferredTitleColor, bool? shouldShowTitle)
+        {
+            PrefferedControlColor = prefferedControlColor;
+            PreferredBackgroundColor = preferredBackgroundColor;
+            PreferredTitleColor = preferredTitleColor;
+            ShouldShowTitle = shouldShowTitle;
+        }
+
+        public EssentialsColor? PreferredTitleColor { get; }
+
+        public EssentialsColor? PreferredBackgroundColor { get; }
+
+        public EssentialsColor? PrefferedControlColor { get; }
+
+        public bool? ShouldShowTitle { get; }
+
+        public static bool operator ==(BrowserLaunchOptions lhs, BrowserLaunchOptions rhs) => lhs.Equals(rhs);
+
+        public static bool operator !=(BrowserLaunchOptions lhs, BrowserLaunchOptions rhs) => lhs.Equals(rhs);
+
+        public override bool Equals(object other) => other is BrowserLaunchOptions options && Equals(options);
+
+        public bool Equals(BrowserLaunchOptions other) => PreferredTitleColor.Equals(other.PreferredTitleColor)
+                                                          && PreferredBackgroundColor.Equals(other.PreferredBackgroundColor)
+                                                          && PrefferedControlColor.Equals(other.PrefferedControlColor)
+                                                          && ShouldShowTitle.Equals(other.ShouldShowTitle);
+
+        public override int GetHashCode() => (PreferredBackgroundColor, PreferredBackgroundColor, PrefferedControlColor, ShouldShowTitle).GetHashCode();
+    }
+
+    public readonly partial struct EssentialsColor : IEquatable<EssentialsColor>
+    {
+        public byte R { get; }
+
+        public byte G { get; }
+
+        public byte B { get; }
+
+        public byte A { get; }
+
+        public static bool operator ==(EssentialsColor lhs, EssentialsColor rhs) => lhs.Equals(rhs);
+
+        public static bool operator !=(EssentialsColor lhs, EssentialsColor rhs) => lhs.Equals(rhs);
+
+        public override bool Equals(object other) => other is EssentialsColor color && Equals(color);
+
+        public bool Equals(EssentialsColor other) =>
+            A.Equals(other.A) && R.Equals(other.R) && G.Equals(other.G) && B.Equals(other.B);
+
+        public override int GetHashCode() => (A, R, G, B).GetHashCode();
     }
 
     public enum BrowserLaunchMode

--- a/Xamarin.Essentials/Browser/Browser.shared.cs
+++ b/Xamarin.Essentials/Browser/Browser.shared.cs
@@ -62,15 +62,6 @@ namespace Xamarin.Essentials
 
     public class BrowserLaunchOptions : IEquatable<BrowserLaunchOptions>
     {
-        public BrowserLaunchOptions(Color? prefferedControlColor, Color? preferredBackgroundColor, Color? preferredTitleColor, BrowserLaunchMode launchMode, BrowserTitleMode shouldShowTitle)
-        {
-            PrefferedControlColor = prefferedControlColor;
-            PreferredBackgroundColor = preferredBackgroundColor;
-            PreferredTitleColor = preferredTitleColor;
-            LaunchMode = launchMode;
-            TitleMode = shouldShowTitle;
-        }
-
         public BrowserLaunchOptions()
         {
             LaunchMode = BrowserLaunchMode.Default;
@@ -91,11 +82,11 @@ namespace Xamarin.Essentials
 
         public BrowserTitleMode TitleMode { get; set; }
 
-        public static bool operator ==(BrowserLaunchOptions lhs, BrowserLaunchOptions rhs) => lhs.Equals(rhs);
+        public static bool operator ==(BrowserLaunchOptions lhs, BrowserLaunchOptions rhs) => (lhs == null && rhs == null) || (lhs != null && lhs.Equals(rhs));
 
-        public static bool operator !=(BrowserLaunchOptions lhs, BrowserLaunchOptions rhs) => lhs.Equals(rhs);
+        public static bool operator !=(BrowserLaunchOptions lhs, BrowserLaunchOptions rhs) => !(lhs == rhs);
 
-        public override bool Equals(object other) => other is BrowserLaunchOptions options && other != null && Equals(options);
+        public override bool Equals(object other) => other is BrowserLaunchOptions options && Equals(options);
 
         public bool Equals(BrowserLaunchOptions other) => other != null && PreferredTitleColor.Equals(other.PreferredTitleColor)
                                                           && PreferredBackgroundColor.Equals(

--- a/Xamarin.Essentials/Browser/Browser.shared.cs
+++ b/Xamarin.Essentials/Browser/Browser.shared.cs
@@ -25,12 +25,12 @@ namespace Xamarin.Essentials
     public static partial class Browser
     {
         public static Task OpenAsync(string uri) =>
-            OpenAsync(uri, default(BrowserLaunchOptions));
+            OpenAsync(uri, new BrowserLaunchOptions());
 
         public static Task OpenAsync(string uri, BrowserLaunchMode launchMode) =>
-            OpenAsync(uri, new BrowserLaunchOptions(launchMode));
+            OpenAsync(uri, new BrowserLaunchOptions());
 
-        public static Task OpenAsync(string uri, BrowserLaunchOptions options = default)
+        public static Task OpenAsync(string uri, BrowserLaunchOptions options)
         {
             if (string.IsNullOrWhiteSpace(uri))
             {
@@ -40,7 +40,13 @@ namespace Xamarin.Essentials
             return OpenAsync(new Uri(uri), options);
         }
 
-        public static Task<bool> OpenAsync(Uri uri, BrowserLaunchOptions options = default) =>
+        public static Task OpenAsync(Uri uri) =>
+            OpenAsync(uri, new BrowserLaunchOptions());
+
+        public static Task OpenAsync(Uri uri, BrowserLaunchMode launchMode) =>
+            OpenAsync(uri, new BrowserLaunchOptions(launchMode));
+
+        public static Task<bool> OpenAsync(Uri uri, BrowserLaunchOptions options) =>
             PlatformOpenAsync(EscapeUri(uri), options);
 
         internal static Uri EscapeUri(Uri uri)

--- a/Xamarin.Essentials/Browser/Browser.shared.cs
+++ b/Xamarin.Essentials/Browser/Browser.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 #if NETSTANDARD1_0
@@ -16,6 +17,7 @@ public struct Color
 }
 #else
 using System.Drawing;
+[assembly: TypeForwardedTo(typeof(Color))]
 #endif
 
 namespace Xamarin.Essentials
@@ -55,7 +57,7 @@ namespace Xamarin.Essentials
         }
     }
 
-    public readonly struct BrowserLaunchOptions : IEquatable<BrowserLaunchOptions>
+    public class BrowserLaunchOptions : IEquatable<BrowserLaunchOptions>
     {
         public BrowserLaunchOptions(Color? prefferedControlColor, Color? preferredBackgroundColor, Color? preferredTitleColor, BrowserLaunchMode launchMode, BrowserTitleMode shouldShowTitle)
         {
@@ -75,23 +77,23 @@ namespace Xamarin.Essentials
             PrefferedControlColor = null;
         }
 
-        public Color? PreferredTitleColor { get; }
+        public Color? PreferredTitleColor { get; set; }
 
-        public Color? PreferredBackgroundColor { get; }
+        public Color? PreferredBackgroundColor { get; set; }
 
-        public Color? PrefferedControlColor { get; }
+        public Color? PrefferedControlColor { get; set; }
 
-        public BrowserLaunchMode LaunchMode { get; }
+        public BrowserLaunchMode LaunchMode { get; set; }
 
-        public BrowserTitleMode TitleMode { get; }
+        public BrowserTitleMode TitleMode { get; set; }
 
         public static bool operator ==(BrowserLaunchOptions lhs, BrowserLaunchOptions rhs) => lhs.Equals(rhs);
 
         public static bool operator !=(BrowserLaunchOptions lhs, BrowserLaunchOptions rhs) => lhs.Equals(rhs);
 
-        public override bool Equals(object other) => other is BrowserLaunchOptions options && Equals(options);
+        public override bool Equals(object other) => other is BrowserLaunchOptions options && other != null && Equals(options);
 
-        public bool Equals(BrowserLaunchOptions other) => PreferredTitleColor.Equals(other.PreferredTitleColor)
+        public bool Equals(BrowserLaunchOptions other) => other != null && PreferredTitleColor.Equals(other.PreferredTitleColor)
                                                           && PreferredBackgroundColor.Equals(
                                                               other.PreferredBackgroundColor)
                                                           && PrefferedControlColor.Equals(other.PrefferedControlColor)

--- a/Xamarin.Essentials/Browser/Browser.uwp.cs
+++ b/Xamarin.Essentials/Browser/Browser.uwp.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Browser
     {
-        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchType, BrowserLaunchOptions options) =>
+        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchOptions options) =>
              Windows.System.Launcher.LaunchUriAsync(uri).AsTask();
     }
 }

--- a/Xamarin.Essentials/Browser/Browser.uwp.cs
+++ b/Xamarin.Essentials/Browser/Browser.uwp.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Browser
     {
-        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchType) =>
+        static Task<bool> PlatformOpenAsync(Uri uri, BrowserLaunchMode launchType, BrowserLaunchOptions options) =>
              Windows.System.Launcher.LaunchUriAsync(uri).AsTask();
     }
 }

--- a/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.shared.cs
+++ b/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.shared.cs
@@ -45,6 +45,9 @@ namespace Xamarin.Essentials
 
         public static uint ToUInt(this Color color) =>
             (uint)((color.A << 24) | (color.R << 16) | (color.G << 8) | (color.B << 0));
+
+        public static int ToInt(this Color color) =>
+            (color.A << 24) | (color.R << 16) | (color.G << 8) | (color.B << 0);
     }
 }
 #endif

--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -23,7 +23,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <RepositoryUrl>https://github.com/xamarin/Essentials</RepositoryUrl>
     <PackageReleaseNotes>See: https://github.com/xamarin/Essentials/wiki/Release-Notes</PackageReleaseNotes>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>


### PR DESCRIPTION
### Description of Change ###
Implemented some Features required for GH- #196. 
### API Changes ###

List all API changes here (or just put None), example:

Added: 

```csharp
public readonly struct EssentialsColor : IEquatable<EssentialsColor>
{
        public byte R { get; }
        public byte G { get; }
        public byte B { get; }
        public byte A { get; }
}

public readonly partial struct BrowserLaunchOptions : IEquatable<BrowserLaunchOptions>
{
        public EssentialsColor? PreferredTitleColor { get; }

        public EssentialsColor? PreferredBackgroundColor { get; }

        public EssentialsColor? PrefferedControlColor { get; }

        public bool? ShouldShowTitle { get; }
}
```
Changed:
 - `Browser.OpenAsync(string uri, BrowserLaunchOptions options = default) // Added default parameter`

### Behavioral Changes ###

None. All values are nullable. If they are not set as they are by default no changes are made.
### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
