### PR TITLE
Use "portable" PDB files

### DIFF
--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -32,25 +32,18 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=868960</PackageProjectUrl>
     <MDocDocumentationDirectory>$(MSBuildThisFileDirectory)..\docs\en</MDocDocumentationDirectory>
     <Configurations>Debug;Release;Samples;Docs</Configurations>
+    <DebugType>portable</DebugType>
  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Samples'">
-    <DebugType>pdbonly</DebugType>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
-    <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)'=='Release' And '$(OS)' == 'Windows_NT' ">
-    <DebugType>pdbonly</DebugType>
     <!-- sourcelink: Declare that the Repository URL can be published to NuSpec -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- sourcelink: Embed source files that are not tracked by the source control manager to the PDB -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- sourcelink: Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)'=='Docs' ">
-    <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup Condition=" '$(Configuration)'=='Release' And '$(OS)' == 'Windows_NT' ">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />    


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/dotnet/core/blob/79c19c12ab2bc11912551bb0c3025f602cd541d9/Documentation/diagnostics/portable_pdb.md

In doing some performance testing with builds in VS 2019, I noticed:

    115 ms  _ConvertPdbFiles                           1 calls

And looking at files were converted:

    ConvertDebuggingFiles
        Parameters
            Files
                C:\ProgramData\Xamarin\NuGet\xamarin.essentials\1.0.1\lib\monoandroid81\Xamarin.Essentials.pdb
        [Output] ConvertedFiles:
            C:\ProgramData\Xamarin\NuGet\xamarin.essentials\1.0.1\lib\monoandroid81\Xamarin.Essentials.dll

The Xamarin.Essentials NuGet package is shipping a non-portable PDB
file. This is a Windows-specific format that Mono doesn't support.

Xamarin.Android runs a tool called `pdb2mdb` when it encounters a
non-portable PDB file so symbols be converted to something that Mono
can use. If you have `DebugType=full` or `DebugType=pdbonly`,
Xamarin.Android has to do this extra work to convert it.

I see no drawbacks to just use `DebugType=portable` in this project
all the time?

Since Xamarin.Essentials uses sourcelink, I double-checked and they
support portable PDBs:

https://github.com/dotnet/sourcelink#prerequisites-for-net-projects

I sent a similar PR to Xamarin.Forms, shipping since 3.4. I wrote a
bit more detail on symbol files there if you need more info:

https://github.com/xamarin/Xamarin.Forms/pull/4201

### Bugs Fixed ###

None filed, I just saw this when doing perf work with VS 2019.

### API Changes ###

n/a

### Behavioral Changes ###

Initial build times should improve by ~100ms.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
