### PR TITLE
Don't request location permission if disabled.

### DIFF
--- a/Xamarin.Essentials/Permissions/Permissions.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.ios.tvos.watchos.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Essentials
                 EnsureDeclared();
 
                 var status = GetLocationStatus(true);
-                if (status == PermissionStatus.Granted)
+                if (status == PermissionStatus.Granted || status == PermissionStatus.Disabled)
                     return status;
 
                 EnsureMainThread();


### PR DESCRIPTION
Currently, we prompt for permission is it is disabled, but we shouldn't and just return that state.

Fixes #1161