### PR TITLE
Fixes #745 to return real metrics, not app metrics on display.

### DIFF
--- a/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.android.cs
+++ b/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.android.cs
@@ -3,6 +3,7 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Provider;
 using Android.Runtime;
+using Android.Util;
 using Android.Views;
 
 namespace Xamarin.Essentials
@@ -32,7 +33,10 @@ namespace Xamarin.Essentials
 
         static DisplayInfo GetMainDisplayInfo()
         {
-            var displayMetrics = Platform.AppContext.Resources?.DisplayMetrics;
+            var displayMetrics = new DisplayMetrics();
+
+            var display = GetDefaultDisplay();
+            display?.GetRealMetrics(displayMetrics);
 
             return new DisplayInfo(
                 width: displayMetrics?.WidthPixels ?? 0,
@@ -63,8 +67,7 @@ namespace Xamarin.Essentials
 
         static DisplayRotation CalculateRotation()
         {
-            var service = Platform.AppContext.GetSystemService(Context.WindowService);
-            var display = service?.JavaCast<IWindowManager>()?.DefaultDisplay;
+            var display = GetDefaultDisplay();
 
             if (display != null)
             {
@@ -105,6 +108,12 @@ namespace Xamarin.Essentials
 
         static string GetSystemSetting(string name)
            => Settings.System.GetString(Platform.AppContext.ContentResolver, name);
+
+        static Display GetDefaultDisplay()
+        {
+            var service = Platform.AppContext.GetSystemService(Context.WindowService);
+            return service?.JavaCast<IWindowManager>()?.DefaultDisplay;
+        }
     }
 
     class Listener : OrientationEventListener

--- a/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.android.cs
+++ b/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.android.cs
@@ -33,17 +33,20 @@ namespace Xamarin.Essentials
 
         static DisplayInfo GetMainDisplayInfo()
         {
-            var displayMetrics = new DisplayMetrics();
+            using (var displayMetrics = new DisplayMetrics())
+            {
+                using (var display = GetDefaultDisplay())
+                {
+                    display?.GetRealMetrics(displayMetrics);
 
-            var display = GetDefaultDisplay();
-            display?.GetRealMetrics(displayMetrics);
-
-            return new DisplayInfo(
-                width: displayMetrics?.WidthPixels ?? 0,
-                height: displayMetrics?.HeightPixels ?? 0,
-                density: displayMetrics?.Density ?? 0,
-                orientation: CalculateOrientation(),
-                rotation: CalculateRotation());
+                    return new DisplayInfo(
+                        width: displayMetrics?.WidthPixels ?? 0,
+                        height: displayMetrics?.HeightPixels ?? 0,
+                        density: displayMetrics?.Density ?? 0,
+                        orientation: CalculateOrientation(),
+                        rotation: CalculateRotation());
+                }
+            }
         }
 
         static void StartScreenMetricsListeners()
@@ -67,10 +70,11 @@ namespace Xamarin.Essentials
 
         static DisplayRotation CalculateRotation()
         {
-            var display = GetDefaultDisplay();
-
-            if (display != null)
+            using (var display = GetDefaultDisplay())
             {
+                if (display == null)
+                    return DisplayRotation.Unknown;
+
                 switch (display.Rotation)
                 {
                     case SurfaceOrientation.Rotation270:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ variables:
   IOS_SIM_RUNTIME: 'iOS 12.1'
   ANDROID_EMU_TARGET: 'system-images;android-26;google_apis;x86'
   ANDROID_EMU_DEVICE: 'Nexus 5X'
+  RunPoliCheck: 'false'
 
 resources:
   repositories:
@@ -67,7 +68,7 @@ jobs:
           condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
           displayName: Component Detection - Report
         - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
-          condition: eq(variables['System.TeamProject'], 'devdiv')
+          condition: eq(variables['RunPoliCheck'], 'true')
           displayName: 'PoliCheck'
           inputs:
             targetType: F


### PR DESCRIPTION
### Description of Change ###

Uses real device metrics instead of app.

### Bugs Fixed ###

- Related to issue #745

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###
### Behavioral Changes ###

Will return different device metrics, but are correct to match iOS/UWP

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
