### PR TITLE
build.ps1: fix build with GithubActionsCI

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -13,7 +13,7 @@ if ($IsMacOS) {
 } else {
     $vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
     $msbuild = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
-    $msbuild = join-path $msbuild 'MSBuild\15.0\Bin\MSBuild.exe'
+    $msbuild = join-path $msbuild 'MSBuild\Current\Bin\MSBuild.exe'
     $cibuild = "true"
 }
 


### PR DESCRIPTION
This error was happening when trying to build XamarinEssentials
under a GithubActions VM:

```
Run .\build.ps1
Using MSBuild from: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\15.0\Bin\MSBuild.exe
& : The term 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\15.0\Bin\MSBuild.exe' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At D:\a\DotNetEssentials\DotNetEssentials\build.ps1:27 char:3
+ & $msbuild "./Xamarin.Essentials.sln" /restore /t:Build /p:Configurat ...
+   ~~~~~~~~
+ CategoryInfo          : ObjectNotFound: (C:\Program Files (x\u20265.0\Bin\MSBuild.exe:String) [], ParentContainsErrorRecordException
+ FullyQualifiedErrorId : CommandNotFoundException
```

For reference, see the build error (by clicking on the commit with the red X) and fix-commit here:
https://github.com/knocte/Essentials/commits/master