### PR TITLE
GH-1020 - Fix issue with checking mainthread to early on UWP.

### DIFF
--- a/Samples/Samples.UWP/App.xaml.cs
+++ b/Samples/Samples.UWP/App.xaml.cs
@@ -4,6 +4,7 @@ using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
+using Xamarin.Essentials;
 
 namespace Samples.UWP
 {
@@ -13,6 +14,13 @@ namespace Samples.UWP
         {
             InitializeComponent();
             Suspending += OnSuspending;
+
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                Console.WriteLine("Success!");
+            });
+
+            var test = DeviceInfo.DeviceType;
         }
 
         protected override void OnLaunched(LaunchActivatedEventArgs e)

--- a/Xamarin.Essentials/MainThread/MainThread.uwp.cs
+++ b/Xamarin.Essentials/MainThread/MainThread.uwp.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
 
@@ -13,8 +14,16 @@ namespace Xamarin.Essentials
                 // if there is no main window, then this is either a service
                 // or the UI is not yet constructed, so the main thread is the
                 // current thread
-                if (CoreApplication.MainView?.CoreWindow == null)
+                try
+                {
+                    if (CoreApplication.MainView?.CoreWindow == null)
+                        return true;
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Unable to validate MainView creation. {ex.Message}");
                     return true;
+                }
 
                 return CoreApplication.MainView.CoreWindow.Dispatcher?.HasThreadAccess ?? false;
             }


### PR DESCRIPTION
### Description of Change ###

Even though we check for null it is possible that this check will throw an exception :(

### Bugs Fixed ###

- Related to issue #1020


### API Changes ###

None


### Behavioral Changes ###

Com exception wont be thrown 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
