### PR TITLE
GH-1148 - Check if 4th value is present in orientation sensor

### DIFF
--- a/Xamarin.Essentials/OrientationSensor/OrientationSensor.android.cs
+++ b/Xamarin.Essentials/OrientationSensor/OrientationSensor.android.cs
@@ -43,11 +43,21 @@ namespace Xamarin.Essentials
 
         void ISensorEventListener.OnSensorChanged(SensorEvent e)
         {
-            if ((e?.Values?.Count ?? 0) < 4)
+            var count = e?.Values?.Count ?? 0;
+            if (count < 3)
                 return;
 
-            var data = new OrientationSensorData(e.Values[0], e.Values[1], e.Values[2], e.Values[3]);
-            OrientationSensor.OnChanged(data);
+            OrientationSensorData? data;
+
+            // Docs: https://developer.android.com/reference/android/hardware/SensorEvent#sensor.type_rotation_vector-:
+            // values[3], originally optional, will always be present from SDK Level 18 onwards. values[4] is a new value that has been added in SDK Level 18.
+
+            if (count < 4)
+                data = new OrientationSensorData(e.Values[0], e.Values[1], e.Values[2], -1);
+            else
+                data = new OrientationSensorData(e.Values[0], e.Values[1], e.Values[2], e.Values[3]);
+
+            OrientationSensor.OnChanged(data.Value);
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Builds on top of previous PR so we return -1 if 4th value isn't present.

### Bugs Fixed ###

- Related to issue #1148

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### Behavioral Changes ###

Will return -1 if [3] isn't available on Android

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
