### PR TITLE
GH-1158 Remove configure await false, needs to be on main thread.

### DIFF
--- a/Xamarin.Essentials/Launcher/Launcher.android.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.android.cs
@@ -59,10 +59,10 @@ namespace Xamarin.Essentials
 
         static async Task<bool> PlatformTryOpenAsync(Uri uri)
         {
-            var canOpen = await PlatformCanOpenAsync(uri).ConfigureAwait(false);
+            var canOpen = await PlatformCanOpenAsync(uri);
 
             if (canOpen)
-                await PlatformOpenAsync(uri).ConfigureAwait(false);
+                await PlatformOpenAsync(uri);
 
             return canOpen;
         }

--- a/Xamarin.Essentials/Launcher/Launcher.tizen.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.tizen.cs
@@ -57,10 +57,10 @@ namespace Xamarin.Essentials
 
         static async Task<bool> PlatformTryOpenAsync(Uri uri)
         {
-            var canOpen = await PlatformCanOpenAsync(uri).ConfigureAwait(false);
+            var canOpen = await PlatformCanOpenAsync(uri);
 
             if (canOpen)
-                await PlatformOpenAsync(uri).ConfigureAwait(false);
+                await PlatformOpenAsync(uri);
 
             return canOpen;
         }

--- a/Xamarin.Essentials/Launcher/Launcher.uwp.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.uwp.cs
@@ -27,10 +27,10 @@ namespace Xamarin.Essentials
 
         static async Task<bool> PlatformTryOpenAsync(Uri uri)
         {
-            var canOpen = await PlatformCanOpenAsync(uri).ConfigureAwait(false);
+            var canOpen = await PlatformCanOpenAsync(uri);
 
             if (canOpen)
-                return await WinLauncher.LaunchUriAsync(uri).AsTask().ConfigureAwait(false);
+                return await WinLauncher.LaunchUriAsync(uri).AsTask();
 
             return canOpen;
         }


### PR DESCRIPTION
### Description of Change ###

Invoking launcher needs main thread so can't use configure await false.

### Bugs Fixed ###

- Related to issue #1158

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.


### Behavioral Changes ###

Tested on latest targets on UWP

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
