### PR TITLE
GH-833 Fix Open File on iPad

### DIFF
--- a/Xamarin.Essentials/Launcher/Launcher.ios.tvos.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.ios.tvos.cs
@@ -37,7 +37,18 @@ namespace Xamarin.Essentials
 
             var vc = Platform.GetCurrentViewController();
 
-            documentController.PresentOpenInMenu(vc.View.Frame, vc.View, true);
+            CoreGraphics.CGRect? rect = null;
+            if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
+            {
+                rect = new CoreGraphics.CGRect(new CoreGraphics.CGPoint(vc.View.Bounds.Width / 2, vc.View.Bounds.Height), CoreGraphics.CGRect.Empty.Size);
+            }
+            else
+            {
+                rect = vc.View.Bounds;
+            }
+
+            documentController.PresentOpenInMenu(rect.Value, vc.View, true);
+
             return Task.CompletedTask;
         }
 #else


### PR DESCRIPTION
### Description of Change ###

On phones we need use the bounds and on iPad we need to specify. Usually this is based on a button or toolbar item, but we just put it in the bottom center, which looks pretty good. 

### Bugs Fixed ###

- Related to issue #833 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Now work on iPad :)

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
