### PR TITLE
Xamarin.Android.Support.Core.Utils isn't needed for Monodroid90 and up

### DIFF
--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -73,7 +73,7 @@
     <AndroidResource Include="Resources\xml\*.xml" />
     <PackageReference Include="Xamarin.Android.Support.Compat" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="28.0.0.1" />
+    <PackageReference Condition="$(TargetFrameworkVersion.TrimStart('vV')) &lt; 9.0" Include="Xamarin.Android.Support.Core.Utils" Version="28.0.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
     <Compile Include="**\*.ios.cs" />


### PR DESCRIPTION
### Description of Change ###

The only class that is part of *Xamarin.Android.Support.Core.Utils* in Monodroid90 is an obsolete BroadcastReceiver which Essentials doesn't use

The types used by early Monodroid versions looks to have been moved to the Compat library

This will simplify the transient dependencies for MonoAndroid 9.0 and up


### Behavioral Changes ###

This shouldn't change anything
### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
