### PR TITLE
GH-714 Use original string instead of Uri for ios/android

### DIFF
--- a/Xamarin.Essentials/Launcher/Launcher.android.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.android.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Essentials
     {
         static Task<bool> PlatformCanOpenAsync(Uri uri)
         {
-            var intent = new Intent(Intent.ActionView, AndroidUri.Parse(uri.AbsoluteUri));
+            var intent = new Intent(Intent.ActionView, AndroidUri.Parse(uri.OriginalString));
 
             if (Platform.AppContext == null)
                 return Task.FromResult(false);
@@ -23,7 +23,7 @@ namespace Xamarin.Essentials
 
         static Task PlatformOpenAsync(Uri uri)
         {
-            var intent = new Intent(Intent.ActionView, AndroidUri.Parse(uri.AbsoluteUri));
+            var intent = new Intent(Intent.ActionView, AndroidUri.Parse(uri.OriginalString));
             intent.SetFlags(ActivityFlags.ClearTop);
             intent.SetFlags(ActivityFlags.NewTask);
             Platform.AppContext.StartActivity(intent);

--- a/Xamarin.Essentials/Launcher/Launcher.ios.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.ios.cs
@@ -8,9 +8,9 @@ namespace Xamarin.Essentials
     public static partial class Launcher
     {
         static Task<bool> PlatformCanOpenAsync(Uri uri) =>
-            Task.FromResult(UIApplication.SharedApplication.CanOpenUrl(new NSUrl(uri.AbsoluteUri)));
+            Task.FromResult(UIApplication.SharedApplication.CanOpenUrl(new NSUrl(uri.OriginalString)));
 
         static Task PlatformOpenAsync(Uri uri) =>
-            UIApplication.SharedApplication.OpenUrlAsync(new NSUrl(uri.AbsoluteUri), new UIApplicationOpenUrlOptions());
+            UIApplication.SharedApplication.OpenUrlAsync(new NSUrl(uri.OriginalString), new UIApplicationOpenUrlOptions());
     }
 }


### PR DESCRIPTION
### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #714

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###
None


### Behavioral Changes ###

We don't escape these uris anyways and always wanted to use the original. The problem is that the URI adds in a / :( no way to get around it except to use the original, which is the correct thing to do.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
