### PR TITLE
Updated to use UrlEncode in GetMailToUrl

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Create a report to help us improve
 title: "[Bug] "
-labels: bug :bug:
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: "[Bug] "
+labels: bug :bug:
+assignees: ''
+
+---
+
+<!-- Bug report best practices: https://github.com/xamarin/Essentials/wiki -->
+
+### Description
+
+### Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+### Expected Behavior
+
+### Actual Behavior
+
+### Basic Information
+
+- Version with issue:
+- Last known good version:
+- IDE:
+- Platform Target Frameworks: <!-- All that apply -->
+  - iOS:  <!-- The version of the iOS SDK you are compiling against, e.g. 11.1 -->
+  - Android: <!-- The version of the Android SDK you are compiling against, e.g. 7.1 --> 
+  - UWP:  <!-- The version of the UWP SDK you are compiling against, e.g. 16299 --> 
+- Android Support Library Version: <!-- if applicable -->
+- Nuget Packages:
+- Affected Devices:
+
+### Screenshots
+
+<!-- If the issue is a visual issue, please include screenshots showing the problem if possible -->
+
+### Reproduction Link
+
+<!-- Please upload or provide a link to a reproduction case -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for Essentials
+title: "[Enhancement] YOUR IDEA!"
+labels: feature-request 
+assignees: ''
+
+---
+
+## Summary
+Please provide a brief summary of your proposal. Two to three sentences is best here.
+
+## API Changes
+
+Include a list of all API changes, additions, subtractions as would be required by your proposal. These APIs should be considered placeholders, so the naming is not as important as getting the concepts correct. If possible you should include some "example" code of usage of your new API.  You should also provide details of the level of availability for the feature on each of the supported platforms.
+
+e.g.
+
+In order to facilitate the new Shiny Button api, a bool is added to the Button class. This is done as a bool because it is simpler to data bind and other reasons...
+
+    var button = new Button ();
+    button.MakeShiny = true; // new API
+
+The MakeShiny API works even if the button is already visible.
+
+## Intended Use Case
+Provide a detailed example of where your proposal would be used and for what purpose.

--- a/.github/ISSUE_TEMPLATE/new-api-spec.md
+++ b/.github/ISSUE_TEMPLATE/new-api-spec.md
@@ -1,0 +1,39 @@
+---
+name: New API Spec
+about: An official specification for new APIS
+title: "[Spec]  "
+labels: "feature-request"
+assignees: ''
+
+---
+
+# [The feature] 
+
+Provide a concise description of the feature and the motivation for adding it to Xamarin.Essentials
+
+# API
+
+## [ class ]
+
+### Properties
+
+| API | Description |
+| ------------- | ------------- |
+| [name] | Gets or sets [description]. |
+
+### Events
+
+| API | Description |
+| ------------- | ------------- |
+| [name] | [API documentation/description] |
+ 
+# Scenarios
+
+# Platform Compatibility
+- Target Frameworks: <!-- All that apply -->
+  - iOS:  <!-- Support on iOS for the API -->
+  - Android: <!-- Support on Android for the API -->
+  - UWP: <!-- Support on UWP for the API -->
+# Backward Compatibility
+
+# Difficulty : [low/medium/high]

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -74,7 +74,7 @@
       "nuget_feed": "https://www.myget.org/F/op/api/v2",
       "path_to_root": "_dependentPackages/ECMA2Yaml",
       "target_framework": "net45",
-      "version": "latest"
+      "version": "1.0.417"
     },
     {
       "id": "memberpage.plugins",

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -74,7 +74,7 @@
       "nuget_feed": "https://www.myget.org/F/op/api/v2",
       "path_to_root": "_dependentPackages/ECMA2Yaml",
       "target_framework": "net45",
-      "version": "1.0.417"
+      "version": "latest"
     },
     {
       "id": "memberpage.plugins",

--- a/Samples/Samples/View/LauncherPage.xaml
+++ b/Samples/Samples/View/LauncherPage.xaml
@@ -23,7 +23,8 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
                 <Entry Grid.Row="0" Grid.ColumnSpan="2" Text="{Binding LaunchUri}" />
-                <Button Grid.Row="1" Grid.ColumnSpan="2"  Text="Check Launch" Command="{Binding CanLaunchCommand}"/>
+                <Button Grid.Row="1" Text="Check Launch" Command="{Binding CanLaunchCommand}"/>
+                <Button Grid.Row="1" Grid.Column="1"  Text=" Launch" Command="{Binding LaunchCommand}"/>
                 <Button Grid.Row="2" Grid.Column="0" Text="Launch Browser" Command="{Binding LaunchBrowserCommand}"/>
                 <Button Grid.Row="2" Grid.Column="1" Text="Launch Mail" Command="{Binding LaunchMailCommand}"/>
                 

--- a/Xamarin.Essentials/Email/Email.shared.cs
+++ b/Xamarin.Essentials/Email/Email.shared.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Xamarin.Essentials
@@ -29,15 +30,15 @@ namespace Xamarin.Essentials
 
             var parts = new List<string>();
             if (!string.IsNullOrEmpty(message?.Body))
-                parts.Add("body=" + Uri.EscapeUriString(message.Body));
+                parts.Add("body=" + WebUtility.UrlEncode(message.Body));
             if (!string.IsNullOrEmpty(message?.Subject))
-                parts.Add("subject=" + Uri.EscapeUriString(message.Subject));
+                parts.Add("subject=" + WebUtility.UrlEncode(message.Subject));
             if (message?.To.Count > 0)
-                parts.Add("to=" + string.Join(",", message.To));
+                parts.Add("to=" + WebUtility.UrlEncode(string.Join(",", message.To)));
             if (message?.Cc.Count > 0)
-                parts.Add("cc=" + string.Join(",", message.Cc));
+                parts.Add("cc=" + WebUtility.UrlEncode(string.Join(",", message.Cc)));
             if (message?.Bcc.Count > 0)
-                parts.Add("bcc=" + string.Join(",", message.Bcc));
+                parts.Add("bcc=" + WebUtility.UrlEncode(string.Join(",", message.Bcc)));
 
             var uri = "mailto:";
             if (parts.Count > 0)

--- a/Xamarin.Essentials/Share/Share.ios.cs
+++ b/Xamarin.Essentials/Share/Share.ios.cs
@@ -57,8 +57,8 @@ namespace Xamarin.Essentials
 
     class ShareActivityItemSource : UIActivityItemSource
     {
-        NSObject item;
-        string subject;
+        readonly NSObject item;
+        readonly string subject;
 
         internal ShareActivityItemSource(NSObject item, string subject)
         {

--- a/Xamarin.Essentials/Sms/Sms.ios.cs
+++ b/Xamarin.Essentials/Sms/Sms.ios.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Essentials
             messageController.Finished += (sender, e) =>
             {
                 messageController.DismissViewController(true, null);
-                tcs.SetResult(e.Result == MessageComposeResult.Sent);
+                tcs?.TrySetResult(e.Result == MessageComposeResult.Sent);
             };
             controller.PresentViewController(messageController, true, null);
 


### PR DESCRIPTION
Fixes #843 

Because the things we are escaping are parts of the url, not the whole uri