### PR TITLE
[Tizen] Fix reference for avoid duplication

### DIFF
--- a/Samples/Samples.Tizen/Samples.Tizen.csproj
+++ b/Samples/Samples.Tizen/Samples.Tizen.csproj
@@ -25,6 +25,9 @@
 
   <ItemGroup>
     <PackageReference Include="Tizen.Wearable.CircularUI" Version="1.3.0-pre1-00043" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0">
+      <ExcludeAssets>Runtime</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\CodeStyles.targets" />

--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -97,7 +97,6 @@
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">
     <PackageReference Include="Tizen.NET" Version="4.0.0" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
     <Compile Include="**\*.tizen.cs" />
     <Compile Include="**\*.tizen.*.cs" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

I fixed the reference to not include `System.Numerics.Vectors.dll` in `Sample.Tizen` project 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
