### PR TITLE
Allow for code reuse on macOS

### DIFF
--- a/Xamarin.Essentials/Geolocation/Geolocation.ios.cs
+++ b/Xamarin.Essentials/Geolocation/Geolocation.ios.cs
@@ -45,8 +45,10 @@ namespace Xamarin.Essentials
             manager.DesiredAccuracy = request.PlatformDesiredAccuracy;
             manager.Delegate = listener;
 
+#if __IOS__
             // we're only listening for a single update
             manager.PausesLocationUpdatesAutomatically = false;
+#endif
 
             manager.StartUpdatingLocation();
 


### PR DESCRIPTION
### Description of Change ###

Even though macOS is not yet officially supported, it is nice to reuse this code. macOS is exactly the same, except for this single property not supported.
https://developer.apple.com/documentation/corelocation/cllocationmanager/1620553-pauseslocationupdatesautomatical

### API Changes ###

None.

### Behavioral Changes ###

None for iOS.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))

> VS bug [#756378](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/756378)