### PR TITLE
URL Encode Phone Number on Android intent (Fixes #912)

### DIFF
--- a/Xamarin.Essentials/PhoneDialer/PhoneDialer.android.cs
+++ b/Xamarin.Essentials/PhoneDialer/PhoneDialer.android.cs
@@ -2,6 +2,7 @@
 using Android.Content;
 using Android.OS;
 using Android.Telephony;
+using Java.Net;
 using Java.Util;
 using Uri = Android.Net.Uri;
 
@@ -39,6 +40,8 @@ namespace Xamarin.Essentials
 #pragma warning disable CS0618
                 phoneNumber = PhoneNumberUtils.FormatNumber(number);
 #pragma warning restore CS0618
+
+            phoneNumber = URLEncoder.Encode(phoneNumber, "UTF-8");
 
             var dialIntent = ResolveDialIntent(phoneNumber)
                 .SetFlags(ActivityFlags.ClearTop)


### PR DESCRIPTION
URL encoding the phone number to ensure that extension dialing works fine.

### Description of Change ###

Added code to encode the phone number, before being passed to the dialer. This makes it possible for the dialer to understand the pause needed for dialing an extension e.g. "+1 555 010 9999, 222" where "222" is an extension number

### Bugs Fixed ###

- Related to issue #912

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests
- [ ] Has samples
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation

Existing tests, documentation and samples do not need to change.