### PR TITLE
.gitattributes: get better diff context for C# code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,7 @@
 # default for csharp files.
 # Note: This is only used by command line
 ###############################################################################
-#*.cs     diff=csharp
+*.cs     diff=csharp
 
 ###############################################################################
 # Set the merge driver for project and solution files


### PR DESCRIPTION
### Description of Change ###

This PR simply uncomments one line in the gitattributes file, giving me better diff context in hunk headers.

Background: When looking at commit diffs (at the command line or via tools like gitk), one currently gets rather bad context indicators in the hunk headers for C# code (usually the enclosing namespace). With this change, the situation improves a lot, and one gets the correct context (class or function name). Not sure why this is commented out in the first place.
