### PR TITLE
Updated to use UrlEncode in GetMailToUrl

### DIFF
--- a/Xamarin.Essentials/Email/Email.shared.cs
+++ b/Xamarin.Essentials/Email/Email.shared.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Net;
+using System.Threading.Tasks;
 
 namespace Xamarin.Essentials
 {
@@ -30,15 +30,15 @@ namespace Xamarin.Essentials
 
             var parts = new List<string>();
             if (!string.IsNullOrEmpty(message?.Body))
-               parts.Add("body=" + WebUtility.UrlEncode(message.Body));
-           if (!string.IsNullOrEmpty(message?.Subject))
-               parts.Add("subject=" + WebUtility.UrlEncode(message.Subject));
-           if (message?.To.Count > 0)
-               parts.Add("to=" + WebUtility.UrlEncode(string.Join(",", message.To)));
-           if (message?.Cc.Count > 0)
-               parts.Add("cc=" + WebUtility.UrlEncode(string.Join(",", message.Cc)));
-           if (message?.Bcc.Count > 0)
-               parts.Add("bcc=" + WebUtility.UrlEncode(string.Join(",", message.Bcc)));
+                parts.Add("body=" + WebUtility.UrlEncode(message.Body));
+            if (!string.IsNullOrEmpty(message?.Subject))
+                parts.Add("subject=" + WebUtility.UrlEncode(message.Subject));
+            if (message?.To.Count > 0)
+                parts.Add("to=" + WebUtility.UrlEncode(string.Join(",", message.To)));
+            if (message?.Cc.Count > 0)
+                parts.Add("cc=" + WebUtility.UrlEncode(string.Join(",", message.Cc)));
+            if (message?.Bcc.Count > 0)
+                parts.Add("bcc=" + WebUtility.UrlEncode(string.Join(",", message.Bcc)));
 
             var uri = "mailto:";
             if (parts.Count > 0)

--- a/Xamarin.Essentials/Email/Email.shared.cs
+++ b/Xamarin.Essentials/Email/Email.shared.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Net;
 
 namespace Xamarin.Essentials
 {

--- a/Xamarin.Essentials/Email/Email.shared.cs
+++ b/Xamarin.Essentials/Email/Email.shared.cs
@@ -29,15 +29,15 @@ namespace Xamarin.Essentials
 
             var parts = new List<string>();
             if (!string.IsNullOrEmpty(message?.Body))
-                parts.Add("body=" + Uri.EscapeUriString(message.Body));
-            if (!string.IsNullOrEmpty(message?.Subject))
-                parts.Add("subject=" + Uri.EscapeUriString(message.Subject));
-            if (message?.To.Count > 0)
-                parts.Add("to=" + string.Join(",", message.To));
-            if (message?.Cc.Count > 0)
-                parts.Add("cc=" + string.Join(",", message.Cc));
-            if (message?.Bcc.Count > 0)
-                parts.Add("bcc=" + string.Join(",", message.Bcc));
+               parts.Add("body=" + WebUtility.UrlEncode(message.Body));
+           if (!string.IsNullOrEmpty(message?.Subject))
+               parts.Add("subject=" + WebUtility.UrlEncode(message.Subject));
+           if (message?.To.Count > 0)
+               parts.Add("to=" + WebUtility.UrlEncode(string.Join(",", message.To)));
+           if (message?.Cc.Count > 0)
+               parts.Add("cc=" + WebUtility.UrlEncode(string.Join(",", message.Cc)));
+           if (message?.Bcc.Count > 0)
+               parts.Add("bcc=" + WebUtility.UrlEncode(string.Join(",", message.Bcc)));
 
             var uri = "mailto:";
             if (parts.Count > 0)

--- a/Xamarin.Essentials/Types/PlacemarkExtensions.shared.cs
+++ b/Xamarin.Essentials/Types/PlacemarkExtensions.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Xamarin.Essentials
@@ -22,16 +23,16 @@ namespace Xamarin.Essentials
             else
                 escaped.Location = new Location(placemark.Location);
 
-            escaped.CountryCode = string.IsNullOrWhiteSpace(placemark.CountryCode) ? string.Empty : Uri.EscapeUriString(placemark.CountryCode);
-            escaped.CountryName = string.IsNullOrWhiteSpace(placemark.CountryName) ? string.Empty : Uri.EscapeUriString(placemark.CountryName);
-            escaped.FeatureName = string.IsNullOrWhiteSpace(placemark.FeatureName) ? string.Empty : Uri.EscapeUriString(placemark.FeatureName);
-            escaped.PostalCode = string.IsNullOrWhiteSpace(placemark.PostalCode) ? string.Empty : Uri.EscapeUriString(placemark.PostalCode);
-            escaped.Locality = string.IsNullOrWhiteSpace(placemark.Locality) ? string.Empty : Uri.EscapeUriString(placemark.Locality);
-            escaped.SubLocality = string.IsNullOrWhiteSpace(placemark.SubLocality) ? string.Empty : Uri.EscapeUriString(placemark.SubLocality);
-            escaped.Thoroughfare = string.IsNullOrWhiteSpace(placemark.Thoroughfare) ? string.Empty : Uri.EscapeUriString(placemark.Thoroughfare);
-            escaped.SubThoroughfare = string.IsNullOrWhiteSpace(placemark.SubThoroughfare) ? string.Empty : Uri.EscapeUriString(placemark.SubThoroughfare);
-            escaped.SubAdminArea = string.IsNullOrWhiteSpace(placemark.SubAdminArea) ? string.Empty : Uri.EscapeUriString(placemark.SubAdminArea);
-            escaped.AdminArea = string.IsNullOrWhiteSpace(placemark.AdminArea) ? string.Empty : Uri.EscapeUriString(placemark.AdminArea);
+            escaped.CountryCode = string.IsNullOrWhiteSpace(placemark.CountryCode) ? string.Empty : WebUtility.UrlEncode(placemark.CountryCode);
+            escaped.CountryName = string.IsNullOrWhiteSpace(placemark.CountryName) ? string.Empty : WebUtility.UrlEncode(placemark.CountryName);
+            escaped.FeatureName = string.IsNullOrWhiteSpace(placemark.FeatureName) ? string.Empty : WebUtility.UrlEncode(placemark.FeatureName);
+            escaped.PostalCode = string.IsNullOrWhiteSpace(placemark.PostalCode) ? string.Empty : WebUtility.UrlEncode(placemark.PostalCode);
+            escaped.Locality = string.IsNullOrWhiteSpace(placemark.Locality) ? string.Empty : WebUtility.UrlEncode(placemark.Locality);
+            escaped.SubLocality = string.IsNullOrWhiteSpace(placemark.SubLocality) ? string.Empty : WebUtility.UrlEncode(placemark.SubLocality);
+            escaped.Thoroughfare = string.IsNullOrWhiteSpace(placemark.Thoroughfare) ? string.Empty : WebUtility.UrlEncode(placemark.Thoroughfare);
+            escaped.SubThoroughfare = string.IsNullOrWhiteSpace(placemark.SubThoroughfare) ? string.Empty : WebUtility.UrlEncode(placemark.SubThoroughfare);
+            escaped.SubAdminArea = string.IsNullOrWhiteSpace(placemark.SubAdminArea) ? string.Empty : WebUtility.UrlEncode(placemark.SubAdminArea);
+            escaped.AdminArea = string.IsNullOrWhiteSpace(placemark.AdminArea) ? string.Empty : WebUtility.UrlEncode(placemark.AdminArea);
             return escaped;
         }
     }


### PR DESCRIPTION
Fixes #843 

Because the things we are escaping are parts of the url, not the whole uri