### PR TITLE
Add synchronous API for SecureStorage: Get / Set

### DIFF
--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Essentials
         static Task PlatformSetAsync(string key, string data)
         {
             PlatformSet(key, data);
-            
+
             return Task.CompletedTask;
         }
 

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -17,6 +17,9 @@ namespace Xamarin.Essentials
         static readonly object locker = new object();
 
         static Task<string> PlatformGetAsync(string key)
+            => Task.FromResult(PlatformGet(key));
+
+        static string PlatformGet(string key)
         {
             var context = Platform.AppContext;
 
@@ -42,10 +45,17 @@ namespace Xamarin.Essentials
                 }
             }
 
-            return Task.FromResult(decryptedData);
+            return decryptedData;
         }
 
         static Task PlatformSetAsync(string key, string data)
+        {
+            PlatformSet(key, data);
+            
+            return Task.CompletedTask;
+        }
+
+        static Task PlatformSet(string key, string data)
         {
             var context = Platform.AppContext;
 

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.cs
@@ -14,28 +14,40 @@ namespace Xamarin.Essentials
 
         public static Task SetAsync(string key, string value, SecAccessible accessible)
         {
+            Set(key, value, accessible);
+
+            return Task.CompletedTask;
+        }
+
+        public static void Set(string key, string value, SecAccessible accessible)
+        {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
-
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
             var kc = new KeyChain(accessible);
             kc.SetValueForKey(value, key, Alias);
 
-            return Task.CompletedTask;
+            return;
         }
 
         static Task<string> PlatformGetAsync(string key)
+            => Task.FromResult(PlatformGet(key));
+
+        static string PlatformGet(string key)
         {
             var kc = new KeyChain(DefaultAccessible);
             var value = kc.ValueForKey(key, Alias);
 
-            return Task.FromResult(value);
+            return value;
         }
 
         static Task PlatformSetAsync(string key, string data) =>
             SetAsync(key, data, DefaultAccessible);
+
+        static void PlatformSet(string key, string data) =>
+            Set(key, data, DefaultAccessible);
 
         static bool PlatformRemove(string key)
         {

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.netstandard.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.netstandard.cs
@@ -6,14 +6,20 @@ namespace Xamarin.Essentials
     {
         static Task<string> PlatformGetAsync(string key) =>
             throw new NotImplementedInReferenceAssemblyException();
+        
+        static string PlatformGet(string key) =>
+            throw new NotImplementedInReferenceAssemblyException();
 
         static Task PlatformSetAsync(string key, string data) =>
+            throw new NotImplementedInReferenceAssemblyException();
+
+        static void PlatformSet(string key, string data) =>
             throw new NotImplementedInReferenceAssemblyException();
 
         static bool PlatformRemove(string key) =>
             throw new NotImplementedInReferenceAssemblyException();
 
         static void PlatformRemoveAll() =>
-            throw new NotImplementedInReferenceAssemblyException();
+            throw new NotImplementedInReferenceAssemblyException();    
     }
 }

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.netstandard.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.netstandard.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Essentials
     {
         static Task<string> PlatformGetAsync(string key) =>
             throw new NotImplementedInReferenceAssemblyException();
-        
+
         static string PlatformGet(string key) =>
             throw new NotImplementedInReferenceAssemblyException();
 
@@ -20,6 +20,6 @@ namespace Xamarin.Essentials
             throw new NotImplementedInReferenceAssemblyException();
 
         static void PlatformRemoveAll() =>
-            throw new NotImplementedInReferenceAssemblyException();    
+            throw new NotImplementedInReferenceAssemblyException();
     }
 }

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.shared.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.shared.cs
@@ -16,6 +16,14 @@ namespace Xamarin.Essentials
             return PlatformGetAsync(key);
         }
 
+        public static string Get(string key)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+
+            return PlatformGet(key);
+        }
+
         public static Task SetAsync(string key, string value)
         {
             if (string.IsNullOrWhiteSpace(key))
@@ -25,6 +33,17 @@ namespace Xamarin.Essentials
                 throw new ArgumentNullException(nameof(value));
 
             return PlatformSetAsync(key, value);
+        }
+
+        public static void SetAsync(string key, string value)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+            
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+            
+            return PlatformSet(key, value);
         }
 
         public static bool Remove(string key)

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.shared.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.shared.cs
@@ -28,22 +28,20 @@ namespace Xamarin.Essentials
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
-
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
             return PlatformSetAsync(key, value);
         }
 
-        public static void SetAsync(string key, string value)
+        public static void Set(string key, string value)
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
-            
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-            
-            return PlatformSet(key, value);
+
+            return;
         }
 
         public static bool Remove(string key)

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.uwp.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.uwp.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Essentials
 
         static void PlatformSet(string key, string value)
             => throw new NotImplementedException();
+
         static async Task<string> PlatformGetAsync(string key)
         {
             var settings = GetSettings(Alias);

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.uwp.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.uwp.cs
@@ -9,6 +9,11 @@ namespace Xamarin.Essentials
 {
     public partial class SecureStorage
     {
+        static string PlatformGet(string key)
+            => throw new NotImplementedException();
+
+        static void PlatformSet(string key, string value)
+            => throw new NotImplementedException();
         static async Task<string> PlatformGetAsync(string key)
         {
             var settings = GetSettings(Alias);


### PR DESCRIPTION
### Description of Change ###

SecureStorage provides async APIs for getting and setting values:  SetAsync/GetAsync.  This PR adds a synchronous API on iOS and Android: Set/Get for users who may not want the async wrapping.

### Bugs Fixed ###

None

- Related to issue #856

### API Changes ###

Added: 
 
- public static string SecureStorage.Get(string key)
- public static void SecureStorage.Set(string key, string value)

Changed:

In some cases, the platform specific async APIs are converted to wrappers around the new synchronous APIs.
 
### Behavioral Changes ###

Should be fully backwards compatible.
