### PR TITLE
Put in check for iOS 12 to use new openurlasync method

### DIFF
--- a/Xamarin.Essentials/Browser/Browser.ios.cs
+++ b/Xamarin.Essentials/Browser/Browser.ios.cs
@@ -31,7 +31,15 @@ namespace Xamarin.Essentials
                     await vc.PresentViewControllerAsync(sfViewController, true);
                     break;
                 case BrowserLaunchMode.External:
-                    return await UIApplication.SharedApplication.OpenUrlAsync(nativeUrl, new UIApplicationOpenUrlOptions());
+                    if (Platform.HasOSVersion(12, 0))
+                    {
+                        return await UIApplication.SharedApplication.OpenUrlAsync(nativeUrl, new UIApplicationOpenUrlOptions());
+                    }
+                    else
+                    {
+                        UIApplication.SharedApplication.OpenUrl(nativeUrl);
+                    }
+                    break;
             }
 
             return true;


### PR DESCRIPTION
### Description of Change ###

We were using too new of an API for openurl so <12 woudl have issues

### Bugs Fixed ###

- Related to issue #269

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###


### Behavioral Changes ###

When using external it should be fine now on devices < 12

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
