### PR TITLE
Fixes #1129 - set empty required declarations on UWP

### DIFF
--- a/Xamarin.Essentials/Permissions/Permissions.uwp.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.uwp.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Essentials
 
         public abstract partial class BasePlatformPermission : BasePermission
         {
-            protected virtual Func<IEnumerable<string>> RequiredDeclarations { get; }
+            protected virtual Func<IEnumerable<string>> RequiredDeclarations { get; } = () => new string[] { };
 
             public override Task<PermissionStatus> CheckStatusAsync()
             {

--- a/Xamarin.Essentials/Permissions/Permissions.uwp.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.uwp.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Essentials
 
         public abstract partial class BasePlatformPermission : BasePermission
         {
-            protected virtual Func<IEnumerable<string>> RequiredDeclarations { get; } = () => new string[] { };
+            protected virtual Func<IEnumerable<string>> RequiredDeclarations { get; } = () => Array.Empty<string>();
 
             public override Task<PermissionStatus> CheckStatusAsync()
             {


### PR DESCRIPTION
### Description of Change ###

We need to set a empty array else we get an exception

### Bugs Fixed ###

- Related to issue #1129

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.


### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
