### PR TITLE
bugfix for OrientationSensor on iOS

### DIFF
--- a/Xamarin.Essentials/OrientationSensor/OrientationSensor.ios.watchos.cs
+++ b/Xamarin.Essentials/OrientationSensor/OrientationSensor.ios.watchos.cs
@@ -26,12 +26,16 @@ namespace Xamarin.Essentials
 
             var field = data.Attitude.Quaternion;
 
-            // the quaternion returned by the MotionManager refers to a frame where the X axis points north
+            // the quaternion returned by the MotionManager refers to a frame where the X axis points north ("iOS frame")
             var q = new Quaternion((float)field.x, (float)field.y, (float)field.z, (float)field.w);
 
-            // we rotate it by 90 degrees around the Z axis, so that the Y axis points north and the X axis points east
+            // in Xamarin, the reference frame is defined such that Y points north and Z is vertical,
+            // so we first rotate by 90 degrees around the Z axis, in order to get from the Xamarin frame to the iOS frame
             var qz90 = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)(Math.PI / 2.0));
-            q = Quaternion.Multiply(q, qz90);
+
+            // on top of this rotation, we apply the actual quaternion obtained from the MotionManager,
+            // so that the final quaternion will take us from the earth frame in Xamarin convention to the phone frame
+            q = Quaternion.Multiply(qz90, q);
             var rotationData = new OrientationSensorData(q.X, q.Y, q.Z, q.W);
             OnChanged(rotationData);
         }


### PR DESCRIPTION
### Description of Change ###

* this is a fix-up for commit 84579595f36a008e172824aa41269596d83d167c
* quaternions are not commutative, and the original commit had the multiplication in the wrong order
* it worked for some special cases, but not in general

### Bugs Fixed ###

- Related to issue #981

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
