### PR TITLE
[Tizen] Removed non-mandatory reference

### DIFF
--- a/Samples/Samples.Tizen/Program.cs
+++ b/Samples/Samples.Tizen/Program.cs
@@ -16,8 +16,6 @@ namespace Samples.Tizen
         {
             var app = new Program();
             Forms.Init(app);
-            if (Device.Idiom == TargetIdiom.Watch)
-                global::Tizen.Wearable.CircularUI.Forms.Renderer.FormsCircularUI.Init();
             Xamarin.Essentials.Platform.MapServiceToken = "MAP_SERVICE_KEY";
             app.Run(args);
         }

--- a/Samples/Samples.Tizen/Samples.Tizen.csproj
+++ b/Samples/Samples.Tizen/Samples.Tizen.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.Wearable.CircularUI" Version="1.3.0-pre1-00043" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0">
       <ExcludeAssets>Runtime</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
Removed a reference on Samples.Tizen project.
The Tizen.Wearable.CircularUI pacakge was used for the appearance of components on the Tizen watch device, it is not a mandatory package.
Besides it may causes a conflict with the Xamarin.Forms package depending on the version.
So this Tizen.Wearable.CircularUI pacakge reference should be removed.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
