### PR TITLE
Add Share Source Position

### DIFF
--- a/Samples/Samples/ViewModel/ShareViewModel.cs
+++ b/Samples/Samples/ViewModel/ShareViewModel.cs
@@ -104,7 +104,10 @@ namespace Samples.ViewModel
                 await Share.RequestAsync(new ShareFileRequest
                 {
                     Title = Title,
-                    File = new ShareFile(file)
+                    File = new ShareFile(file),
+                    SourceScreenPosition = Device.RuntimePlatform == Device.iOS && Device.Idiom == TargetIdiom.Tablet
+                                            ? new System.Drawing.Rectangle(0, 20, 0, 0)
+                                            : System.Drawing.Rectangle.Empty
                 });
             }
         }

--- a/Samples/Samples/ViewModel/ShareViewModel.cs
+++ b/Samples/Samples/ViewModel/ShareViewModel.cs
@@ -105,7 +105,7 @@ namespace Samples.ViewModel
                 {
                     Title = Title,
                     File = new ShareFile(file),
-                    SourceScreenPosition = Device.RuntimePlatform == Device.iOS && Device.Idiom == TargetIdiom.Tablet
+                    PresentationSourceBounds = Device.RuntimePlatform == Device.iOS && Device.Idiom == TargetIdiom.Tablet
                                             ? new System.Drawing.Rectangle(0, 20, 0, 0)
                                             : System.Drawing.Rectangle.Empty
                 });

--- a/Xamarin.Essentials/Share/Share.ios.cs
+++ b/Xamarin.Essentials/Share/Share.ios.cs
@@ -29,8 +29,8 @@ namespace Xamarin.Essentials
             {
                 activityController.PopoverPresentationController.SourceView = vc.View;
 
-                if (request.SourceScreenPosition != Rectangle.Empty)
-                    activityController.PopoverPresentationController.SourceRect = request.SourceScreenPosition.ToPlatformRectangle();
+                if (request.PresentationSourceBounds != Rectangle.Empty)
+                    activityController.PopoverPresentationController.SourceRect = request.PresentationSourceBounds.ToPlatformRectangle();
             }
 
             return vc.PresentViewControllerAsync(activityController, true);
@@ -54,8 +54,8 @@ namespace Xamarin.Essentials
             {
                 activityController.PopoverPresentationController.SourceView = vc.View;
 
-                if (request.SourceScreenPosition != Rectangle.Empty)
-                    activityController.PopoverPresentationController.SourceRect = request.SourceScreenPosition.ToPlatformRectangle();
+                if (request.PresentationSourceBounds != Rectangle.Empty)
+                    activityController.PopoverPresentationController.SourceRect = request.PresentationSourceBounds.ToPlatformRectangle();
             }
 
             return vc.PresentViewControllerAsync(activityController, true);

--- a/Xamarin.Essentials/Share/Share.ios.cs
+++ b/Xamarin.Essentials/Share/Share.ios.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Drawing;
 using System.Threading.Tasks;
 using Foundation;
 using UIKit;
@@ -27,6 +28,9 @@ namespace Xamarin.Essentials
             if (activityController.PopoverPresentationController != null)
             {
                 activityController.PopoverPresentationController.SourceView = vc.View;
+
+                if (request.SourceScreenPosition != Rectangle.Empty)
+                    activityController.PopoverPresentationController.SourceRect = request.SourceScreenPosition.ToPlatformRectangle();
             }
 
             return vc.PresentViewControllerAsync(activityController, true);
@@ -49,6 +53,9 @@ namespace Xamarin.Essentials
             if (activityController.PopoverPresentationController != null)
             {
                 activityController.PopoverPresentationController.SourceView = vc.View;
+
+                if (request.SourceScreenPosition != Rectangle.Empty)
+                    activityController.PopoverPresentationController.SourceRect = request.SourceScreenPosition.ToPlatformRectangle();
             }
 
             return vc.PresentViewControllerAsync(activityController, true);

--- a/Xamarin.Essentials/Share/Share.shared.cs
+++ b/Xamarin.Essentials/Share/Share.shared.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Essentials
         public string Title { get; set; }
 
 #if !NETSTANDARD1_0
-        public Rectangle SourceScreenPosition { get; set; } = Rectangle.Empty;
+        public Rectangle PresentationSourceBounds { get; set; } = Rectangle.Empty;
 #endif
     }
 

--- a/Xamarin.Essentials/Share/Share.shared.cs
+++ b/Xamarin.Essentials/Share/Share.shared.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Essentials
         }
     }
 
-    public class ShareRequestBase
+    public abstract class ShareRequestBase
     {
         public string Title { get; set; }
 

--- a/Xamarin.Essentials/Share/Share.shared.cs
+++ b/Xamarin.Essentials/Share/Share.shared.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+#if !NETSTANDARD1_0
+using System.Drawing;
+#endif
 
 namespace Xamarin.Essentials
 {
@@ -21,7 +24,16 @@ namespace Xamarin.Essentials
         }
     }
 
-    public class ShareTextRequest
+    public class ShareBase
+    {
+        public string Title { get; set; }
+
+#if !NETSTANDARD1_0
+        public Rectangle SourceScreenPosition { get; set; } = Rectangle.Empty;
+#endif
+    }
+
+    public class ShareTextRequest : ShareBase
     {
         public ShareTextRequest()
         {
@@ -32,8 +44,6 @@ namespace Xamarin.Essentials
         public ShareTextRequest(string text, string title)
             : this(text) => Title = title;
 
-        public string Title { get; set; }
-
         public string Subject { get; set; }
 
         public string Text { get; set; }
@@ -41,7 +51,7 @@ namespace Xamarin.Essentials
         public string Uri { get; set; }
     }
 
-    public class ShareFileRequest
+    public class ShareFileRequest : ShareBase
     {
         public ShareFileRequest()
         {
@@ -68,8 +78,6 @@ namespace Xamarin.Essentials
         {
             File = new ShareFile(file);
         }
-
-        public string Title { get; set; }
 
         public ShareFile File { get; set; }
     }

--- a/Xamarin.Essentials/Share/Share.shared.cs
+++ b/Xamarin.Essentials/Share/Share.shared.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Essentials
         }
     }
 
-    public class ShareBase
+    public class ShareRequestBase
     {
         public string Title { get; set; }
 
@@ -33,7 +33,7 @@ namespace Xamarin.Essentials
 #endif
     }
 
-    public class ShareTextRequest : ShareBase
+    public class ShareTextRequest : ShareRequestBase
     {
         public ShareTextRequest()
         {
@@ -51,7 +51,7 @@ namespace Xamarin.Essentials
         public string Uri { get; set; }
     }
 
-    public class ShareFileRequest : ShareBase
+    public class ShareFileRequest : ShareRequestBase
     {
         public ShareFileRequest()
         {

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -632,7 +632,11 @@
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.FileBase)" />
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.ShareFile)" />
       <Member Id="P:Xamarin.Essentials.ShareFileRequest.File" />
-      <Member Id="P:Xamarin.Essentials.ShareFileRequest.Title" />
+    </Type>
+    <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
+      <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor" />
@@ -640,7 +644,6 @@
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Subject" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Text" />
-      <Member Id="P:Xamarin.Essentials.ShareTextRequest.Title" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Uri" />
     </Type>
     <Type Name="Xamarin.Essentials.SizeExtensions" Id="T:Xamarin.Essentials.SizeExtensions">

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -635,7 +635,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
       <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
-      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.PresentationSourceBounds" />
       <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -610,7 +610,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
       <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
-      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.PresentationSourceBounds" />
       <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -607,7 +607,11 @@
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.FileBase)" />
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.ShareFile)" />
       <Member Id="P:Xamarin.Essentials.ShareFileRequest.File" />
-      <Member Id="P:Xamarin.Essentials.ShareFileRequest.Title" />
+    </Type>
+    <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
+      <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor" />
@@ -615,7 +619,6 @@
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Subject" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Text" />
-      <Member Id="P:Xamarin.Essentials.ShareTextRequest.Title" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Uri" />
     </Type>
     <Type Name="Xamarin.Essentials.SizeExtensions" Id="T:Xamarin.Essentials.SizeExtensions">

--- a/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
@@ -609,7 +609,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
       <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
-      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.PresentationSourceBounds" />
       <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">

--- a/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
@@ -606,7 +606,11 @@
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.FileBase)" />
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.ShareFile)" />
       <Member Id="P:Xamarin.Essentials.ShareFileRequest.File" />
-      <Member Id="P:Xamarin.Essentials.ShareFileRequest.Title" />
+    </Type>
+    <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
+      <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor" />
@@ -614,7 +618,6 @@
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Subject" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Text" />
-      <Member Id="P:Xamarin.Essentials.ShareTextRequest.Title" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Uri" />
     </Type>
     <Type Name="Xamarin.Essentials.Sms" Id="T:Xamarin.Essentials.Sms">

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -607,7 +607,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
       <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
-      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.PresentationSourceBounds" />
       <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -604,7 +604,11 @@
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.FileBase)" />
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.ShareFile)" />
       <Member Id="P:Xamarin.Essentials.ShareFileRequest.File" />
-      <Member Id="P:Xamarin.Essentials.ShareFileRequest.Title" />
+    </Type>
+    <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
+      <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor" />
@@ -612,7 +616,6 @@
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Subject" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Text" />
-      <Member Id="P:Xamarin.Essentials.ShareTextRequest.Title" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Uri" />
     </Type>
     <Type Name="Xamarin.Essentials.SizeExtensions" Id="T:Xamarin.Essentials.SizeExtensions">

--- a/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
@@ -607,7 +607,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
       <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
-      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.PresentationSourceBounds" />
       <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">

--- a/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
@@ -604,7 +604,11 @@
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.FileBase)" />
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.ShareFile)" />
       <Member Id="P:Xamarin.Essentials.ShareFileRequest.File" />
-      <Member Id="P:Xamarin.Essentials.ShareFileRequest.Title" />
+    </Type>
+    <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
+      <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor" />
@@ -612,7 +616,6 @@
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Subject" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Text" />
-      <Member Id="P:Xamarin.Essentials.ShareTextRequest.Title" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Uri" />
     </Type>
     <Type Name="Xamarin.Essentials.Sms" Id="T:Xamarin.Essentials.Sms">

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -592,7 +592,11 @@
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.FileBase)" />
       <Member Id="M:Xamarin.Essentials.ShareFileRequest.#ctor(Xamarin.Essentials.ShareFile)" />
       <Member Id="P:Xamarin.Essentials.ShareFileRequest.File" />
-      <Member Id="P:Xamarin.Essentials.ShareFileRequest.Title" />
+    </Type>
+    <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
+      <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor" />
@@ -600,7 +604,6 @@
       <Member Id="M:Xamarin.Essentials.ShareTextRequest.#ctor(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Subject" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Text" />
-      <Member Id="P:Xamarin.Essentials.ShareTextRequest.Title" />
       <Member Id="P:Xamarin.Essentials.ShareTextRequest.Uri" />
     </Type>
     <Type Name="Xamarin.Essentials.Sms" Id="T:Xamarin.Essentials.Sms">

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -595,7 +595,7 @@
     </Type>
     <Type Name="Xamarin.Essentials.ShareRequestBase" Id="T:Xamarin.Essentials.ShareRequestBase">
       <Member Id="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
-      <Member Id="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <Member Id="P:Xamarin.Essentials.ShareRequestBase.PresentationSourceBounds" />
       <Member Id="P:Xamarin.Essentials.ShareRequestBase.Title" />
     </Type>
     <Type Name="Xamarin.Essentials.ShareTextRequest" Id="T:Xamarin.Essentials.ShareTextRequest">

--- a/docs/en/Xamarin.Essentials/ShareFileRequest.xml
+++ b/docs/en/Xamarin.Essentials/ShareFileRequest.xml
@@ -1,6 +1,6 @@
 <Type Name="ShareFileRequest" FullName="Xamarin.Essentials.ShareFileRequest">
-  <TypeSignature Language="C#" Value="public class ShareFileRequest" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit ShareFileRequest extends System.Object" />
+  <TypeSignature Language="C#" Value="public class ShareFileRequest : Xamarin.Essentials.ShareRequestBase" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit ShareFileRequest extends Xamarin.Essentials.ShareRequestBase" />
   <TypeSignature Language="DocId" Value="T:Xamarin.Essentials.ShareFileRequest" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Essentials</AssemblyName>
@@ -8,6 +8,7 @@
   </AssemblyInfo>
   <Base>
     <BaseTypeName>System.Object</BaseTypeName>
+    <BaseTypeName FrameworkAlternate="xamarin-essentials">Xamarin.Essentials.ShareRequestBase</BaseTypeName>
   </Base>
   <Interfaces />
   <Docs>
@@ -124,28 +125,6 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the file to share.</summary>
-        <value>
-          <para />
-        </value>
-        <remarks>
-          <para />
-        </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Title">
-      <MemberSignature Language="C#" Value="public string Title { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance string Title" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.ShareFileRequest.Title" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.String</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Gets or sets the title to use on the share user interface</summary>
         <value>
           <para />
         </value>

--- a/docs/en/Xamarin.Essentials/ShareFileRequest.xml
+++ b/docs/en/Xamarin.Essentials/ShareFileRequest.xml
@@ -7,8 +7,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Base>
-    <BaseTypeName>System.Object</BaseTypeName>
-    <BaseTypeName FrameworkAlternate="xamarin-essentials">Xamarin.Essentials.ShareRequestBase</BaseTypeName>
+    <BaseTypeName>Xamarin.Essentials.ShareRequestBase</BaseTypeName>
   </Base>
   <Interfaces />
   <Docs>

--- a/docs/en/Xamarin.Essentials/ShareRequestBase.xml
+++ b/docs/en/Xamarin.Essentials/ShareRequestBase.xml
@@ -30,10 +30,10 @@
         <remarks></remarks>
       </Docs>
     </Member>
-    <Member MemberName="SourceScreenPosition">
+    <Member MemberName="PresentationSourceBounds">
       <MemberSignature Language="C#" Value="public System.Drawing.Rectangle PresentationSourceBounds { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance valuetype System.Drawing.Rectangle SourceScreenPosition" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype System.Drawing.Rectangle PresentationSourceBounds" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.ShareRequestBase.PresentationSourceBounds" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
         <AssemblyName>Xamarin.Essentials</AssemblyName>

--- a/docs/en/Xamarin.Essentials/ShareRequestBase.xml
+++ b/docs/en/Xamarin.Essentials/ShareRequestBase.xml
@@ -1,0 +1,70 @@
+<Type Name="ShareRequestBase" FullName="Xamarin.Essentials.ShareRequestBase">
+  <TypeSignature Language="C#" Value="public class ShareRequestBase" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit ShareRequestBase extends System.Object" />
+  <TypeSignature Language="DocId" Value="T:Xamarin.Essentials.ShareRequestBase" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Essentials</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary></summary>
+    <remarks></remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public ShareRequestBase ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.ShareRequestBase.#ctor" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary></summary>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SourceScreenPosition">
+      <MemberSignature Language="C#" Value="public System.Drawing.Rectangle SourceScreenPosition { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype System.Drawing.Rectangle SourceScreenPosition" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Drawing.Rectangle</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets the source rectangle to display the Share UI from.</summary>
+        <value></value>
+        <remarks>This is only used on iOS currently.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Title">
+      <MemberSignature Language="C#" Value="public string Title { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string Title" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.ShareRequestBase.Title" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets the title to use on the share user interface</summary>
+        <value>The title to be displayed.</value>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/en/Xamarin.Essentials/ShareRequestBase.xml
+++ b/docs/en/Xamarin.Essentials/ShareRequestBase.xml
@@ -31,7 +31,7 @@
       </Docs>
     </Member>
     <Member MemberName="SourceScreenPosition">
-      <MemberSignature Language="C#" Value="public System.Drawing.Rectangle SourceScreenPosition { get; set; }" />
+      <MemberSignature Language="C#" Value="public System.Drawing.Rectangle PresentationSourceBounds { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance valuetype System.Drawing.Rectangle SourceScreenPosition" />
       <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.ShareRequestBase.SourceScreenPosition" />
       <MemberType>Property</MemberType>

--- a/docs/en/Xamarin.Essentials/ShareTextRequest.xml
+++ b/docs/en/Xamarin.Essentials/ShareTextRequest.xml
@@ -1,6 +1,6 @@
 <Type Name="ShareTextRequest" FullName="Xamarin.Essentials.ShareTextRequest">
-  <TypeSignature Language="C#" Value="public class ShareTextRequest" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit ShareTextRequest extends System.Object" />
+  <TypeSignature Language="C#" Value="public class ShareTextRequest : Xamarin.Essentials.ShareRequestBase" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit ShareTextRequest extends Xamarin.Essentials.ShareRequestBase" />
   <TypeSignature Language="DocId" Value="T:Xamarin.Essentials.ShareTextRequest" />
   <AssemblyInfo>
     <AssemblyName>Xamarin.Essentials</AssemblyName>
@@ -8,6 +8,7 @@
   </AssemblyInfo>
   <Base>
     <BaseTypeName>System.Object</BaseTypeName>
+    <BaseTypeName FrameworkAlternate="xamarin-essentials">Xamarin.Essentials.ShareRequestBase</BaseTypeName>
   </Base>
   <Interfaces />
   <Docs>
@@ -109,26 +110,6 @@
       <Docs>
         <summary>Gets or sets the main text or message to share.</summary>
         <value>The main text.</value>
-        <remarks>
-          <para />
-        </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="Title">
-      <MemberSignature Language="C#" Value="public string Title { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance string Title" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.ShareTextRequest.Title" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.String</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Gets or sets the title to use on the share user interface.</summary>
-        <value>The title to display.</value>
         <remarks>
           <para />
         </remarks>

--- a/docs/en/Xamarin.Essentials/ShareTextRequest.xml
+++ b/docs/en/Xamarin.Essentials/ShareTextRequest.xml
@@ -7,8 +7,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Base>
-    <BaseTypeName>System.Object</BaseTypeName>
-    <BaseTypeName FrameworkAlternate="xamarin-essentials">Xamarin.Essentials.ShareRequestBase</BaseTypeName>
+    <BaseTypeName>Xamarin.Essentials.ShareRequestBase</BaseTypeName>
   </Base>
   <Interfaces />
   <Docs>

--- a/docs/en/index.xml
+++ b/docs/en/index.xml
@@ -93,7 +93,7 @@
           <AttributeName>System.Runtime.Versioning.TargetFramework("MonoAndroid,Version=v9.0", FrameworkDisplayName="Xamarin.Android v9.0 Support")</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Reflection.AssemblyInformationalVersion("1.0.0+93121294be53f4171d1182fb463e3232d6d760c6")</AttributeName>
+          <AttributeName>System.Reflection.AssemblyInformationalVersion("1.0.0+ff9fe28695639322b3f845ff4ad7be931189987b")</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
@@ -190,6 +190,7 @@
       <Type Name="Share" Kind="Class" />
       <Type Name="ShareFile" Kind="Class" />
       <Type Name="ShareFileRequest" Kind="Class" />
+      <Type Name="ShareRequestBase" Kind="Class" />
       <Type Name="ShareTextRequest" Kind="Class" />
       <Type Name="SizeExtensions" Kind="Class" />
       <Type Name="Sms" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###

Adds the ability to specify a Source Rectangle for Share*Requests.  This is really only used for now on iOS where on some iOS 13 versions it seems the `sourceRect` needs to be set in order for the dialog to display.

This should address #980 #979 #944 by allowing users to set their own source position.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
