### PR TITLE
Fixes issue https://github.com/xamarin/Essentials/issues/808

### DIFF
--- a/Tests/Browser_Tests.cs
+++ b/Tests/Browser_Tests.cs
@@ -33,6 +33,8 @@ namespace Tests
         [InlineData("https://xamariñ.com/?test=xamariñ", "https://xn--xamari-1wa.com/?test=xamari%C3%B1")]
         [InlineData("http://xamariñ.com/?test=xamariñ", "http://xn--xamari-1wa.com/?test=xamari%C3%B1")]
         [InlineData("http://xamariñ.com/?test=xamariñ xamariñ", "http://xn--xamari-1wa.com/?test=xamari%C3%B1%20xamari%C3%B1")]
+        [InlineData("https://xamariñ.com:56/test.html#fragment", "https://xn--xamari-1wa.com:56/test.html#fragment")]
+        [InlineData("https://xamarin.com/#", "https://xamarin.com/#")]
         public void Escape_Uri(string uri, string escaped)
         {
             var escapedUri = Browser.EscapeUri(new Uri(uri));

--- a/Xamarin.Essentials/Browser/Browser.shared.cs
+++ b/Xamarin.Essentials/Browser/Browser.shared.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Essentials
             return uri;
 #else
             var idn = new System.Globalization.IdnMapping();
-            return new Uri(uri.Scheme + "://" + idn.GetAscii(uri.Authority) + uri.PathAndQuery);
+            return new Uri(uri.Scheme + "://" + idn.GetAscii(uri.Authority) + uri.PathAndQuery + uri.Fragment);
 #endif
         }
     }


### PR DESCRIPTION
### Description of Change ###
After calling `Browser.OpenAsync` with the URL that contained a fragment part, the fragment part was being omitted as a result of a call to `Browser.EscapeUri`.

Changed `Browser.EscapeUri` to include the fragment part of the escaped URL as its last part. 
[See RFC 3986](https://www.ietf.org/rfc/rfc3986.txt)


### Bugs Fixed ###

- Related to issue #808 

### API Changes ###
None

### Behavioral Changes ###

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
