### PR TITLE
GH-1142 AccessBackgroundLocation only when compile & running Q

### DIFF
--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -229,9 +229,10 @@ namespace Xamarin.Essentials
                 get
                 {
                     var permissions = new List<(string, bool)>();
-
+#if __ANDROID_29__
                     if (Platform.HasApiLevelQ)
                         permissions.Add((Manifest.Permission.AccessBackgroundLocation, true));
+#endif
 
                     permissions.Add((Manifest.Permission.AccessCoarseLocation, true));
                     permissions.Add((Manifest.Permission.AccessFineLocation, true));

--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -224,15 +224,21 @@ namespace Xamarin.Essentials
 
         public partial class LocationAlways : BasePlatformPermission
         {
-            public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
-                new (string, bool)[]
+            public override (string androidPermission, bool isRuntime)[] RequiredPermissions
+            {
+                get
                 {
-#if __ANDROID_29__
-                    (Manifest.Permission.AccessBackgroundLocation, true),
-#endif
-                    (Manifest.Permission.AccessCoarseLocation, true),
-                    (Manifest.Permission.AccessFineLocation, true)
-                };
+                    var permissions = new List<(string, bool)>();
+
+                    if (Platform.HasApiLevelQ)
+                        permissions.Add((Manifest.Permission.AccessBackgroundLocation, true));
+
+                    permissions.Add((Manifest.Permission.AccessCoarseLocation, true));
+                    permissions.Add((Manifest.Permission.AccessFineLocation, true));
+
+                    return permissions.ToArray();
+                }
+            }
         }
 
         public partial class Maps : BasePlatformPermission

--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -173,6 +173,13 @@ namespace Xamarin.Essentials
             false;
 #endif
 
+        internal static bool HasApiLevelQ =>
+#if __ANDROID_29__
+            HasApiLevel(BuildVersionCodes.Q);
+#else
+            false;
+#endif
+
         internal static bool HasApiLevel(BuildVersionCodes versionCode) =>
             (int)Build.VERSION.SdkInt >= (int)versionCode;
 


### PR DESCRIPTION
### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #1142

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

Added Q Check and use it instead of just compile check

### Behavioral Changes ###

Now should validate background permissions too.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
