### PR TITLE
Clarify ContentType API

### DIFF
--- a/docs/en/Xamarin.Essentials/EmailAttachment.xml
+++ b/docs/en/Xamarin.Essentials/EmailAttachment.xml
@@ -67,8 +67,8 @@
       </Parameters>
       <Docs>
         <param name="fullPath">Full path and filename to file.</param>
-        <param name="contentType"></param>
-        <summary>Explicit content type of file.</summary>
+        <param name="contentType">Content type (MIME type) of the file (eg: `image/png`).</param>
+        <summary>Explicit content type (MIME type) of file.</summary>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/docs/en/Xamarin.Essentials/FileBase.xml
+++ b/docs/en/Xamarin.Essentials/FileBase.xml
@@ -48,7 +48,7 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets the file's content type.</summary>
+        <summary>Gets or sets the file's content type as a MIME type (eg: `image/png`).</summary>
         <value></value>
         <remarks></remarks>
       </Docs>

--- a/docs/en/Xamarin.Essentials/ReadOnlyFile.xml
+++ b/docs/en/Xamarin.Essentials/ReadOnlyFile.xml
@@ -72,8 +72,8 @@
       </Parameters>
       <Docs>
         <param name="fullPath">Full file path.</param>
-        <param name="contentType">Content type of the file.</param>
-        <summary>Construct a file taking in file path and content type.</summary>
+        <param name="contentType">Content type (MIME type) of the file (eg: `image/png`).</param>
+        <summary>Construct a file taking in file path and content type (MIME type).</summary>
         <remarks>
           <para />
         </remarks>


### PR DESCRIPTION
From feedback at https://github.com/MicrosoftDocs/xamarin-docs/issues/2246

Improving the API docs to be more clear that Content Type is MIME type.