### PR TITLE
Location.VerticalAccuracy: add runtime check for Android version

### DIFF
--- a/Xamarin.Essentials/Types/LocationExtensions.android.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.android.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Essentials
                 Accuracy = location.HasAccuracy ? location.Accuracy : default(float?),
                 VerticalAccuracy =
 #if __ANDROID_26__
-                    location.HasVerticalAccuracy ? location.VerticalAccuracyMeters : default(float?),
+                    Platform.HasApiLevelO && location.HasVerticalAccuracy ? location.VerticalAccuracyMeters : default(float?),
 #else
                     default(float?),
 #endif


### PR DESCRIPTION
### Description of Change ###

* the compile-time check is not enough
* it crashed on old Android versions (<8.0)

### Bugs Fixed ###

- Related to issue #1099 

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
