### PR TITLE
Fix FilePicker permissions check

### DIFF
--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Essentials
         {
             // we only need the permission when accessing the file, but it's more natural
             // to ask the user first, then show the picker.
-            await Permissions.RequireAsync(PermissionType.ReadExternalStorage);
+            await Permissions.RequestAsync<Permissions.StorageRead>();
 
             var intent = new Intent(Intent.ActionGetContent);
             intent.SetType("*/*");

--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -74,7 +74,10 @@ namespace Xamarin.Essentials
                 return contentUri.Path;
 
             // ask the content provider for the data column, which may contain the actual file path
+#pragma warning disable CS0618 // Type or member is obsolete
             var path = QueryContentResolverColumn(contentUri, MediaStore.Files.FileColumns.Data);
+#pragma warning restore CS0618 // Type or member is obsolete
+
             if (!string.IsNullOrEmpty(path) && Path.IsPathRooted(path))
                 return path;
 


### PR DESCRIPTION
### Description of Change ###

This is a continuation of PR #975 where all of the commits were merged to the dev/file-picker branch. There are some compiler errors in this branch, which this PR should fix. My hope is that we can continue working on the FilePicker then and finally bring this feature to a close.

### Bugs Fixed ###

- Related to issue #975, #790, #613, #986 and #251

### API Changes ###

None.

### Behavioral Changes ###

None
### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
