### PR TITLE
Calendar Read-Only API

### DIFF
--- a/DeviceTests/DeviceTests.Android/Properties/AndroidManifest.xml
+++ b/DeviceTests/DeviceTests.Android/Properties/AndroidManifest.xml
@@ -5,10 +5,11 @@
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.BATTERY_STATS" />
+  <uses-permission android:name="android.permission.READ_CALENDAR" />
 	<uses-permission android:name="android.permission.CAMERA" />
-	<uses-permission android:name="android.permission.FLASHLIGHT" />
+  <uses-permission android:name="android.permission.FLASHLIGHT" />
 	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.VIBRATE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.VIBRATE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<application android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/MainTheme"></application>
 </manifest>

--- a/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Essentials;
+using Xunit;
+
+namespace DeviceTests
+{
+    // TEST NOTES:
+    //   - a human needs to accept permissions on all systems
+    //  If no calendars are set up none will be returned at this stage
+    //  Same goes for events
+    public class Calendar_Tests
+    {
+        [Fact]
+        [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
+        public Task Get_Calendar_List()
+        {
+            return Utils.OnMainThread(async () =>
+            {
+                var calendarList = await Calendar.GetCalendarsAsync();
+                Assert.NotNull(calendarList);
+            });
+        }
+
+        [Fact]
+        [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
+        public Task Get_Events_List()
+        {
+            return Utils.OnMainThread(async () =>
+            {
+                var eventList = await Calendar.GetEventsAsync();
+                Assert.NotNull(eventList);
+            });
+        }
+
+        [Theory]
+        [InlineData("ThisIsAFakeId")]
+        [InlineData("-1")]
+        [InlineData("")]
+        [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
+        public Task Get_Event_By_Bad_Id(string calendarId)
+        {
+            return Utils.OnMainThread(async () =>
+            {
+#if __IOS__
+                await Assert.ThrowsAsync<NullReferenceException>(() => Calendar.GetEventByIdAsync(calendarId));
+#else
+                await Assert.ThrowsAsync<ArgumentException>(() => Calendar.GetEventByIdAsync(calendarId));
+#endif
+            });
+        }
+    }
+}

--- a/DeviceTests/DeviceTests.UWP/Package.appxmanifest
+++ b/DeviceTests/DeviceTests.UWP/Package.appxmanifest
@@ -33,6 +33,7 @@
     <Capability Name="internetClient" />
     <Capability Name="internetClientServer" />
     <Capability Name="privateNetworkClientServer" />
+    <uap:Capability Name="appointments"/>
     <DeviceCapability Name="location" />
   </Capabilities>
 </Package>

--- a/DeviceTests/DeviceTests.iOS/Info.plist
+++ b/DeviceTests/DeviceTests.iOS/Info.plist
@@ -10,7 +10,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+    <string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
@@ -55,5 +55,7 @@
 	<string>1.0.1.0</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Access to your location is required for cool things to happen!</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Access to view and create calendar events</string>
 </dict>
 </plist>

--- a/Samples/Samples.Android/Properties/AndroidManifest.xml
+++ b/Samples/Samples.Android/Properties/AndroidManifest.xml
@@ -8,6 +8,7 @@
 	<uses-permission android:name="android.permission.CAMERA" />
 	<uses-permission android:name="android.permission.FLASHLIGHT" />
 	<uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.READ_CALENDAR" />
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-feature android:name="android.hardware.location" android:required="false" />
 	<uses-feature android:name="android.hardware.location.gps" android:required="false" />

--- a/Samples/Samples.UWP/Package.appxmanifest
+++ b/Samples/Samples.UWP/Package.appxmanifest
@@ -24,6 +24,7 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <uap:Capability Name="appointments"/>
     <DeviceCapability Name="location" />
   </Capabilities>
 </Package>

--- a/Samples/Samples.iOS/Info.plist
+++ b/Samples/Samples.iOS/Info.plist
@@ -55,6 +55,8 @@
 	<string>1.0</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Access to your location is required for cool things to happen!</string>
+  <key>NSCalendarsUsageDescription</key>
+  <string>Access to view and create calendar events</string>
   <key>CFBundleURLTypes</key>
   <array>
     <dict>

--- a/Samples/Samples.iOS/Samples.iOS.csproj
+++ b/Samples/Samples.iOS/Samples.iOS.csproj
@@ -91,7 +91,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GlobalSuppressions.cs" />
+	<Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
     <None Include="Entitlements.plist" />

--- a/Samples/Samples/App.xaml
+++ b/Samples/Samples/App.xaml
@@ -5,6 +5,7 @@
              x:Class="Samples.App">
     <Application.Resources>
         <ResourceDictionary>
+            <x:String x:Key="DateDisplayFormatter">{0:dd/MM/yy hh:mm tt}</x:String>
             <converters:NegativeConverter x:Key="NegativeConverter" />
             <Style TargetType="Page" ApplyToDerivedTypes="True">
                 <Setter Property="Visual" Value="Material" />

--- a/Samples/Samples/Behaviors/BehaviorBase.cs
+++ b/Samples/Samples/Behaviors/BehaviorBase.cs
@@ -1,0 +1,45 @@
+﻿// This code is a slightly modified version of the Xamarin-Forms-sample/Behaviors code provided here:
+// https://github.com/xamarin/xamarin-forms-samples/tree/master/Behaviors/EventToCommandBehavior/EventToCommandBehavior/Behaviors
+
+using System;
+using Xamarin.Forms;
+
+namespace Samples.Behaviors
+{
+    public class BehaviorBase<T> : Behavior<T>
+        where T : BindableObject
+    {
+        public T AssociatedObject { get; private set; }
+
+        protected override void OnAttachedTo(T bindable)
+        {
+            base.OnAttachedTo(bindable);
+            AssociatedObject = bindable;
+
+            if (bindable.BindingContext != null)
+            {
+                BindingContext = bindable.BindingContext;
+            }
+
+            bindable.BindingContextChanged += OnBindingContextChanged;
+        }
+
+        protected override void OnDetachingFrom(T bindable)
+        {
+            base.OnDetachingFrom(bindable);
+            bindable.BindingContextChanged -= OnBindingContextChanged;
+            AssociatedObject = null;
+        }
+
+        void OnBindingContextChanged(object sender, EventArgs e)
+        {
+            OnBindingContextChanged();
+        }
+
+        protected override void OnBindingContextChanged()
+        {
+            base.OnBindingContextChanged();
+            BindingContext = AssociatedObject.BindingContext;
+        }
+    }
+}

--- a/Samples/Samples/Behaviors/EventToCommandBehaviour.cs
+++ b/Samples/Samples/Behaviors/EventToCommandBehaviour.cs
@@ -1,0 +1,135 @@
+﻿// This code is a slightly modified version of the Xamarin-Forms-sample/Behaviors code provided here:
+// https://github.com/xamarin/xamarin-forms-samples/tree/master/Behaviors/EventToCommandBehavior/EventToCommandBehavior/Behaviors
+
+using System;
+using System.Reflection;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace Samples.Behaviors
+{
+    public class EventToCommandBehavior : BehaviorBase<Xamarin.Forms.View>
+    {
+        Delegate eventHandler;
+
+        public static readonly BindableProperty EventNameProperty = BindableProperty.Create(nameof(EventName), typeof(string), typeof(EventToCommandBehavior), null, propertyChanged: OnEventNameChanged);
+        public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(EventToCommandBehavior), null);
+        public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(EventToCommandBehavior), null);
+        public static readonly BindableProperty InputConverterProperty = BindableProperty.Create(nameof(Converter), typeof(IValueConverter), typeof(EventToCommandBehavior), null);
+
+        static void OnEventNameChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var behavior = (EventToCommandBehavior)bindable;
+            if (behavior.AssociatedObject == null)
+            {
+                return;
+            }
+
+            var oldEventName = (string)oldValue;
+            var newEventName = (string)newValue;
+
+            behavior.DeregisterEvent(oldEventName);
+            behavior.RegisterEvent(newEventName);
+        }
+
+        public string EventName
+        {
+            get => (string)GetValue(EventNameProperty);
+            set => SetValue(EventNameProperty, value);
+        }
+
+        public ICommand Command
+        {
+            get => (ICommand)GetValue(CommandProperty);
+            set => SetValue(CommandProperty, value);
+        }
+
+        public object CommandParameter
+        {
+            get => GetValue(CommandParameterProperty);
+            set => SetValue(CommandParameterProperty, value);
+        }
+
+        public IValueConverter Converter
+        {
+            get => (IValueConverter)GetValue(InputConverterProperty);
+            set => SetValue(InputConverterProperty, value);
+        }
+
+        protected override void OnAttachedTo(Xamarin.Forms.View bindable)
+        {
+            base.OnAttachedTo(bindable);
+            RegisterEvent(EventName);
+        }
+
+        protected override void OnDetachingFrom(Xamarin.Forms.View bindable)
+        {
+            DeregisterEvent(EventName);
+            base.OnDetachingFrom(bindable);
+        }
+
+        void RegisterEvent(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return;
+            }
+
+            var eventInfo = AssociatedObject.GetType().GetRuntimeEvent(name);
+            if (eventInfo == null)
+            {
+                throw new ArgumentException(string.Format("EventToCommandBehavior: Can't register the '{0}' event.", EventName));
+            }
+            var methodInfo = typeof(EventToCommandBehavior).GetTypeInfo().GetDeclaredMethod("OnEvent");
+            eventHandler = methodInfo.CreateDelegate(eventInfo.EventHandlerType, this);
+            eventInfo.AddEventHandler(AssociatedObject, eventHandler);
+        }
+
+        void DeregisterEvent(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return;
+            }
+
+            if (eventHandler == null)
+            {
+                return;
+            }
+            var eventInfo = AssociatedObject.GetType().GetRuntimeEvent(name);
+            if (eventInfo == null)
+            {
+                throw new ArgumentException(string.Format("EventToCommandBehavior: Can't de-register the '{0}' event.", EventName));
+            }
+            eventInfo.RemoveEventHandler(AssociatedObject, eventHandler);
+            eventHandler = null;
+        }
+
+        void OnEvent(object sender, object eventArgs)
+        {
+            if (Command == null)
+            {
+                return;
+            }
+
+            object resolvedParameter;
+            if (CommandParameter != null)
+            {
+                resolvedParameter = CommandParameter;
+            }
+            else if (Converter != null)
+            {
+                resolvedParameter = Converter.Convert(eventArgs, typeof(object), null, null);
+            }
+            else
+            {
+                resolvedParameter = eventArgs;
+            }
+
+            if (Command.CanExecute(resolvedParameter))
+            {
+                Command.Execute(resolvedParameter);
+            }
+        }
+    }
+}

--- a/Samples/Samples/Converters/CheckBoxEventArgsConverter.cs
+++ b/Samples/Samples/Converters/CheckBoxEventArgsConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms;
+
+namespace Samples.Converters
+{
+    public class CheckBoxEventArgsConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var eventArgs = value as CheckedChangedEventArgs;
+
+            if (eventArgs == null)
+                return value;
+
+            return eventArgs.Value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}

--- a/Samples/Samples/Converters/DateSelectedEventArgsConverter.cs
+++ b/Samples/Samples/Converters/DateSelectedEventArgsConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms;
+
+namespace Samples.Converters
+{
+    public class DateSelectedEventArgsConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var eventArgs = value as DateChangedEventArgs;
+
+            if (eventArgs == null)
+                return value;
+
+            return eventArgs.NewDate;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}

--- a/Samples/Samples/Converters/TimeSelectedEventArgsConverter.cs
+++ b/Samples/Samples/Converters/TimeSelectedEventArgsConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms;
+
+namespace Samples.Converters
+{
+    public class TimeSelectedEventArgsConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var eventArgs = value as PropertyChangedEventArgs;
+
+            if (eventArgs == null || eventArgs.PropertyName != nameof(TimePicker.Time))
+                return null;
+
+            return eventArgs.PropertyName;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}

--- a/Samples/Samples/Samples.csproj
+++ b/Samples/Samples/Samples.csproj
@@ -23,5 +23,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Xamarin.Essentials\Xamarin.Essentials.csproj" />
   </ItemGroup>
-
+  
 </Project>

--- a/Samples/Samples/View/AppInfoPage.xaml
+++ b/Samples/Samples/View/AppInfoPage.xaml
@@ -25,5 +25,5 @@
             </StackLayout>
         </ScrollView>
     </StackLayout>
-
+	
 </views:BasePage>

--- a/Samples/Samples/View/CalendarEventPage.xaml
+++ b/Samples/Samples/View/CalendarEventPage.xaml
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:BasePage  xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Samples.View"
+             xmlns:viewmodels="clr-namespace:Samples.ViewModel"
+             xmlns:essentials="clr-namespace:Xamarin.Essentials;assembly=Xamarin.Essentials"
+             xmlns:converters="clr-namespace:Samples.Converters;assembly=Samples"
+             x:Class="Samples.View.CalendarEventPage"
+             x:DataType="essentials:DeviceEvent"
+             Title="Event"
+             Padding="20,20,20,20">
+    <views:BasePage.Resources>
+        <ResourceDictionary>
+            <x:String x:Key="DateDisplayFormatter">{0:dd/MM/yy hh:mm tt}</x:String>
+            <x:String x:Key="TimeSpanFormatter">{0:h\:mm}</x:String>
+        </ResourceDictionary>
+    </views:BasePage.Resources>
+    <views:BasePage.Content>
+        <StackLayout>
+            <Label Text="{Binding Title}"
+                   FontSize="34"
+                   TextColor="Black"
+                   HorizontalTextAlignment="Center"/>
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition/>
+              <ColumnDefinition/>
+              <ColumnDefinition Width="Auto"/>
+              <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition/>
+            </Grid.RowDefinitions>
+            <Label Grid.Row="1"
+                   Grid.Column="0"
+                   Text="Location:"/>
+            <Label Grid.Row="1"
+                   Grid.Column="1"
+                   Grid.ColumnSpan="3"
+                   HorizontalTextAlignment="Center"
+                   Text="{Binding Location}"/>
+            <Label Grid.Row="2"
+                   Grid.Column="0"
+                   Text="When:"/>
+            <Label Grid.Column="1"
+                   Grid.Row="2"
+                   Text="{Binding StartDate, StringFormat={StaticResource DateDisplayFormatter}, Mode=OneWay}"
+                   TextColor="Black"
+                   HorizontalTextAlignment="Center"/>
+            <Label Grid.Column="2"
+                   Grid.Row="2"
+                   Text="-"
+                   IsVisible="{Binding AllDay, Converter={StaticResource NegativeConverter}}"/>
+            <Label Grid.Column="3"
+                   Grid.Row="2"
+                   Text="{Binding EndDate, StringFormat={StaticResource DateDisplayFormatter}, Mode=OneWay}"
+                   TextColor="Black"
+                   HorizontalTextAlignment="Center"/>
+          </Grid>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                <Label Text="Duration: "/>
+                <Label Grid.Column="1"  
+                       Text="{Binding Duration, StringFormat={StaticResource TimeSpanFormatter}}"
+                       HorizontalTextAlignment="Center"/>
+            </Grid>
+            
+          <ScrollView>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+              <Grid.RowDefinitions>
+                  <RowDefinition Height="Auto"/>
+                  <RowDefinition/>
+              </Grid.RowDefinitions>
+                <Label Text="Attendees:"/>
+              <StackLayout Grid.Row="0"
+                           Grid.Column="1"
+                           BindableLayout.ItemsSource="{Binding Attendees}">
+                  <BindableLayout.ItemTemplate>
+                    <DataTemplate x:DataType="essentials:DeviceEventAttendee">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <Label Text="{Binding Name}"
+                                   TextColor="Black"/>
+                            <Label Grid.Column="1"
+                                   Text="{Binding Email}"
+                                   TextColor="DarkGray"/>
+                        </Grid>
+                    </DataTemplate>
+                  </BindableLayout.ItemTemplate>
+              </StackLayout>
+                <Label Grid.Row="1" 
+                       Grid.Column="0"
+                       Text="Description:"/>
+                <Label Grid.Row="1"
+                       Grid.Column="1"
+                       Text="{Binding Description}"/>
+            </Grid>
+          </ScrollView >
+        </StackLayout>
+    </views:BasePage.Content>
+</views:BasePage>

--- a/Samples/Samples/View/CalendarEventPage.xaml.cs
+++ b/Samples/Samples/View/CalendarEventPage.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+
+namespace Samples.View
+{
+    public partial class CalendarEventPage : BasePage
+    {
+        public CalendarEventPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Samples/Samples/View/CalendarPage.xaml
+++ b/Samples/Samples/View/CalendarPage.xaml
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:BasePage  xmlns="http://xamarin.com/schemas/2014/forms"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                 xmlns:views="clr-namespace:Samples.View"
+                 xmlns:viewmodels="clr-namespace:Samples.ViewModel"
+                 xmlns:behaviors="clr-namespace:Samples.Behaviors;assembly=Samples"
+                 xmlns:converters="clr-namespace:Samples.Converters;assembly=Samples"
+                 xmlns:essentials="clr-namespace:Xamarin.Essentials;assembly=Xamarin.Essentials"
+                 x:Class="Samples.View.CalendarPage"
+                 x:DataType="viewmodels:CalendarViewModel"
+                 Title="Calendar">
+    <views:BasePage.Resources>
+        <ResourceDictionary>
+            <converters:CheckBoxEventArgsConverter x:Key="CheckBoxEventArgsConverter" />
+            <converters:DateSelectedEventArgsConverter x:Key="DateSelectedEventArgsConverter" />
+            <converters:TimeSelectedEventArgsConverter x:Key="TimeSelectedEventArgsConverter" />
+            <DataTemplate x:DataType="essentials:DeviceEvent"
+                          x:Key="EventItemTemplate">
+                <ViewCell>
+                    <StackLayout>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition />
+                            </Grid.ColumnDefinitions>
+                            <Label Text="{Binding Title}"
+                                   TextColor="Black"
+                                   HorizontalTextAlignment="Center" />
+                            <Label Grid.Column="1"
+                                   Text="{Binding StartDate, StringFormat={StaticResource DateDisplayFormatter}}"
+                                   TextColor="Black"
+                                   HorizontalTextAlignment="Center" />
+                            <Label Grid.Column="2"
+                                   Text="-"
+                                   IsVisible="{Binding AllDay, Converter={StaticResource NegativeConverter}}"/>
+                            <Label Grid.Column="3"
+                                   Text="{Binding EndDate, StringFormat={StaticResource DateDisplayFormatter}}"
+                                   TextColor="Black"
+                                   HorizontalTextAlignment="Center" />
+                        </Grid>
+                    </StackLayout>
+                </ViewCell>
+            </DataTemplate>
+        </ResourceDictionary>
+    </views:BasePage.Resources>
+    <views:BasePage.BindingContext>
+        <viewmodels:CalendarViewModel />
+    </views:BasePage.BindingContext>
+    <views:BasePage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <StackLayout>
+                <Label Text="Quickly view a range of calendars and upcoming events." FontAttributes="Bold" Margin="12" />
+                <Button Grid.Column="1"
+                        Text="Load Calendars"
+                        Command="{Binding GetCalendars}" 
+                        HorizontalOptions="Center"/>
+            </StackLayout>
+            <Picker x:Name="SelectedCalendar"
+                    Grid.Row="1"
+                    Title="Select a Calendar"
+                    ItemsSource="{Binding Calendars}"
+                    ItemDisplayBinding="{Binding Name}"
+                    SelectedItem="{Binding SelectedCalendar}" />
+            <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+                <CheckBox Grid.Row="0"
+                          Grid.Column="0"
+                          IsChecked="{Binding StartDatePickersEnabled}">
+                    <CheckBox.Behaviors>
+                        <behaviors:EventToCommandBehavior EventName="CheckedChanged"
+                                                          Command="{Binding StartDateEnabledCheckBoxChanged}"
+                                                          Converter="{StaticResource CheckBoxEventArgsConverter}" />
+                    </CheckBox.Behaviors>
+                </CheckBox>
+                <Label Grid.Row="0"
+                       Grid.Column="1"
+                       Text="Start Date"
+                       HorizontalTextAlignment="Center"
+                       VerticalTextAlignment="Center" />
+                <DatePicker Date="{Binding StartDate}"
+                            MinimumDate="1970-01-01"
+                            IsEnabled="{Binding StartDatePickersEnabled}"
+                            Grid.Row = "0"
+                            Grid.Column="2">
+                    <DatePicker.Behaviors>
+                        <behaviors:EventToCommandBehavior EventName="DateSelected"
+                                                          Command="{Binding StartDateSelectedCommand}"
+                                                          Converter="{StaticResource DateSelectedEventArgsConverter}" />
+                    </DatePicker.Behaviors>
+                </DatePicker>
+                <TimePicker Time="{Binding StartTime}"
+                            IsEnabled="{Binding StartDatePickersEnabled}"
+                            Grid.Row = "0"
+                            Grid.Column="3">
+                    <TimePicker.Behaviors>
+                        <behaviors:EventToCommandBehavior EventName="PropertyChanged"
+                                                          Command="{Binding StartTimeSelectedCommand}"
+                                                          Converter="{StaticResource TimeSelectedEventArgsConverter}" />
+                    </TimePicker.Behaviors>
+                </TimePicker>
+                <CheckBox Grid.Row="1"
+                          Grid.Column="0"
+                          IsChecked="{Binding EndDatePickersEnabled}">
+                    <CheckBox.Behaviors>
+                        <behaviors:EventToCommandBehavior EventName="CheckedChanged"
+                                                          Command="{Binding EndDateEnabledCheckBoxChanged}"
+                                                          Converter="{StaticResource CheckBoxEventArgsConverter}" />
+                    </CheckBox.Behaviors>
+                </CheckBox>
+                <Label Text="End Date"
+                       HorizontalTextAlignment="Center"
+                       VerticalTextAlignment="Center"
+                       Grid.Row="1"
+                       Grid.Column="1" />
+                <DatePicker Date="{Binding EndDate}"
+                            MinimumDate="1970-01-01"
+                            IsEnabled="{Binding EndDatePickersEnabled}"
+                            Grid.Row="1"
+                            Grid.Column="2">
+                    <DatePicker.Behaviors>
+                        <behaviors:EventToCommandBehavior EventName="DateSelected"
+                                                          Command="{Binding EndDateSelectedCommand}"
+                                                          Converter="{StaticResource DateSelectedEventArgsConverter}" />
+                    </DatePicker.Behaviors>
+                </DatePicker>
+                <TimePicker Time="{Binding EndTime}"
+                            IsEnabled="{Binding EndDatePickersEnabled}"
+                            Grid.Row = "1"
+                            Grid.Column="3">
+                    <TimePicker.Behaviors>
+                        <behaviors:EventToCommandBehavior EventName="PropertyChanged"
+                                                          Command="{Binding EndTimeSelectedCommand}"
+                                                          Converter="{StaticResource TimeSelectedEventArgsConverter}" />
+                    </TimePicker.Behaviors>
+                </TimePicker>
+            </Grid>
+            <BoxView Grid.Row="3"
+                     VerticalOptions="Center"
+                     HorizontalOptions="FillAndExpand"
+                     HeightRequest="1"
+                     Color="#5b5d68" />
+            <ListView Grid.Row="4"
+                      HasUnevenRows="true"
+                      ItemsSource="{Binding Events}"
+                      ItemTemplate="{StaticResource EventItemTemplate}"
+                      SelectionMode="None"
+                      ItemTapped="OnEventTapped" />
+        </Grid>
+    </views:BasePage.Content>
+</views:BasePage>

--- a/Samples/Samples/View/CalendarPage.xaml.cs
+++ b/Samples/Samples/View/CalendarPage.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Samples.ViewModel;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+
+namespace Samples.View
+{
+    public partial class CalendarPage : BasePage
+    {
+        public CalendarPage()
+        {
+            InitializeComponent();
+        }
+
+        async void OnEventTapped(object sender, ItemTappedEventArgs e)
+        {
+            if (e.Item == null || !(e.Item is DeviceEvent evt))
+                return;
+
+            var calendarEvent = await Calendar.GetEventByIdAsync((e.Item as DeviceEvent)?.Id);
+            var modal = new CalendarEventPage
+            {
+                BindingContext = calendarEvent
+            };
+            await Navigation.PushAsync(modal);
+        }
+    }
+}

--- a/Samples/Samples/ViewModel/CalendarViewModel.cs
+++ b/Samples/Samples/ViewModel/CalendarViewModel.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Xamarin.Essentials;
+using Xamarin.Forms;
+
+namespace Samples.ViewModel
+{
+    public class CalendarViewModel : BaseViewModel
+    {
+        const int endDateDaysToOffset = 14;
+
+        const string endOfDay = "23:59";
+
+        public CalendarViewModel()
+        {
+            GetCalendars = new Command(OnClickGetCalendars);
+            StartDateSelectedCommand = new Command(OnStartDateSelected);
+            StartTimeSelectedCommand = new Command(OnStartTimeSelected);
+            EndDateSelectedCommand = new Command(OnEndDateSelected);
+            EndTimeSelectedCommand = new Command(OnEndTimeSelected);
+            StartDateEnabledCheckBoxChanged = new Command(OnStartCheckboxChanged);
+            EndDateEnabledCheckBoxChanged = new Command(OnEndCheckboxChanged);
+        }
+
+        DeviceCalendar selectedCalendar;
+
+        bool startdatePickersEnabled;
+
+        bool enddatePickersEnabled;
+
+        public bool StartDatePickersEnabled
+        {
+            get => startdatePickersEnabled;
+            set => SetProperty(ref startdatePickersEnabled, value);
+        }
+
+        public bool EndDatePickersEnabled
+        {
+            get => enddatePickersEnabled;
+            set => SetProperty(ref enddatePickersEnabled, value);
+        }
+
+        public ICommand GetCalendars { get; }
+
+        public ICommand StartDateEnabledCheckBoxChanged { get; }
+
+        public ICommand EndDateEnabledCheckBoxChanged { get; }
+
+        public ICommand StartDateSelectedCommand { get; }
+
+        public ICommand StartTimeSelectedCommand { get; }
+
+        public ICommand EndDateSelectedCommand { get; }
+
+        public ICommand EndTimeSelectedCommand { get; }
+
+        public DateTime StartDate { get; set; } = DateTime.Now;
+
+        public TimeSpan StartTime { get; set; }
+
+        public DateTime EndDate { get; set; } = DateTime.Now.AddDays(endDateDaysToOffset);
+
+        public TimeSpan EndTime { get; set; } = TimeSpan.Parse(endOfDay);
+
+        public bool HasCalendarReadAccess { get; set; }
+
+        public ObservableCollection<DeviceCalendar> Calendars { get; } = new ObservableCollection<DeviceCalendar>();
+
+        public ObservableCollection<DeviceEvent> Events { get; } = new ObservableCollection<DeviceEvent>();
+
+        public DeviceCalendar SelectedCalendar
+        {
+            get => selectedCalendar;
+
+            set
+            {
+                if (SetProperty(ref selectedCalendar, value) && selectedCalendar != null)
+                {
+                    OnChangeRequestCalendarSpecificEvents(selectedCalendar.Id);
+                }
+            }
+        }
+
+        void OnStartCheckboxChanged(object parameter)
+        {
+            if (parameter is bool b)
+            {
+                StartDatePickersEnabled = b;
+
+                RefreshEventList(SelectedCalendar?.Id);
+            }
+        }
+
+        void OnEndCheckboxChanged(object parameter)
+        {
+            if (parameter is bool b)
+            {
+                EndDatePickersEnabled = b;
+
+                RefreshEventList(SelectedCalendar?.Id);
+            }
+        }
+
+        async void OnClickGetCalendars()
+        {
+            Calendars.Clear();
+            Calendars.Add(new DeviceCalendar() { Id = null, Name = "All" });
+            var calendars = await Calendar.GetCalendarsAsync();
+            foreach (var calendar in calendars)
+            {
+                Calendars.Add(calendar);
+            }
+            SelectedCalendar = Calendars[0];
+        }
+
+        void OnStartDateSelected(object parameter)
+        {
+            var startDate = parameter as DateTime?;
+
+            if (!startDate.HasValue)
+                return;
+
+            startDate += StartTime;
+
+            RefreshEventList(SelectedCalendar?.Id, startDate);
+        }
+
+        void OnStartTimeSelected(object parameter)
+        {
+            if (parameter == null)
+                return;
+
+            RefreshEventList(SelectedCalendar?.Id);
+        }
+
+        void OnEndDateSelected(object parameter)
+        {
+            var endDate = parameter as DateTime?;
+
+            if (!endDate.HasValue)
+                return;
+
+            endDate += EndTime;
+            RefreshEventList(SelectedCalendar?.Id, null, endDate);
+        }
+
+        void OnEndTimeSelected(object parameter)
+        {
+            if (parameter == null)
+                return;
+
+            RefreshEventList();
+        }
+
+        void OnChangeRequestCalendarSpecificEvents(string calendarId = null, DateTime? startDateTime = null, DateTime? endDateTime = null) => RefreshEventList(calendarId, startDateTime, endDateTime);
+
+        async void RefreshEventList(string calendarId = null, DateTime? startDate = null, DateTime? endDate = null)
+        {
+            startDate = StartDatePickersEnabled && !startDate.HasValue ? (DateTime?)StartDate.Date + StartTime : startDate;
+            endDate = (EndDatePickersEnabled && !endDate.HasValue) ? (DateTime?)EndDate.Date + EndTime : endDate;
+            if (Calendars.Count == 0)
+                return;
+
+            Events.Clear();
+            var events = await Calendar.GetEventsAsync(calendarId, startDate, endDate);
+            foreach (var calendarEvent in events)
+            {
+                Events.Add(calendarEvent);
+            }
+        }
+    }
+}

--- a/Samples/Samples/ViewModel/HomeViewModel.cs
+++ b/Samples/Samples/ViewModel/HomeViewModel.cs
@@ -55,6 +55,12 @@ namespace Samples.ViewModel
                     "Quickly and easily open a browser to a specific website.",
                     new[] { "browser", "web", "internet" }),
                 new SampleItem(
+                    "📆",
+                    "Calendar",
+                    typeof(CalendarPage),
+                    "Access the calendars on the device.",
+                    new[] { "calendar", "event", "appointment" }),
+                new SampleItem(
                     "📋",
                     "Clipboard",
                     typeof(ClipboardPage),

--- a/Tests/Calendar_Tests.cs
+++ b/Tests/Calendar_Tests.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Essentials;
+using Xunit;
+
+namespace Tests
+{
+    public class Calendar_Tests
+    {
+        [Fact]
+        public async Task Calendar_Get_Calendar_List_Fail_On_NetStandard() => await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Calendar.GetCalendarsAsync());
+
+        [Fact]
+        public async Task Calendar_Get_Event_By_Id_Fail_On_NetStandard() => await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Calendar.GetEventByIdAsync("An ID"));
+
+        [Fact]
+        public async Task Calendar_Get_Events_Fail_On_NetStandard() => await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => Calendar.GetEventsAsync());
+    }
+}

--- a/Xamarin.Essentials/Calendar/Calendar.android.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.android.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Android.Content;
+using Android.Database;
+using Android.Provider;
+using Java.Security;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Calendar
+    {
+        const string andCondition = "AND";
+
+        static async Task<IEnumerable<DeviceCalendar>> PlatformGetCalendarsAsync()
+        {
+            await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            var calendarsUri = CalendarContract.Calendars.ContentUri;
+            var calendarsProjection = new List<string>
+            {
+                CalendarContract.Calendars.InterfaceConsts.Id,
+                CalendarContract.Calendars.InterfaceConsts.CalendarDisplayName
+            };
+            var queryConditions = $"{CalendarContract.Calendars.InterfaceConsts.Deleted} != 1";
+
+            using (var cur = Platform.AppContext.ApplicationContext.ContentResolver.Query(calendarsUri, calendarsProjection.ToArray(), queryConditions, null, null))
+            {
+                var calendars = new List<DeviceCalendar>();
+                while (cur.MoveToNext())
+                {
+                    calendars.Add(new DeviceCalendar()
+                    {
+                        Id = cur.GetString(calendarsProjection.IndexOf(CalendarContract.Calendars.InterfaceConsts.Id)),
+                        Name = cur.GetString(calendarsProjection.IndexOf(CalendarContract.Calendars.InterfaceConsts.CalendarDisplayName)),
+                    });
+                }
+                return calendars;
+            }
+        }
+
+        static async Task<IEnumerable<DeviceEvent>> PlatformGetEventsAsync(string calendarId = null, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)
+        {
+            await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            var eventsUri = CalendarContract.Events.ContentUri;
+            var eventsProjection = new List<string>
+            {
+                CalendarContract.Events.InterfaceConsts.Id,
+                CalendarContract.Events.InterfaceConsts.CalendarId,
+                CalendarContract.Events.InterfaceConsts.Title,
+                CalendarContract.Events.InterfaceConsts.AllDay,
+                CalendarContract.Events.InterfaceConsts.Dtstart,
+                CalendarContract.Events.InterfaceConsts.Dtend,
+                CalendarContract.Events.InterfaceConsts.Deleted
+            };
+            var calendarSpecificEvent = string.Empty;
+            var sDate = startDate ?? DateTimeOffset.Now.Add(defaultStartTimeFromNow);
+            var eDate = endDate ?? sDate.Add(defaultEndTimeFromStartTime);
+            if (!string.IsNullOrEmpty(calendarId))
+            {
+                calendarSpecificEvent = $"{CalendarContract.Events.InterfaceConsts.CalendarId}={calendarId} {andCondition} ";
+            }
+            calendarSpecificEvent += $"{CalendarContract.Events.InterfaceConsts.Dtend} >= {sDate.AddMilliseconds(sDate.Offset.TotalMilliseconds).ToUnixTimeMilliseconds()} {andCondition} ";
+            calendarSpecificEvent += $"{CalendarContract.Events.InterfaceConsts.Dtstart} <= {eDate.AddMilliseconds(sDate.Offset.TotalMilliseconds).ToUnixTimeMilliseconds()} {andCondition} ";
+            calendarSpecificEvent += $"{CalendarContract.Events.InterfaceConsts.Deleted} != 1";
+
+            using (var cur = Platform.AppContext.ApplicationContext.ContentResolver.Query(eventsUri, eventsProjection.ToArray(), calendarSpecificEvent, null, $"{CalendarContract.Events.InterfaceConsts.Dtstart} ASC"))
+            {
+                var events = new List<DeviceEvent>();
+                while (cur.MoveToNext())
+                {
+                    events.Add(new DeviceEvent()
+                    {
+                        Id = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Id)),
+                        CalendarId = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.CalendarId)),
+                        Title = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Title)),
+                        StartDate = DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtstart))),
+                        EndDate = cur.GetInt(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.AllDay)) == 0 ? (DateTimeOffset?)DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtend))) : null
+                    });
+                }
+                return events;
+            }
+        }
+
+        static async Task<DeviceEvent> PlatformGetEventByIdAsync(string eventId)
+        {
+            await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            var eventsUri = CalendarContract.Events.ContentUri;
+            var eventsProjection = new List<string>
+            {
+                CalendarContract.Events.InterfaceConsts.Id,
+                CalendarContract.Events.InterfaceConsts.CalendarId,
+                CalendarContract.Events.InterfaceConsts.Title,
+                CalendarContract.Events.InterfaceConsts.Description,
+                CalendarContract.Events.InterfaceConsts.EventLocation,
+                CalendarContract.Events.InterfaceConsts.AllDay,
+                CalendarContract.Events.InterfaceConsts.Dtstart,
+                CalendarContract.Events.InterfaceConsts.Dtend
+            };
+
+            // Android event ids are always integers
+            if (!int.TryParse(eventId, out var resultId))
+            {
+                throw new ArgumentException($"[Android]: No Event found for event Id {eventId}");
+            }
+
+            var calendarSpecificEvent = $"{CalendarContract.Events.InterfaceConsts.Id}={resultId}";
+            using (var cur = Platform.AppContext.ApplicationContext.ContentResolver.Query(eventsUri, eventsProjection.ToArray(), calendarSpecificEvent, null, null))
+            {
+                if (cur.Count > 0)
+                {
+                    cur.MoveToNext();
+                    var eventResult = new DeviceEvent
+                    {
+                        Id = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Id)),
+                        CalendarId = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.CalendarId)),
+                        Title = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Title)),
+                        Description = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Description)),
+                        Location = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.EventLocation)),
+                        StartDate = DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtstart))),
+                        EndDate = cur.GetInt(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.AllDay)) == 0 ? (DateTimeOffset?)DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtend))) : null,
+                        Attendees = GetAttendeesForEvent(eventId)
+                    };
+                    return eventResult;
+                }
+                else
+                {
+                    throw new ArgumentException($"[Android]: No Event found for event Id {eventId}");
+                }
+            }
+        }
+
+        static IEnumerable<DeviceEventAttendee> GetAttendeesForEvent(string eventId)
+        {
+            var attendeesUri = CalendarContract.Attendees.ContentUri;
+            var attendeesProjection = new List<string>
+            {
+                CalendarContract.Attendees.InterfaceConsts.EventId,
+                CalendarContract.Attendees.InterfaceConsts.AttendeeEmail,
+                CalendarContract.Attendees.InterfaceConsts.AttendeeName
+            };
+            var attendeeSpecificAttendees = $"{CalendarContract.Attendees.InterfaceConsts.EventId}={eventId}";
+            var cur = Platform.AppContext.ApplicationContext.ContentResolver.Query(attendeesUri, attendeesProjection.ToArray(), attendeeSpecificAttendees, null, null);
+            var attendees = new List<DeviceEventAttendee>();
+            while (cur.MoveToNext())
+            {
+                attendees.Add(new DeviceEventAttendee()
+                {
+                    Name = cur.GetString(attendeesProjection.IndexOf(CalendarContract.Attendees.InterfaceConsts.AttendeeName)),
+                    Email = cur.GetString(attendeesProjection.IndexOf(CalendarContract.Attendees.InterfaceConsts.AttendeeEmail)),
+                });
+            }
+            cur.Dispose();
+            return attendees;
+        }
+    }
+}

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventKit;
+using Foundation;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Calendar
+    {
+        static async Task<IEnumerable<DeviceCalendar>> PlatformGetCalendarsAsync()
+        {
+            await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            EKCalendar[] calendars;
+            try
+            {
+                calendars = CalendarRequest.Instance.Calendars;
+            }
+            catch (NullReferenceException ex)
+            {
+                throw new Exception($"iOS: Unexpected null reference exception {ex.Message}");
+            }
+            var calendarList = (from calendar in calendars
+                                select new DeviceCalendar
+                                {
+                                    Id = calendar.CalendarIdentifier,
+                                    Name = calendar.Title
+                                }).ToList();
+
+            return calendarList;
+        }
+
+        static async Task<IEnumerable<DeviceEvent>> PlatformGetEventsAsync(string calendarId = null, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)
+        {
+            await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            var startDateToConvert = startDate ?? DateTimeOffset.Now.Add(defaultStartTimeFromNow);
+            var endDateToConvert = endDate ?? startDateToConvert.Add(defaultEndTimeFromStartTime);  // NOTE: 4 years is the maximum period that a iOS calendar events can search
+            var sDate = startDateToConvert.ToNSDate();
+            var eDate = endDateToConvert.ToNSDate();
+            EKCalendar[] calendars;
+            try
+            {
+                calendars = !string.IsNullOrWhiteSpace(calendarId)
+                    ? CalendarRequest.Instance.Calendars.Where(x => x.CalendarIdentifier == calendarId).ToArray()
+                    : null;
+            }
+            catch (NullReferenceException ex)
+            {
+                throw new NullReferenceException($"iOS: Unexpected null reference exception {ex.Message}");
+            }
+
+            var query = CalendarRequest.Instance.PredicateForEvents(sDate, eDate, calendars);
+            var events = CalendarRequest.Instance.EventsMatching(query);
+
+            var eventList = (from e in events
+                            select new DeviceEvent
+                            {
+                                Id = e.CalendarItemIdentifier,
+                                CalendarId = e.Calendar.CalendarIdentifier,
+                                Title = e.Title,
+                                StartDate = e.StartDate.ToDateTimeOffset(),
+                                EndDate = !e.AllDay ? (DateTimeOffset?)e.EndDate.ToDateTimeOffset() : null
+                            })
+                            .OrderBy(e => e.StartDate)
+                            .ToList();
+
+            return eventList;
+        }
+
+        static async Task<DeviceEvent> PlatformGetEventByIdAsync(string eventId)
+        {
+            await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            EKEvent e;
+            try
+            {
+                e = CalendarRequest.Instance.GetCalendarItem(eventId) as EKEvent;
+            }
+            catch (NullReferenceException)
+            {
+                throw new NullReferenceException($"[iOS]: No Event found for event Id {eventId}");
+            }
+
+            return new DeviceEvent
+            {
+                Id = e.CalendarItemIdentifier,
+                CalendarId = e.Calendar.CalendarIdentifier,
+                Title = e.Title,
+                Description = e.Notes,
+                Location = e.Location,
+                StartDate = e.StartDate.ToDateTimeOffset(),
+                EndDate = !e.AllDay ? (DateTimeOffset?)e.EndDate.ToDateTimeOffset() : null,
+                Attendees = e.Attendees != null ? GetAttendeesForEvent(e.Attendees) : new List<DeviceEventAttendee>()
+            };
+        }
+
+        static IEnumerable<DeviceEventAttendee> GetAttendeesForEvent(IEnumerable<EKParticipant> inviteList)
+        {
+            var attendees = (from attendee in inviteList
+                             select new DeviceEventAttendee
+                             {
+                                 Name = attendee.Name,
+                                 Email = attendee.Name
+                             })
+                            .OrderBy(e => e.Name)
+                            .ToList();
+
+            return attendees;
+        }
+    }
+}

--- a/Xamarin.Essentials/Calendar/Calendar.netstandard.tvos.watchos.tizen.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.netstandard.tvos.watchos.tizen.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Calendar
+    {
+        static Task<IEnumerable<DeviceCalendar>> PlatformGetCalendarsAsync() => throw new NotImplementedException();
+
+        static Task<IEnumerable<DeviceEvent>> PlatformGetEventsAsync(string calendarId = null, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null) => throw new NotImplementedException();
+
+        static Task<DeviceEvent> PlatformGetEventByIdAsync(string eventId) => throw new NotImplementedException();
+    }
+}

--- a/Xamarin.Essentials/Calendar/Calendar.shared.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.shared.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Calendar
+    {
+        static TimeSpan defaultStartTimeFromNow = TimeSpan.Zero;
+
+        static TimeSpan defaultEndTimeFromStartTime = TimeSpan.FromDays(14);
+
+        public static Task<IEnumerable<DeviceCalendar>> GetCalendarsAsync() => PlatformGetCalendarsAsync();
+
+        public static Task<IEnumerable<DeviceEvent>> GetEventsAsync(string calendarId = null, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null) => PlatformGetEventsAsync(calendarId, startDate, endDate);
+
+        public static Task<DeviceEvent> GetEventByIdAsync(string eventId) => PlatformGetEventByIdAsync(eventId);
+    }
+}

--- a/Xamarin.Essentials/Calendar/Calendar.uwp.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.uwp.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Appointments;
+
+namespace Xamarin.Essentials
+{
+    public static partial class Calendar
+    {
+        static async Task<IEnumerable<DeviceCalendar>> PlatformGetCalendarsAsync()
+        {
+            await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            var instance = await CalendarRequest.GetInstanceAsync();
+            var uwpCalendarList = await instance.FindAppointmentCalendarsAsync(FindAppointmentCalendarsOptions.IncludeHidden);
+
+            var calendars = (from calendar in uwpCalendarList
+                                select new DeviceCalendar
+                                {
+                                    Id = calendar.LocalId,
+                                    Name = calendar.DisplayName
+                                }).ToList();
+
+            return calendars;
+        }
+
+        static async Task<IEnumerable<DeviceEvent>> PlatformGetEventsAsync(string calendarId = null, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)
+        {
+            await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            var options = new FindAppointmentsOptions();
+            options.FetchProperties.Add(AppointmentProperties.Subject);
+            options.FetchProperties.Add(AppointmentProperties.StartTime);
+            options.FetchProperties.Add(AppointmentProperties.Duration);
+            options.FetchProperties.Add(AppointmentProperties.AllDay);
+            var sDate = startDate ?? DateTimeOffset.Now.Add(defaultStartTimeFromNow);
+            var eDate = endDate ?? sDate.Add(defaultEndTimeFromStartTime);
+
+            if (eDate < sDate)
+                eDate = sDate;
+
+            var instance = await CalendarRequest.GetInstanceAsync();
+            var events = await instance.FindAppointmentsAsync(sDate, eDate.Subtract(sDate), options);
+
+            var eventList = (from e in events
+                             select new DeviceEvent
+                             {
+                                 Id = e.LocalId,
+                                 CalendarId = e.CalendarId,
+                                 Title = e.Subject,
+                                 StartDate = e.StartTime,
+                                 EndDate = !e.AllDay ? (DateTimeOffset?)e.StartTime.Add(e.Duration) : null
+                             })
+                            .Where(e => e.CalendarId == calendarId || calendarId == null)
+                            .OrderBy(e => e.StartDate)
+                            .ToList();
+
+            return eventList;
+        }
+
+        static async Task<DeviceEvent> PlatformGetEventByIdAsync(string eventId)
+        {
+            await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            var instance = await CalendarRequest.GetInstanceAsync();
+
+            Appointment e;
+            try
+            {
+                e = await instance.GetAppointmentAsync(eventId);
+                e.DetailsKind = AppointmentDetailsKind.PlainText;
+            }
+            catch (ArgumentException)
+            {
+                throw new ArgumentException($"[UWP]: No Event found for event Id {eventId}");
+            }
+            catch (NullReferenceException)
+            {
+                throw new NullReferenceException($"[UWP]: No Event found for event Id {eventId}");
+            }
+
+            return new DeviceEvent()
+            {
+                Id = e.LocalId,
+                CalendarId = e.CalendarId,
+                Title = e.Subject,
+                Description = e.Details,
+                Location = e.Location,
+                StartDate = e.StartTime,
+                EndDate = !e.AllDay ? (DateTimeOffset?)e.StartTime.Add(e.Duration) : null,
+                Attendees = GetAttendeesForEvent(e.Invitees)
+            };
+        }
+
+        static IEnumerable<DeviceEventAttendee> GetAttendeesForEvent(IEnumerable<AppointmentInvitee> inviteList)
+        {
+            var attendees = (from attendee in inviteList
+                             select new DeviceEventAttendee
+                             {
+                                 Name = attendee.DisplayName,
+                                 Email = attendee.Address
+                             })
+                            .OrderBy(e => e.Name)
+                            .ToList();
+
+            return attendees;
+        }
+    }
+}

--- a/Xamarin.Essentials/Calendar/CalendarRequest.ios.cs
+++ b/Xamarin.Essentials/Calendar/CalendarRequest.ios.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using EventKit;
+
+namespace Xamarin.Essentials
+{
+    static class CalendarRequest
+    {
+        static readonly Lazy<EKEventStore> EventStore = new Lazy<EKEventStore>(() => new EKEventStore());
+
+        public static EKEventStore Instance => EventStore.Value;
+    }
+}

--- a/Xamarin.Essentials/Calendar/CalendarRequest.uwp.cs
+++ b/Xamarin.Essentials/Calendar/CalendarRequest.uwp.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.ApplicationModel.Appointments;
+
+namespace Xamarin.Essentials
+{
+    static class CalendarRequest
+    {
+        static AppointmentStore uwpAppointmentStore;
+
+        public static async System.Threading.Tasks.Task<AppointmentStore> GetInstanceAsync(AppointmentStoreAccessType type = AppointmentStoreAccessType.AllCalendarsReadOnly)
+        {
+            if (uwpAppointmentStore == null)
+            {
+                uwpAppointmentStore = await AppointmentManager.RequestStoreAsync(type);
+            }
+
+            return uwpAppointmentStore;
+        }
+    }
+}

--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -80,6 +80,7 @@ namespace Xamarin.Essentials
         static async Task<PermissionStatus> PlatformRequestAsync(PermissionType permission)
         {
             // Check status before requesting first
+
             if (await PlatformCheckStatusAsync(permission) == PermissionStatus.Granted)
                 return PermissionStatus.Granted;
 
@@ -156,6 +157,9 @@ namespace Xamarin.Essentials
                     break;
                 case PermissionType.Camera:
                     permissions.Add((Manifest.Permission.Camera, true));
+                    break;
+                case PermissionType.CalendarRead:
+                    permissions.Add((Manifest.Permission.ReadCalendar, true));
                     break;
                 case PermissionType.Flashlight:
                     permissions.Add((Manifest.Permission.Camera, true));

--- a/Xamarin.Essentials/Permissions/Permissions.shared.enums.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.enums.cs
@@ -23,6 +23,7 @@
         Unknown,
         Battery,
         Camera,
+        CalendarRead,
         Flashlight,
         LaunchApp,
         LocationWhenInUse,

--- a/Xamarin.Essentials/Types/AttendeeDetails.android.cs
+++ b/Xamarin.Essentials/Types/AttendeeDetails.android.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Essentials
+{
+    // Android
+    public class DeviceSpecificAttendeeDetails
+    {
+        public bool IsAttending { get; set; }
+
+        public AttendanceStatus Status { get; set; }
+    }
+
+    public enum AttendanceStatus
+    {
+        None,
+        Accepted,
+        Declined,
+        Invited,
+        Tentative
+    }
+}

--- a/Xamarin.Essentials/Types/AttendeeDetails.ios.cs
+++ b/Xamarin.Essentials/Types/AttendeeDetails.ios.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Essentials
+{
+    // iOS
+    public class DeviceSpecificAttendeeDetails
+    {
+        public AttendanceStatus Status { get; set; }
+
+        public Roles Role { get; set; }
+    }
+
+    public enum AttendanceStatus
+    {
+        Unknown,
+        Pending,
+        Accepted,
+        Declined,
+        Tentative,
+        Delegated,
+        Completed,
+        InProcess
+    }
+
+    public enum Roles
+    {
+        Unknown,
+        Required,
+        Optional,
+        Chair,
+        NonParticipant
+    }
+}

--- a/Xamarin.Essentials/Types/DeviceCalendar.shared.cs
+++ b/Xamarin.Essentials/Types/DeviceCalendar.shared.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xamarin.Essentials
+{
+    [Preserve(AllMembers = true)]
+    public class DeviceCalendar
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    [Preserve(AllMembers = true)]
+    public class DeviceEvent
+    {
+        public string Id { get; set; }
+
+        public string CalendarId { get; set; }
+
+        public string Title { get; set; }
+
+        public string Description { get; set; }
+
+        public string Location { get; set; }
+
+        public bool AllDay
+        {
+            get => !EndDate.HasValue;
+            set
+            {
+                if (value)
+                {
+                    EndDate = null;
+                }
+                else
+                {
+                    EndDate = StartDate;
+                }
+            }
+        }
+
+        public DateTimeOffset StartDate { get; set; }
+
+        public TimeSpan? Duration
+        {
+            get => EndDate.HasValue ? EndDate - StartDate : null;
+            set
+            {
+                if (value.HasValue)
+                {
+                    EndDate = StartDate.Add(value.Value);
+                }
+                else
+                {
+                    EndDate = null;
+                }
+            }
+        }
+
+        public DateTimeOffset? EndDate { get; set; }
+
+        public IEnumerable<DeviceEventAttendee> Attendees { get; set; }
+    }
+
+    [Preserve(AllMembers = true)]
+    public class DeviceEventAttendee
+    {
+        public string Name { get; set; }
+
+        public string Email { get; set; }
+    }
+}

--- a/Xamarin.Essentials/Types/PlatformExtensions/CalendarExtensions.ios.cs
+++ b/Xamarin.Essentials/Types/PlatformExtensions/CalendarExtensions.ios.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Drawing;
+using Foundation;
+using iOSSize = CoreGraphics.CGSize;
+
+namespace Xamarin.Essentials
+{
+    public static partial class CalendarExtensions
+    {
+        // https://developer.apple.com/documentation/foundation/nsdate
+        // NSDate minimum date is 2001/01/01
+        static DateTime iosNSDateTimeSystemZeroPoint = new DateTime(2001, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        static long ToEpochTime(this NSDate date) => (long)Math.Floor((Math.Abs(NSDate.FromTimeIntervalSince1970(0).SecondsSinceReferenceDate) + date.SecondsSinceReferenceDate) * 1000);
+
+        public static NSDate ToNSDate(this DateTimeOffset date) => NSDate.FromTimeIntervalSinceReferenceDate((date.UtcDateTime - iosNSDateTimeSystemZeroPoint).TotalSeconds).AddSeconds(date.Offset.TotalSeconds);
+
+        public static DateTimeOffset ToDateTimeOffset(this NSDate date) => DateTimeOffset.FromUnixTimeMilliseconds(date.ToEpochTime());
+    }
+}


### PR DESCRIPTION
# Calendar Read-Only API

Calendar API for reading calendar/event information seamlessly across uwp, iOS and Android
(Issue https://github.com/xamarin/Essentials/issues/996)
# API

## Calendar

### Methods

| API | Description |
| ------------- | ------------- |
| ``Task<IEnumerable<DeviceCalendar>> GetCalendarsAsync()`` | Retrieve all calendars for device |
|  ``Task<IEnumerable<DeviceEvent>> GetEventsAsync( string calendarId = null, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)`` | Retrieve all events for a specified range/calendar. Null values for parameters will result in default values being used: null calendarId will return events from all calendares, startDate will default to the Now, endDate will default to startDate+14 days |
| ``Task<DeviceEvent> GetEventByIdAsync(string eventId)`` | Gets more detailed information about a specific event by the event id |

### Classes
```
public class DeviceCalendar
{
    string Id { get; set; }

    string Name { get; set; }
}

public class DeviceEvent
{
    string Id { get; set; }

    string CalendarId { get; set; }

    string Title { get; set; }

    string Description { get; set; }

    string Location { get; set; }

    bool AllDay { get; set; }

    DateTimeOffset Start { get; set; }

    DateTimeOffset? End { get; set; }

    TimeSpan? Duration { get; set; }

    IEnumerable<DeviceEventAttendee> Attendees { get; set; }
}

public class DeviceEventAttendee
{
    string Name { get; set; }

    string Email { get; set; }
}
```
# Scenarios

- User wants to see upcoming events.
- User wants to see who is attending an upcoming event.
- User wants to know when they will be free.

# Platform Compatibility
- Target Frameworks: <!-- All that apply -->
  - iOS:  Support on iOS for the API
  - Android: Support on Android for the API
  - UWP: Support on UWP for the API
# Backward Compatibility
- UWP: Windows 10 (introduced v10.0.10240.0) 
(https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.appointments.appointment)
- Android: android:minSdkVersion="14" 
(https://developer.android.com/reference/android/provider/CalendarContract)
- iOS: All versions until reminders are added, then iOS 6
(https://developer.apple.com/documentation/eventkit/ekeventstore)

# Contributors
@ScottBTR
@mkieres