### PR TITLE
Fixes #1066 Need to cache locationmanager or dialog dissapears

### DIFF
--- a/Xamarin.Essentials/Permissions/Permissions.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.ios.tvos.watchos.cs
@@ -125,9 +125,11 @@ namespace Xamarin.Essentials
                 };
             }
 
+            static CLLocationManager locationManager;
+
             internal static Task<PermissionStatus> RequestLocationAsync(bool whenInUse, Action<CLLocationManager> invokeRequest)
             {
-                var locationManager = new CLLocationManager();
+                locationManager = new CLLocationManager();
 
                 var tcs = new TaskCompletionSource<PermissionStatus>(locationManager);
 
@@ -155,6 +157,8 @@ namespace Xamarin.Essentials
                                 {
                                     locationManager.AuthorizationChanged -= LocationAuthCallback;
                                     tcs.TrySetResult(GetLocationStatus(whenInUse));
+                                    locationManager.Dispose();
+                                    locationManager = null;
                                 }
                             });
                             return;
@@ -164,6 +168,8 @@ namespace Xamarin.Essentials
                     locationManager.AuthorizationChanged -= LocationAuthCallback;
 
                     tcs.TrySetResult(GetLocationStatus(whenInUse));
+                    locationManager.Dispose();
+                    locationManager = null;
                 }
             }
         }


### PR DESCRIPTION
### Description of Change ###

Must cache location manager: https://stackoverflow.com/questions/7888896/current-location-permission-dialog-disappears-too-quickly/8170382

Clean it up when doen. 

### Bugs Fixed ###

- Related to issue #1066

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###
None

### Behavioral Changes ###

Else dialog disappears :(

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
