### PR TITLE
FilePicker picking multiple files

### DIFF
--- a/Samples/Samples/View/FilePickerPage.xaml
+++ b/Samples/Samples/View/FilePickerPage.xaml
@@ -11,13 +11,13 @@
     <StackLayout Padding="12" Spacing="6">
         <Label Text="Pick files from storage." FontAttributes="Bold" />
 
-        <StackLayout Orientation="Horizontal" Spacing="6">
+        <FlexLayout Direction="Row" Wrap="Wrap">
             <Button Text="Pick file" Command="{Binding PickFileCommand}" HorizontalOptions="FillAndExpand" />
             <Button Text="Pick image" Command="{Binding PickImageCommand}" HorizontalOptions="FillAndExpand" />
             <Button Text="Pick custom type" Command="{Binding PickCustomTypeCommand}" HorizontalOptions="FillAndExpand" />
-        </StackLayout>
-
-        <Button Text="Pick image and send email" Command="{Binding PickAndSendCommand}" />
+            <Button Text="Pick image and send email" Command="{Binding PickAndSendCommand}" HorizontalOptions="FillAndExpand" />
+            <Button Text="Pick multiple files" Command="{Binding PickMultipleFilesCommand}" HorizontalOptions="FillAndExpand" />
+        </FlexLayout>
 
         <Label Text="{Binding Text}" HorizontalOptions="FillAndExpand" />
 

--- a/Samples/Samples/ViewModel/FilePickerViewModel.cs
+++ b/Samples/Samples/ViewModel/FilePickerViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Xamarin.Essentials;
@@ -20,6 +21,7 @@ namespace Samples.ViewModel
             PickImageCommand = new Command(() => DoPickImage());
             PickCustomTypeCommand = new Command(() => DoPickCustomType());
             PickAndSendCommand = new Command(() => DoPickAndSend());
+            PickMultipleFilesCommand = new Command(() => DoPickMultipleFiles());
         }
 
         public ICommand PickFileCommand { get; }
@@ -29,6 +31,8 @@ namespace Samples.ViewModel
         public ICommand PickCustomTypeCommand { get; }
 
         public ICommand PickAndSendCommand { get; }
+
+        public ICommand PickMultipleFilesCommand { get; }
 
         public string Text
         {
@@ -143,6 +147,44 @@ namespace Samples.ViewModel
                 Text = ex.ToString();
                 IsImageVisible = false;
                 return null;
+            }
+        }
+
+        async void DoPickMultipleFiles()
+        {
+            try
+            {
+                var options = PickOptions.Default;
+                var resultList = await FilePicker.PickMultipleFilesAsync(options);
+
+                if (resultList != null && resultList.Any())
+                {
+                    Text = "File Names: " + string.Join(", ", resultList.Select(result => result.FileName));
+
+                    // only showing the first file's content
+                    var firstResult = resultList.First();
+
+                    if (firstResult.FileName.EndsWith("jpg", StringComparison.OrdinalIgnoreCase) ||
+                        firstResult.FileName.EndsWith("png", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var stream = await firstResult.OpenReadStreamAsync();
+                        Image = ImageSource.FromStream(() => stream);
+                        IsImageVisible = true;
+                    }
+                    else
+                    {
+                        IsImageVisible = false;
+                    }
+                }
+                else
+                {
+                    Text = $"Pick cancelled.";
+                }
+            }
+            catch (Exception ex)
+            {
+                Text = ex.ToString();
+                IsImageVisible = false;
             }
         }
     }

--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Essentials
         {
             // we only need the permission when accessing the file, but it's more natural
             // to ask the user first, then show the picker.
-            await Permissions.RequireAsync(PermissionType.ReadExternalStorage);
+            await Permissions.RequestAsync<Permissions.StorageRead>();
 
             var intent = new Intent(Intent.ActionGetContent);
             intent.SetType("*/*");

--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -74,7 +74,10 @@ namespace Xamarin.Essentials
                 return contentUri.Path;
 
             // ask the content provider for the data column, which may contain the actual file path
+#pragma warning disable CS0618 // Type or member is obsolete
             var path = QueryContentResolverColumn(contentUri, MediaStore.Files.FileColumns.Data);
+#pragma warning restore CS0618 // Type or member is obsolete
+
             if (!string.IsNullOrEmpty(path) && Path.IsPathRooted(path))
                 return path;
 

--- a/Xamarin.Essentials/FilePicker/FilePicker.netstandard.watchos.tvos.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.netstandard.watchos.tvos.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Xamarin.Essentials
@@ -6,6 +7,9 @@ namespace Xamarin.Essentials
     public static partial class FilePicker
     {
         static Task<FilePickerResult> PlatformPickFileAsync(PickOptions options)
+            => throw new NotImplementedInReferenceAssemblyException();
+
+        static Task<IEnumerable<FilePickerResult>> PlatformPickMultipleFilesAsync(PickOptions options)
             => throw new NotImplementedInReferenceAssemblyException();
     }
 

--- a/Xamarin.Essentials/FilePicker/FilePicker.shared.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.shared.cs
@@ -12,6 +12,9 @@ namespace Xamarin.Essentials
 
         public static Task<FilePickerResult> PickFileAsync(PickOptions options) =>
             PlatformPickFileAsync(options ?? PickOptions.Default);
+
+        public static Task<IEnumerable<FilePickerResult>> PickMultipleFilesAsync(PickOptions options) =>
+            PlatformPickMultipleFilesAsync(options ?? PickOptions.Default);
     }
 
     public partial class FilePickerFileType

--- a/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
@@ -45,6 +45,9 @@ namespace Xamarin.Essentials
             });
             return tcs.Task;
         }
+
+        static Task<IEnumerable<FilePickerResult>> PlatformPickMultipleFilesAsync(PickOptions options)
+            => throw new NotImplementedInReferenceAssemblyException();
     }
 
     public partial class FilePickerFileType

--- a/Xamarin.Essentials/FilePicker/FilePicker.uwp.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.uwp.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.Storage.AccessCache;
@@ -27,6 +28,26 @@ namespace Xamarin.Essentials
             StorageApplicationPermissions.FutureAccessList.Add(file);
 
             return new FilePickerResult(file);
+        }
+
+        static async Task<IEnumerable<FilePickerResult>> PlatformPickMultipleFilesAsync(PickOptions options)
+        {
+            var picker = new FileOpenPicker
+            {
+                ViewMode = PickerViewMode.List,
+                SuggestedStartLocation = PickerLocationId.DocumentsLibrary
+            };
+
+            SetFileTypes(options, picker);
+
+            var fileList = await picker.PickMultipleFilesAsync();
+            if (fileList == null)
+                return Enumerable.Empty<FilePickerResult>();
+
+            foreach (var file in fileList)
+                StorageApplicationPermissions.FutureAccessList.Add(file);
+
+            return fileList.Select((storageFile) => new FilePickerResult(storageFile));
         }
 
         static void SetFileTypes(PickOptions options, FileOpenPicker picker)


### PR DESCRIPTION
### Description of Change ###

Based on PR #1137, #975 and some more PRs I implemented multiple file picking, for Android, iOS and UWP. Tizen implementation is missing at the moment. Multiple file picking works from Android 4.3 and iOS 11 on. Throws `FeatureNotSupportedException` when running on devices before that versions.

Note: The PR also contains the changes from #1137, which probably should be merged before applying this PR.

### Bugs Fixed ###

- Related to issue #1137, #975

### API Changes ###

Added: 
 
- ` public static Task<IEnumerable<FilePickerResult>> PickMultipleFilesAsync(PickOptions options)`

### Behavioral Changes ###

No behavioral changes.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of dev/file-picker at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
