### PR TITLE
Dev/file picker fix android

### DIFF
--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Essentials
         {
             // we only need the permission when accessing the file, but it's more natural
             // to ask the user first, then show the picker.
-            await Permissions.RequireAsync(PermissionType.ReadExternalStorage);
+            Permissions.EnsureDeclared<Permissions.StorageRead>();
 
             var intent = new Intent(Intent.ActionGetContent);
             intent.SetType("*/*");
@@ -67,18 +67,9 @@ namespace Xamarin.Essentials
 
         readonly global::Android.Net.Uri contentUri;
 
+        // Basically with android 10, its highly discouraged to get the path. Work with the URI.
         static string GetFullPath(global::Android.Net.Uri contentUri)
         {
-            // if this is a file, use that
-            if (contentUri.Scheme == "file")
-                return contentUri.Path;
-
-            // ask the content provider for the data column, which may contain the actual file path
-            var path = QueryContentResolverColumn(contentUri, MediaStore.Files.FileColumns.Data);
-            if (!string.IsNullOrEmpty(path) && Path.IsPathRooted(path))
-                return path;
-
-            // fallback: use content URI
             return contentUri.ToString();
         }
 

--- a/Xamarin.Essentials/Permissions/Permissions.shared.enums.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.enums.cs
@@ -17,4 +17,19 @@
         // Restricted (only iOS)
         Restricted = 4
     }
+
+    enum PermissionType
+    {
+        Unknown,
+        Battery,
+        Camera,
+        Flashlight,
+        LaunchApp,
+        LocationWhenInUse,
+        Maps,
+        NetworkState,
+        Vibrate,
+        WriteExternalStorage,
+        ReadExternalStorage,
+    }
 }


### PR DESCRIPTION
### Description of Change ###
Due to some code loss from a previous merge, I re-added android permissions, and fixed the implementation. Since "Data" is obsolete, I've just returned the URI as path since Android10 doesn't like paths anymore xD

### Behavioral Changes ###

Android will return the original URI for GetPath. This might be wrong, but it appears that is the direction android wants anyways.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))

I don't think I need to make a test for this or update documentation... I've tested this on an android phone (9.0)