### PR TITLE
GH-668 Calculate Phone v Tablet on Android correctly

### DIFF
--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Essentials
         static DeviceIdiom DetectIdiom(UiMode uiMode)
         {
             if (uiMode.HasFlag(UiMode.TypeNormal))
-                return DeviceIdiom.Phone;
+                return DeviceIdiom.Unknown;
             else if (uiMode.HasFlag(UiMode.TypeTelevision))
                 return DeviceIdiom.TV;
             else if (uiMode.HasFlag(UiMode.TypeDesk))


### PR DESCRIPTION
Need to return known and calculate tablet vs phone as "Normal" is returned by all standard devices.

### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #668 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
