### PR TITLE
Cache Android SdkInt at runtime

### DIFF
--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -180,8 +180,15 @@ namespace Xamarin.Essentials
             false;
 #endif
 
+        static int? sdkInt;
+
+        internal static int SdkInt
+            => sdkInt.HasValue
+                ? sdkInt.Value
+                : (sdkInt = (int)Build.VERSION.SdkInt).Value;
+
         internal static bool HasApiLevel(BuildVersionCodes versionCode) =>
-            (int)Build.VERSION.SdkInt >= (int)versionCode;
+            SdkInt >= (int)versionCode;
 
         internal static CameraManager CameraManager =>
             AppContext.GetSystemService(Context.CameraService) as CameraManager;

--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -183,9 +183,7 @@ namespace Xamarin.Essentials
         static int? sdkInt;
 
         internal static int SdkInt
-            => sdkInt.HasValue
-                ? sdkInt.Value
-                : (sdkInt = (int)Build.VERSION.SdkInt).Value;
+            => sdkInt ?? (sdkInt = (int)Build.VERSION.SdkInt).Value;
 
         internal static bool HasApiLevel(BuildVersionCodes versionCode) =>
             SdkInt >= (int)versionCode;

--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -183,7 +183,7 @@ namespace Xamarin.Essentials
         static int? sdkInt;
 
         internal static int SdkInt
-            => sdkInt ?? (sdkInt = (int)Build.VERSION.SdkInt).Value;
+            => sdkInt ??= (int)Build.VERSION.SdkInt;
 
         internal static bool HasApiLevel(BuildVersionCodes versionCode) =>
             SdkInt >= (int)versionCode;


### PR DESCRIPTION
This should never ever change at runtime, so should be safe to cache.

