### PR TITLE
Tiny allocation optimization

### DIFF
--- a/Xamarin.Essentials/Battery/Battery.shared.cs
+++ b/Xamarin.Essentials/Battery/Battery.shared.cs
@@ -145,7 +145,7 @@ namespace Xamarin.Essentials
         public BatteryPowerSource PowerSource { get; }
 
         public override string ToString() =>
-            $"{nameof(ChargeLevel)}: {ChargeLevel}, " +
+            $"{nameof(ChargeLevel)}: {ChargeLevel.ToString()}, " +
             $"{nameof(State)}: {State}, " +
             $"{nameof(PowerSource)}: {PowerSource}";
     }


### PR DESCRIPTION
### Description of Change ###
This double is not in the interning list of doubles(infinity, neg infinity,+0, -0 etc.), so this will allocate less. Verified in Benchmark.Net for random doubles assigned from int values 1-100
### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
