### PR TITLE
Fix CheckStatus for Battery Permission on Android

### DIFF
--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -166,6 +166,9 @@ namespace Xamarin.Essentials
         {
             public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
                 new (string, bool)[] { (Manifest.Permission.BatteryStats, false) };
+
+            public override Task<PermissionStatus> CheckStatusAsync() =>
+                Task.FromResult(IsDeclaredInManifest(Manifest.Permission.BatteryStats) ? PermissionStatus.Granted : PermissionStatus.Denied);
         }
 
         public partial class CalendarRead : BasePlatformPermission


### PR DESCRIPTION
### Description of Change ###

This is a special permission on 18 that just needs a manifest check: https://developer.android.com/reference/android/Manifest.permission#BATTERY_STATS

### Behavioral Changes ###

Now will return granted if in manifest.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
