### PR TITLE
Made ShareActivityItemSource members readonly.

### DIFF
--- a/Xamarin.Essentials/Share/Share.ios.cs
+++ b/Xamarin.Essentials/Share/Share.ios.cs
@@ -57,8 +57,8 @@ namespace Xamarin.Essentials
 
     class ShareActivityItemSource : UIActivityItemSource
     {
-        NSObject item;
-        string subject;
+        readonly NSObject item;
+        readonly string subject;
 
         internal ShareActivityItemSource(NSObject item, string subject)
         {


### PR DESCRIPTION
Very simple improvement making ShareActivityItemSource members readonly.