### PR TITLE
GH-649: Return distinct connectivity profiles.

### DIFF
--- a/DeviceTests/DeviceTests.Shared/Connectivity_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Connectivity_Tests.cs
@@ -11,7 +11,14 @@ namespace DeviceTests
             Assert.Equal(NetworkAccess.Internet, Connectivity.NetworkAccess);
 
         [Fact]
-        public void ConnectionProfiles() =>
+        public void Connection_Profiles() =>
             Assert.True(Connectivity.ConnectionProfiles.Count() > 0);
+
+        [Fact]
+        public void Distict_Connection_Profiles()
+        {
+            var profiles = Connectivity.ConnectionProfiles;
+            Assert.Equal(profiles.Count(), profiles.Distinct().Count());
+        }
     }
 }

--- a/Xamarin.Essentials/Connectivity/Connectivity.shared.cs
+++ b/Xamarin.Essentials/Connectivity/Connectivity.shared.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Essentials
 
         public static NetworkAccess NetworkAccess => PlatformNetworkAccess;
 
-        public static IEnumerable<ConnectionProfile> ConnectionProfiles => PlatformConnectionProfiles;
+        public static IEnumerable<ConnectionProfile> ConnectionProfiles => PlatformConnectionProfiles.Distinct();
 
         public static event EventHandler<ConnectivityChangedEventArgs> ConnectivityChanged
         {


### PR DESCRIPTION
### Description of Change ###

Return only distinct profiles.

### Bugs Fixed ###

- Related to issue #649

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.


### Behavioral Changes ###

Used to be able to return multiple of the same connectivity profile. Now only distinct.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
