### PR TITLE
Fixes #1128 - use new empty rectangle for VS 2017

### DIFF
--- a/Samples/Samples/ViewModel/ShareViewModel.cs
+++ b/Samples/Samples/ViewModel/ShareViewModel.cs
@@ -107,7 +107,7 @@ namespace Samples.ViewModel
                     File = new ShareFile(file),
                     PresentationSourceBounds = Device.RuntimePlatform == Device.iOS && Device.Idiom == TargetIdiom.Tablet
                                             ? new System.Drawing.Rectangle(0, 20, 0, 0)
-                                            : System.Drawing.Rectangle.Empty
+                                            : new System.Drawing.Rectangle(0, 0, 0, 0)
                 });
             }
         }

--- a/Xamarin.Essentials/Share/Share.ios.cs
+++ b/Xamarin.Essentials/Share/Share.ios.cs
@@ -8,6 +8,8 @@ namespace Xamarin.Essentials
 {
     public static partial class Share
     {
+        static Rectangle emptyRect = new Rectangle(0, 0, 0, 0);
+
         static Task PlatformRequestAsync(ShareTextRequest request)
         {
             var items = new List<NSObject>();
@@ -29,7 +31,7 @@ namespace Xamarin.Essentials
             {
                 activityController.PopoverPresentationController.SourceView = vc.View;
 
-                if (request.PresentationSourceBounds != Rectangle.Empty)
+                if (request.PresentationSourceBounds != emptyRect)
                     activityController.PopoverPresentationController.SourceRect = request.PresentationSourceBounds.ToPlatformRectangle();
             }
 
@@ -54,7 +56,7 @@ namespace Xamarin.Essentials
             {
                 activityController.PopoverPresentationController.SourceView = vc.View;
 
-                if (request.PresentationSourceBounds != Rectangle.Empty)
+                if (request.PresentationSourceBounds != emptyRect)
                     activityController.PopoverPresentationController.SourceRect = request.PresentationSourceBounds.ToPlatformRectangle();
             }
 

--- a/Xamarin.Essentials/Share/Share.ios.cs
+++ b/Xamarin.Essentials/Share/Share.ios.cs
@@ -8,8 +8,6 @@ namespace Xamarin.Essentials
 {
     public static partial class Share
     {
-        static Rectangle emptyRect = new Rectangle(0, 0, 0, 0);
-
         static Task PlatformRequestAsync(ShareTextRequest request)
         {
             var items = new List<NSObject>();
@@ -31,8 +29,8 @@ namespace Xamarin.Essentials
             {
                 activityController.PopoverPresentationController.SourceView = vc.View;
 
-                if (request.PresentationSourceBounds != emptyRect)
-                    activityController.PopoverPresentationController.SourceRect = request.PresentationSourceBounds.ToPlatformRectangle();
+                if (request.PresentationSourcePoint != Point.Empty && request.PresentationSourceSize != Size.Empty)
+                    activityController.PopoverPresentationController.SourceRect = new CoreGraphics.CGRect(request.PresentationSourcePoint.ToPlatformPoint(), request.PresentationSourceSize.ToPlatformSize());
             }
 
             return vc.PresentViewControllerAsync(activityController, true);
@@ -56,8 +54,8 @@ namespace Xamarin.Essentials
             {
                 activityController.PopoverPresentationController.SourceView = vc.View;
 
-                if (request.PresentationSourceBounds != emptyRect)
-                    activityController.PopoverPresentationController.SourceRect = request.PresentationSourceBounds.ToPlatformRectangle();
+                if (request.PresentationSourcePoint != Point.Empty && request.PresentationSourceSize != Size.Empty)
+                    activityController.PopoverPresentationController.SourceRect = new CoreGraphics.CGRect(request.PresentationSourcePoint.ToPlatformPoint(), request.PresentationSourceSize.ToPlatformSize());
             }
 
             return vc.PresentViewControllerAsync(activityController, true);

--- a/Xamarin.Essentials/Share/Share.shared.cs
+++ b/Xamarin.Essentials/Share/Share.shared.cs
@@ -28,8 +28,10 @@ namespace Xamarin.Essentials
     {
         public string Title { get; set; }
 
-#if !NETSTANDARD1_0 && !__ANDROID__
-        public Rectangle PresentationSourceBounds { get; set; } = new Rectangle(0, 0, 0, 0);
+#if !NETSTANDARD1_0
+        public Size PresentationSourceSize { get; set; } = Size.Empty;
+
+        public Point PresentationSourcePoint { get; set; } = Point.Empty;
 #endif
     }
 

--- a/Xamarin.Essentials/Share/Share.shared.cs
+++ b/Xamarin.Essentials/Share/Share.shared.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Essentials
         public string Title { get; set; }
 
 #if !NETSTANDARD1_0
-        public Rectangle PresentationSourceBounds { get; set; } = Rectangle.Empty;
+        public Rectangle PresentationSourceBounds { get; set; } = new Rectangle(0, 0, 0, 0);
 #endif
     }
 

--- a/Xamarin.Essentials/Share/Share.shared.cs
+++ b/Xamarin.Essentials/Share/Share.shared.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Essentials
     {
         public string Title { get; set; }
 
-#if !NETSTANDARD1_0
+#if !NETSTANDARD1_0 && !__ANDROID__
         public Rectangle PresentationSourceBounds { get; set; } = new Rectangle(0, 0, 0, 0);
 #endif
     }


### PR DESCRIPTION
for some reason VS 2017 has Rectangle.Zero and not Rectangle.Empty, sad

### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #1128

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.




### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
