### PR TITLE
Fixes #794 try to use original string first else absolute for NSUrl

### DIFF
--- a/DeviceTests/DeviceTests.Shared/Launcher_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Launcher_Tests.cs
@@ -68,6 +68,17 @@ namespace DeviceTests
             Assert.True(await Launcher.CanOpenAsync(new Uri(uri)));
         }
 
+#if __IOS__
+        [Theory]
+        [InlineData("https://maps.apple.com/maps?q=Ole Vigs Gate 8B", "https://maps.apple.com/maps?q=Ole%20Vigs%20Gate%208B")]
+        [InlineData("https://maps.apple.com", "https://maps.apple.com")]
+        public void GetNativeUrl(string uri, string expected)
+        {
+            var url = Launcher.GetNativeUrl(new Uri(uri));
+            Assert.Equal(expected, url.AbsoluteString);
+        }
+#endif
+
         [Theory]
         [InlineData("Not Valid Uri")]
         public async Task InvalidUri(string uri)

--- a/Xamarin.Essentials/Launcher/Launcher.ios.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.ios.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Foundation;
 using UIKit;
@@ -8,9 +9,22 @@ namespace Xamarin.Essentials
     public static partial class Launcher
     {
         static Task<bool> PlatformCanOpenAsync(Uri uri) =>
-            Task.FromResult(UIApplication.SharedApplication.CanOpenUrl(new NSUrl(uri.OriginalString)));
+            Task.FromResult(UIApplication.SharedApplication.CanOpenUrl(GetNativeUrl(uri)));
 
         static Task PlatformOpenAsync(Uri uri) =>
-            UIApplication.SharedApplication.OpenUrlAsync(new NSUrl(uri.OriginalString), new UIApplicationOpenUrlOptions());
+            UIApplication.SharedApplication.OpenUrlAsync(GetNativeUrl(uri), new UIApplicationOpenUrlOptions());
+
+        internal static NSUrl GetNativeUrl(Uri uri)
+        {
+            try
+            {
+                return new NSUrl(uri.OriginalString);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("Unable to create Url from Original string, try absolute Uri: " + ex.Message);
+                return new NSUrl(uri.AbsoluteUri);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description of Change ###

If not encoded string then NSUrl gets mad so try original first for launcher else use absolute

### Bugs Fixed ###

- Related to issue #794 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

None


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
