### PR TITLE
Documentation change - tiny typo

### DIFF
--- a/docs/en/Xamarin.Essentials/AppInfo.xml
+++ b/docs/en/Xamarin.Essentials/AppInfo.xml
@@ -72,7 +72,7 @@
       <Docs>
         <summary>Gets the application package name or identifier.</summary>
         <value>The package name or identifier.</value>
-        <remarks>On android and iOS, this is the application package name. On UWP, this is the application GUID.</remarks>
+        <remarks>On Android and iOS, this is the application package name. On UWP, this is the application GUID.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RequestedTheme">


### PR DESCRIPTION
### Description of Change ###

Changed 'android' to 'Android'