### PR TITLE
GH-656: Connectivity Updates on Android for Not Available

### DIFF
--- a/Xamarin.Essentials/Connectivity/Connectivity.android.cs
+++ b/Xamarin.Essentials/Connectivity/Connectivity.android.cs
@@ -63,10 +63,10 @@ namespace Xamarin.Essentials
                                     continue;
 
                                 var info = manager.GetNetworkInfo(network);
-                                
+
                                 if (info == null || !info.IsAvailable)
                                     continue;
-                                
+
                                 // Check to see if it has the internet capability
                                 if (!capabilities.HasCapability(NetCapability.Internet))
                                 {
@@ -74,7 +74,7 @@ namespace Xamarin.Essentials
                                     currentAccess = IsBetterAccess(currentAccess, NetworkAccess.Local);
                                     continue;
                                 }
-                                
+
                                 ProcessNetworkInfo(info);
                             }
                             catch

--- a/Xamarin.Essentials/Connectivity/Connectivity.android.cs
+++ b/Xamarin.Essentials/Connectivity/Connectivity.android.cs
@@ -62,6 +62,11 @@ namespace Xamarin.Essentials
                                 if (capabilities == null)
                                     continue;
 
+                                var info = manager.GetNetworkInfo(network);
+                                
+                                if (info == null || !info.IsAvailable)
+                                    continue;
+                                
                                 // Check to see if it has the internet capability
                                 if (!capabilities.HasCapability(NetCapability.Internet))
                                 {
@@ -69,9 +74,7 @@ namespace Xamarin.Essentials
                                     currentAccess = IsBetterAccess(currentAccess, NetworkAccess.Local);
                                     continue;
                                 }
-
-                                var info = manager.GetNetworkInfo(network);
-
+                                
                                 ProcessNetworkInfo(info);
                             }
                             catch


### PR DESCRIPTION
Always check IsAvailable
This may fix #656 on select phones where wifi is returned even though it isn't available.

Still need to investigate profiles

### Description of Change ###

On select devices a network may be returned even in airplane mode, but will be marked as not available. 

### Bugs Fixed ###

- Related to issue #656

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- string - string Class.Property { get; set; } 
- void Class.Method();

Changed:

 - object Cell.OldPropertyName => object Cell.NewPropertyName

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
