### PR TITLE
GH-385 - Add method to get the application window's size

### DIFF
--- a/Xamarin.Essentials/AppInfo/AppInfo.android.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.android.cs
@@ -1,6 +1,10 @@
 ﻿using System.Globalization;
+using Android.App;
 using Android.Content;
 using Android.Content.PM;
+using Android.Util;
+using Android.Views;
+using Java.Interop;
 
 namespace Xamarin.Essentials
 {
@@ -47,6 +51,17 @@ namespace Xamarin.Essentials
             settingsIntent.AddFlags(ActivityFlags.NoHistory);
             settingsIntent.AddFlags(ActivityFlags.ExcludeFromRecents);
             context.StartActivity(settingsIntent);
+        }
+
+        static WindowSize PlatformWindowAppSize()
+        {
+            var context = Platform.GetCurrentActivity(false) ?? Platform.AppContext;
+            var windowManager = context.GetSystemService(Context.WindowService);
+            var windows = windowManager.JavaCast<IWindowManager>();
+            var metrics = new DisplayMetrics();
+            windows.DefaultDisplay.GetMetrics(metrics);
+
+            return new WindowSize(metrics.WidthPixels, metrics.HeightPixels);
         }
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.ios.tvos.watchos.cs
@@ -23,5 +23,17 @@ namespace Xamarin.Essentials
         static void PlatformShowSettingsUI() =>
             throw new FeatureNotSupportedException();
 #endif
+
+        static WindowSize PlatformWindowAppSize()
+        {
+#if __IOS__ || __TVOS__
+            var currentView = Platform.GetCurrentViewController().View.Window?.Frame;
+
+            if (currentView == null)
+                return default;
+
+            return new WindowSize(currentView.Value.Width, currentView.Value.Height);
+#endif
+        }
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.netstandard.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.netstandard.cs
@@ -11,5 +11,7 @@
         static string PlatformGetBuild() => throw ExceptionUtils.NotSupportedOrImplementedException;
 
         static void PlatformShowSettingsUI() => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+        static WindowSize PlatformWindowAppSize() => throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.shared.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.shared.cs
@@ -15,5 +15,7 @@ namespace Xamarin.Essentials
         public static string BuildString => PlatformGetBuild();
 
         public static void ShowSettingsUI() => PlatformShowSettingsUI();
+
+        public static WindowSize WindowAppSize() => PlatformWindowAppSize();
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.tizen.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.tizen.cs
@@ -22,5 +22,7 @@ namespace Xamarin.Essentials
             Permissions.EnsureDeclared(PermissionType.LaunchApp);
             AppControl.SendLaunchRequest(new AppControl() { Operation = AppControlOperations.Setting });
         }
+
+        static WindowSize PlatformWindowAppSize() => throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.uwp.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.uwp.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using Windows.ApplicationModel;
+using Windows.UI.ViewManagement;
 
 namespace Xamarin.Essentials
 {
@@ -20,5 +21,12 @@ namespace Xamarin.Essentials
 
         static void PlatformShowSettingsUI() =>
             Windows.System.Launcher.LaunchUriAsync(new System.Uri("ms-settings:appsfeatures-app")).WatchForError();
+
+        static WindowSize PlatformWindowAppSize()
+        {
+            var view = ApplicationView.GetForCurrentView();
+
+            return new WindowSize(view.VisibleBounds.Width, view.VisibleBounds.Height);
+        }
     }
 }

--- a/Xamarin.Essentials/Types/WindowSize.shared.cs
+++ b/Xamarin.Essentials/Types/WindowSize.shared.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace Xamarin.Essentials
+{
+    public readonly struct WindowSize : IEquatable<WindowSize>
+    {
+        public WindowSize(double width, double height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        public double Width { get; }
+
+        public double Height { get; }
+
+        public bool Equals(WindowSize other) =>
+            Width.Equals(other.Width) && Height.Equals(other.Height);
+
+        public override bool Equals(object obj) =>
+            (obj is WindowSize windowSize) && Equals(windowSize);
+
+        public override int GetHashCode() =>
+            (Width, Height).GetHashCode();
+
+        public override string ToString() =>
+            $"{nameof(Width)} : {Width} \n {nameof(Height)}:{Height}";
+
+        public static bool operator ==(WindowSize left, WindowSize right) =>
+            Equals(left, right);
+
+        public static bool operator !=(WindowSize left, WindowSize right) =>
+            !Equals(left, right);
+    }
+}


### PR DESCRIPTION

### Description of Change ###

Created a new method inside of `AppInfo` that returns the `Width` and `Height` from the current application window's size.

### Bugs Fixed ###

- Related to issue #385 

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `WindowSize PlatformWindowAppSize()`

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
