### PR TITLE
GH-1004 Cleanup equals in IEquatable so no boxing occurs.

### DIFF
--- a/Xamarin.Essentials/Accelerometer/Accelerometer.shared.cs
+++ b/Xamarin.Essentials/Accelerometer/Accelerometer.shared.cs
@@ -131,10 +131,10 @@ namespace Xamarin.Essentials
             Acceleration.Equals(other.Acceleration);
 
         public static bool operator ==(AccelerometerData left, AccelerometerData right) =>
-            Equals(left, right);
+            left.Equals(right);
 
         public static bool operator !=(AccelerometerData left, AccelerometerData right) =>
-           !Equals(left, right);
+           !left.Equals(right);
 
         public override int GetHashCode() =>
             Acceleration.GetHashCode();

--- a/Xamarin.Essentials/Barometer/Barometer.shared.cs
+++ b/Xamarin.Essentials/Barometer/Barometer.shared.cs
@@ -81,10 +81,10 @@ namespace Xamarin.Essentials
         public double PressureInHectopascals { get; }
 
         public static bool operator ==(BarometerData left, BarometerData right) =>
-            Equals(left, right);
+            left.Equals(right);
 
         public static bool operator !=(BarometerData left, BarometerData right) =>
-            !Equals(left, right);
+            !left.Equals(right);
 
         public override bool Equals(object obj) =>
             (obj is BarometerData data) && Equals(data);

--- a/Xamarin.Essentials/Compass/Compass.shared.cs
+++ b/Xamarin.Essentials/Compass/Compass.shared.cs
@@ -89,10 +89,10 @@ namespace Xamarin.Essentials
             HeadingMagneticNorth.Equals(other.HeadingMagneticNorth);
 
         public static bool operator ==(CompassData left, CompassData right) =>
-            Equals(left, right);
+            left.Equals(right);
 
         public static bool operator !=(CompassData left, CompassData right) =>
-           !Equals(left, right);
+           !left.Equals(right);
 
         public override int GetHashCode() =>
             HeadingMagneticNorth.GetHashCode();

--- a/Xamarin.Essentials/Gyroscope/Gyroscope.shared.cs
+++ b/Xamarin.Essentials/Gyroscope/Gyroscope.shared.cs
@@ -93,10 +93,10 @@ namespace Xamarin.Essentials
             AngularVelocity.Equals(other.AngularVelocity);
 
         public static bool operator ==(GyroscopeData left, GyroscopeData right) =>
-          Equals(left, right);
+          left.Equals(right);
 
         public static bool operator !=(GyroscopeData left, GyroscopeData right) =>
-           !Equals(left, right);
+           !left.Equals(right);
 
         public override int GetHashCode() =>
             AngularVelocity.GetHashCode();

--- a/Xamarin.Essentials/Magnetometer/Magnetometer.shared.cs
+++ b/Xamarin.Essentials/Magnetometer/Magnetometer.shared.cs
@@ -93,10 +93,10 @@ namespace Xamarin.Essentials
             MagneticField.Equals(other.MagneticField);
 
         public static bool operator ==(MagnetometerData left, MagnetometerData right) =>
-            Equals(left, right);
+            left.Equals(right);
 
         public static bool operator !=(MagnetometerData left, MagnetometerData right) =>
-           !Equals(left, right);
+           !left.Equals(right);
 
         public override int GetHashCode() =>
             MagneticField.GetHashCode();

--- a/Xamarin.Essentials/OrientationSensor/OrientationSensor.shared.cs
+++ b/Xamarin.Essentials/OrientationSensor/OrientationSensor.shared.cs
@@ -93,10 +93,10 @@ namespace Xamarin.Essentials
             Orientation.Equals(other.Orientation);
 
         public static bool operator ==(OrientationSensorData left, OrientationSensorData right) =>
-            Equals(left, right);
+            left.Equals(right);
 
         public static bool operator !=(OrientationSensorData left, OrientationSensorData right) =>
-           !Equals(left, right);
+           !left.Equals(right);
 
         public override int GetHashCode() =>
             Orientation.GetHashCode();

--- a/Xamarin.Essentials/Types/DeviceIdiom.shared.cs
+++ b/Xamarin.Essentials/Types/DeviceIdiom.shared.cs
@@ -51,6 +51,6 @@ namespace Xamarin.Essentials
             left.Equals(right);
 
         public static bool operator !=(DeviceIdiom left, DeviceIdiom right) =>
-            !(left == right);
+            !left.Equals(right);
     }
 }

--- a/Xamarin.Essentials/Types/DevicePlatform.shared.cs
+++ b/Xamarin.Essentials/Types/DevicePlatform.shared.cs
@@ -53,6 +53,6 @@ namespace Xamarin.Essentials
             left.Equals(right);
 
         public static bool operator !=(DevicePlatform left, DevicePlatform right) =>
-            !(left == right);
+            !left.Equals(right);
     }
 }

--- a/Xamarin.Essentials/Types/DisplayInfo.shared.cs
+++ b/Xamarin.Essentials/Types/DisplayInfo.shared.cs
@@ -25,10 +25,10 @@ namespace Xamarin.Essentials
         public DisplayRotation Rotation { get; }
 
         public static bool operator ==(DisplayInfo left, DisplayInfo right) =>
-            Equals(left, right);
+            left.Equals(right);
 
         public static bool operator !=(DisplayInfo left, DisplayInfo right) =>
-            !Equals(left, right);
+            !left.Equals(right);
 
         public override bool Equals(object obj) =>
             (obj is DisplayInfo metrics) && Equals(metrics);


### PR DESCRIPTION
### Description of Change ###

Fix boxing on structs

### Bugs Fixed ###

- Related to issue #1004

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
