### PR TITLE
Implement vertical accuracy in GeoLocation API

### DIFF
--- a/Samples/Samples/ViewModel/GeolocationViewModel.cs
+++ b/Samples/Samples/ViewModel/GeolocationViewModel.cs
@@ -98,8 +98,9 @@ namespace Samples.ViewModel
             return
                 $"Latitude: {location.Latitude}\n" +
                 $"Longitude: {location.Longitude}\n" +
-                $"Accuracy: {location.Accuracy}\n" +
+                $"HorizontalAccuracy: {location.Accuracy}\n" +
                 $"Altitude: {(location.Altitude.HasValue ? location.Altitude.Value.ToString() : notAvailable)}\n" +
+                $"VerticalAccuracy: {(location.VerticalAccuracy.HasValue ? location.VerticalAccuracy.Value.ToString() : notAvailable)}\n" +
                 $"Heading: {(location.Course.HasValue ? location.Course.Value.ToString() : notAvailable)}\n" +
                 $"Speed: {(location.Speed.HasValue ? location.Speed.Value.ToString() : notAvailable)}\n" +
                 $"Date (UTC): {location.Timestamp:d}\n" +

--- a/Xamarin.Essentials/Types/Location.shared.cs
+++ b/Xamarin.Essentials/Types/Location.shared.cs
@@ -52,6 +52,8 @@ namespace Xamarin.Essentials
 
         public double? Accuracy { get; set; }
 
+        public double? VerticalAccuracy { get; set; }
+
         public double? Speed { get; set; }
 
         public double? Course { get; set; }
@@ -88,6 +90,7 @@ namespace Xamarin.Essentials
         public override string ToString() =>
             $"{nameof(Latitude)}: {Latitude}, {nameof(Longitude)}: {Longitude}, " +
             $"{nameof(Altitude)}: {Altitude ?? 0}, {nameof(Accuracy)}: {Accuracy ?? 0}, " +
+            $"{nameof(VerticalAccuracy)}: {VerticalAccuracy ?? 0}, " +
             $"{nameof(Speed)}: {Speed ?? 0}, {nameof(Course)}: {Course ?? 0}, " +
             $"{nameof(Timestamp)}: {Timestamp}";
     }

--- a/Xamarin.Essentials/Types/LocationExtensions.android.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.android.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Essentials
                 Altitude = location.HasAltitude ? location.Altitude : default(double?),
                 Timestamp = location.GetTimestamp().ToUniversalTime(),
                 Accuracy = location.HasAccuracy ? location.Accuracy : default(float?),
+                VerticalAccuracy = location.HasVerticalAccuracy ? location.VerticalAccuracyMeters : default(float?),
                 Course = location.HasBearing ? location.Bearing : default(double?),
                 Speed = location.HasSpeed ? location.Speed : default(double?),
                 IsFromMockProvider = Platform.HasApiLevel(global::Android.OS.BuildVersionCodes.JellyBeanMr2) ? location.IsFromMockProvider : false

--- a/Xamarin.Essentials/Types/LocationExtensions.android.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.android.cs
@@ -28,7 +28,12 @@ namespace Xamarin.Essentials
                 Altitude = location.HasAltitude ? location.Altitude : default(double?),
                 Timestamp = location.GetTimestamp().ToUniversalTime(),
                 Accuracy = location.HasAccuracy ? location.Accuracy : default(float?),
-                VerticalAccuracy = location.HasVerticalAccuracy ? location.VerticalAccuracyMeters : default(float?),
+                VerticalAccuracy =
+#if __ANDROID_26__
+                    location.HasVerticalAccuracy ? location.VerticalAccuracyMeters : default(float?),
+#else
+                    default(float?),
+#endif
                 Course = location.HasBearing ? location.Bearing : default(double?),
                 Speed = location.HasSpeed ? location.Speed : default(double?),
                 IsFromMockProvider = Platform.HasApiLevel(global::Android.OS.BuildVersionCodes.JellyBeanMr2) ? location.IsFromMockProvider : false

--- a/Xamarin.Essentials/Types/LocationExtensions.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.ios.tvos.watchos.cs
@@ -27,6 +27,7 @@ namespace Xamarin.Essentials
                 Longitude = location.Coordinate.Longitude,
                 Altitude = location.VerticalAccuracy < 0 ? default(double?) : location.Altitude,
                 Accuracy = location.HorizontalAccuracy,
+                VerticalAccuracy = location.VerticalAccuracy,
                 Timestamp = location.Timestamp.ToDateTime(),
 #if __iOS__ || __WATCHOS__
                 Course = location.Course < 0 ? default(double?) : location.Course,

--- a/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
@@ -31,6 +31,7 @@ namespace Xamarin.Essentials
                 Timestamp = location.Coordinate.Timestamp,
                 Altitude = location.Coordinate.Point.Position.Altitude,
                 Accuracy = location.Coordinate.Accuracy,
+                VerticalAccuracy = location.Coordinate.AltitudeAccuracy,
                 Speed = (!location.Coordinate.Speed.HasValue || double.IsNaN(location.Coordinate.Speed.Value)) ? default : location.Coordinate.Speed,
                 Course = (!location.Coordinate.Heading.HasValue || double.IsNaN(location.Coordinate.Heading.Value)) ? default : location.Coordinate.Heading,
                 IsFromMockProvider = false
@@ -44,6 +45,7 @@ namespace Xamarin.Essentials
                  Timestamp = coordinate.Timestamp,
                  Altitude = coordinate.Point.Position.Altitude,
                  Accuracy = coordinate.Accuracy,
+                 VerticalAccuracy = coordinate.AltitudeAccuracy,
                  Speed = (!coordinate.Speed.HasValue || double.IsNaN(coordinate.Speed.Value)) ? default : coordinate.Speed,
                  Course = (!coordinate.Heading.HasValue || double.IsNaN(coordinate.Heading.Value)) ? default : coordinate.Heading
              };

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -437,6 +437,7 @@
       <Member Id="P:Xamarin.Essentials.Location.Longitude" />
       <Member Id="P:Xamarin.Essentials.Location.Speed" />
       <Member Id="P:Xamarin.Essentials.Location.Timestamp" />
+      <Member Id="P:Xamarin.Essentials.Location.VerticalAccuracy" />
     </Type>
     <Type Name="Xamarin.Essentials.LocationExtensions" Id="T:Xamarin.Essentials.LocationExtensions">
       <Member Id="M:Xamarin.Essentials.LocationExtensions.CalculateDistance(Xamarin.Essentials.Location,System.Double,System.Double,Xamarin.Essentials.DistanceUnits)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -416,6 +416,7 @@
       <Member Id="P:Xamarin.Essentials.Location.Longitude" />
       <Member Id="P:Xamarin.Essentials.Location.Speed" />
       <Member Id="P:Xamarin.Essentials.Location.Timestamp" />
+      <Member Id="P:Xamarin.Essentials.Location.VerticalAccuracy" />
     </Type>
     <Type Name="Xamarin.Essentials.LocationExtensions" Id="T:Xamarin.Essentials.LocationExtensions">
       <Member Id="M:Xamarin.Essentials.LocationExtensions.CalculateDistance(Xamarin.Essentials.Location,System.Double,System.Double,Xamarin.Essentials.DistanceUnits)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
@@ -415,6 +415,7 @@
       <Member Id="P:Xamarin.Essentials.Location.Longitude" />
       <Member Id="P:Xamarin.Essentials.Location.Speed" />
       <Member Id="P:Xamarin.Essentials.Location.Timestamp" />
+      <Member Id="P:Xamarin.Essentials.Location.VerticalAccuracy" />
     </Type>
     <Type Name="Xamarin.Essentials.LocationExtensions" Id="T:Xamarin.Essentials.LocationExtensions">
       <Member Id="M:Xamarin.Essentials.LocationExtensions.CalculateDistance(Xamarin.Essentials.Location,System.Double,System.Double,Xamarin.Essentials.DistanceUnits)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -415,6 +415,7 @@
       <Member Id="P:Xamarin.Essentials.Location.Longitude" />
       <Member Id="P:Xamarin.Essentials.Location.Speed" />
       <Member Id="P:Xamarin.Essentials.Location.Timestamp" />
+      <Member Id="P:Xamarin.Essentials.Location.VerticalAccuracy" />
     </Type>
     <Type Name="Xamarin.Essentials.LocationExtensions" Id="T:Xamarin.Essentials.LocationExtensions">
       <Member Id="M:Xamarin.Essentials.LocationExtensions.CalculateDistance(Xamarin.Essentials.Location,System.Double,System.Double,Xamarin.Essentials.DistanceUnits)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
@@ -415,6 +415,7 @@
       <Member Id="P:Xamarin.Essentials.Location.Longitude" />
       <Member Id="P:Xamarin.Essentials.Location.Speed" />
       <Member Id="P:Xamarin.Essentials.Location.Timestamp" />
+      <Member Id="P:Xamarin.Essentials.Location.VerticalAccuracy" />
     </Type>
     <Type Name="Xamarin.Essentials.LocationExtensions" Id="T:Xamarin.Essentials.LocationExtensions">
       <Member Id="M:Xamarin.Essentials.LocationExtensions.CalculateDistance(Xamarin.Essentials.Location,System.Double,System.Double,Xamarin.Essentials.DistanceUnits)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -414,6 +414,7 @@
       <Member Id="P:Xamarin.Essentials.Location.Longitude" />
       <Member Id="P:Xamarin.Essentials.Location.Speed" />
       <Member Id="P:Xamarin.Essentials.Location.Timestamp" />
+      <Member Id="P:Xamarin.Essentials.Location.VerticalAccuracy" />
     </Type>
     <Type Name="Xamarin.Essentials.LocationExtensions" Id="T:Xamarin.Essentials.LocationExtensions">
       <Member Id="M:Xamarin.Essentials.LocationExtensions.CalculateDistance(Xamarin.Essentials.Location,System.Double,System.Double,Xamarin.Essentials.DistanceUnits)" />

--- a/docs/en/Xamarin.Essentials/Location.xml
+++ b/docs/en/Xamarin.Essentials/Location.xml
@@ -113,8 +113,8 @@
         <ReturnType>System.Nullable&lt;System.Double&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets the accuracy (in meters) of the location.</summary>
-        <value>The location accuracy.</value>
+        <summary>Gets or sets the horizontal accuracy (in meters) of the location.</summary>
+        <value>The horizontal accuracy of the location.</value>
         <remarks>
           <para />
         </remarks>
@@ -395,6 +395,26 @@
         <summary>A string representation of the location.</summary>
         <returns>A string representation of the location.</returns>
         <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="VerticalAccuracy">
+      <MemberSignature Language="C#" Value="public Nullable&lt;double&gt; VerticalAccuracy { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype System.Nullable`1&lt;float64&gt; VerticalAccuracy" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.Location.VerticalAccuracy" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Nullable&lt;System.Double&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets the vertical accuracy (in meters) of the location.</summary>
+        <value>The vertical accuracy of the location.</value>
+        <remarks>
+          <para />
+        </remarks>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
### Description of Change ###

This extends the GeoLocation API to provide the vertical accuracy.

### Bugs Fixed ###

- Related to issue #1099


### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `double? Location.VerticalAccuracy { get; set; }`

Changed:

 - None
 

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
