### PR TITLE
Rename GetCompliment to GetComplementary

### DIFF
--- a/Tests/Color_Tests.cs
+++ b/Tests/Color_Tests.cs
@@ -65,12 +65,12 @@ namespace Tests
         [InlineData("#00FF00", "#FF00FF")] // Green & Fuschia
         [InlineData("#0000FF", "#FFFF00")] // Blue & Yellow
         [InlineData("#0AF56C", "#F50A93")] // Lime green & bright purple (but with no limit values)
-        public void GetCompliment(string original, string expected)
+        public void GetComplementary(string original, string expected)
         {
             var orig = ColorConverters.FromHex(original);
-            var expectedCompliment = ColorConverters.FromHex(expected);
+            var expectedComplement = ColorConverters.FromHex(expected);
 
-            Assert.Equal(expectedCompliment, ColorConverters.GetCompliment(orig));
+            Assert.Equal(expectedComplement, ColorConverters.GetComplementary(orig));
         }
 
         [Fact]

--- a/Xamarin.Essentials/Types/ColorConverters.shared.cs
+++ b/Xamarin.Essentials/Types/ColorConverters.shared.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Essentials
             return Color.FromArgb(a, r, g, b);
         }
 
-        public static Color GetCompliment(Color original)
+        public static Color GetComplementary(Color original)
         {
             // Divide RGB by 255 as ConvertToHsl expects a value between 0 & 1.
             ConvertToHsl(original.R / 255f, original.G / 255f, original.B / 255f, out var h, out var s, out var l);

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -130,7 +130,7 @@
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsl(System.Single,System.Single,System.Single)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsla(System.Single,System.Single,System.Single,System.Int32)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromUInt(System.UInt32)" />
-      <Member Id="M:Xamarin.Essentials.ColorConverters.GetCompliment(System.Drawing.Color)" />
+      <Member Id="M:Xamarin.Essentials.ColorConverters.GetComplementary(System.Drawing.Color)" />
     </Type>
     <Type Name="Xamarin.Essentials.ColorExtensions" Id="T:Xamarin.Essentials.ColorExtensions">
       <Member Id="M:Xamarin.Essentials.ColorExtensions.AddLuminosity(System.Drawing.Color,System.Single)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -117,7 +117,7 @@
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsl(System.Single,System.Single,System.Single)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsla(System.Single,System.Single,System.Single,System.Int32)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromUInt(System.UInt32)" />
-      <Member Id="M:Xamarin.Essentials.ColorConverters.GetCompliment(System.Drawing.Color)" />
+      <Member Id="M:Xamarin.Essentials.ColorConverters.GetComplementary(System.Drawing.Color)" />
     </Type>
     <Type Name="Xamarin.Essentials.ColorExtensions" Id="T:Xamarin.Essentials.ColorExtensions">
       <Member Id="M:Xamarin.Essentials.ColorExtensions.AddLuminosity(System.Drawing.Color,System.Single)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
@@ -117,7 +117,7 @@
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsl(System.Single,System.Single,System.Single)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsla(System.Single,System.Single,System.Single,System.Int32)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromUInt(System.UInt32)" />
-      <Member Id="M:Xamarin.Essentials.ColorConverters.GetCompliment(System.Drawing.Color)" />
+      <Member Id="M:Xamarin.Essentials.ColorConverters.GetComplementary(System.Drawing.Color)" />
     </Type>
     <Type Name="Xamarin.Essentials.ColorExtensions" Id="T:Xamarin.Essentials.ColorExtensions">
       <Member Id="M:Xamarin.Essentials.ColorExtensions.AddLuminosity(System.Drawing.Color,System.Single)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -117,7 +117,7 @@
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsl(System.Single,System.Single,System.Single)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsla(System.Single,System.Single,System.Single,System.Int32)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromUInt(System.UInt32)" />
-      <Member Id="M:Xamarin.Essentials.ColorConverters.GetCompliment(System.Drawing.Color)" />
+      <Member Id="M:Xamarin.Essentials.ColorConverters.GetComplementary(System.Drawing.Color)" />
     </Type>
     <Type Name="Xamarin.Essentials.ColorExtensions" Id="T:Xamarin.Essentials.ColorExtensions">
       <Member Id="M:Xamarin.Essentials.ColorExtensions.AddLuminosity(System.Drawing.Color,System.Single)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
@@ -117,7 +117,7 @@
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsl(System.Single,System.Single,System.Single)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsla(System.Single,System.Single,System.Single,System.Int32)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromUInt(System.UInt32)" />
-      <Member Id="M:Xamarin.Essentials.ColorConverters.GetCompliment(System.Drawing.Color)" />
+      <Member Id="M:Xamarin.Essentials.ColorConverters.GetComplementary(System.Drawing.Color)" />
     </Type>
     <Type Name="Xamarin.Essentials.ColorExtensions" Id="T:Xamarin.Essentials.ColorExtensions">
       <Member Id="M:Xamarin.Essentials.ColorExtensions.AddLuminosity(System.Drawing.Color,System.Single)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -117,7 +117,7 @@
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsl(System.Single,System.Single,System.Single)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromHsla(System.Single,System.Single,System.Single,System.Int32)" />
       <Member Id="M:Xamarin.Essentials.ColorConverters.FromUInt(System.UInt32)" />
-      <Member Id="M:Xamarin.Essentials.ColorConverters.GetCompliment(System.Drawing.Color)" />
+      <Member Id="M:Xamarin.Essentials.ColorConverters.GetComplementary(System.Drawing.Color)" />
     </Type>
     <Type Name="Xamarin.Essentials.ColorExtensions" Id="T:Xamarin.Essentials.ColorExtensions">
       <Member Id="M:Xamarin.Essentials.ColorExtensions.AddLuminosity(System.Drawing.Color,System.Single)" />

--- a/docs/en/Xamarin.Essentials/ColorConverters.xml
+++ b/docs/en/Xamarin.Essentials/ColorConverters.xml
@@ -123,10 +123,10 @@
         </remarks>
       </Docs>
     </Member>
-    <Member MemberName="GetCompliment">
-      <MemberSignature Language="C#" Value="public static System.Drawing.Color GetCompliment (System.Drawing.Color original);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype System.Drawing.Color GetCompliment(valuetype System.Drawing.Color original) cil managed" />
-      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.ColorConverters.GetCompliment(System.Drawing.Color)" />
+    <Member MemberName="GetComplementary">
+      <MemberSignature Language="C#" Value="public static System.Drawing.Color GetComplementary (System.Drawing.Color original);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype System.Drawing.Color GetComplementary(valuetype System.Drawing.Color original) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.ColorConverters.GetComplementary(System.Drawing.Color)" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyName>Xamarin.Essentials</AssemblyName>
@@ -139,9 +139,9 @@
         <Parameter Name="original" Type="System.Drawing.Color" />
       </Parameters>
       <Docs>
-        <param name="original">A color to obtain the compliment for.</param>
+        <param name="original">A color to obtain the complement for.</param>
         <summary>Returns a new color that is on the opposite side of the color wheel from the original.</summary>
-        <returns>A color that is the compliment of the value passed in.</returns>
+        <returns>A color that is the complement of the value passed in.</returns>
         <remarks>
           <para />
         </remarks>


### PR DESCRIPTION
For #1012

### Description of Change ###

Update the name of a method previously added in #970 
Based on [this comment](https://github.com/xamarin/Essentials/pull/970#issuecomment-563155207) it turns out I can't spell.

Updated code, tests, and docs files.

There are no samples for this method.

### Bugs Fixed ###

- Related to issue #1012 

### API Changes ###

List all API changes here (or just put None), example:

Changed:

 - `ColorExtensions.GetCompliment` => `ColorExtensions.GetComplementary`
 

### Behavioral Changes ###

none

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
