### PR TITLE
[Feature] Event for Requested Theme Changes

### DIFF
--- a/Samples/Samples.Android/MainActivity.cs
+++ b/Samples/Samples.Android/MainActivity.cs
@@ -1,13 +1,14 @@
 ﻿using Android.App;
 using Android.Content;
 using Android.Content.PM;
+using Android.Content.Res;
 using Android.OS;
 using Android.Runtime;
 using Android.Widget;
 
 namespace Samples.Droid
 {
-    [Activity(Label = "@string/app_name", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    [Activity(Label = "@string/app_name", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode)]
     public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
         protected override void OnCreate(Bundle bundle)
@@ -24,6 +25,12 @@ namespace Samples.Droid
             Xamarin.Essentials.Platform.ActivityStateChanged += Platform_ActivityStateChanged;
 
             LoadApplication(new App());
+        }
+
+        public override void OnConfigurationChanged(Configuration newConfig)
+        {
+            base.OnConfigurationChanged(newConfig);
+            Xamarin.Essentials.Platform.OnConfigurationChanged(newConfig);
         }
 
         protected override void OnResume()

--- a/Samples/Samples.UWP/App.xaml
+++ b/Samples/Samples.UWP/App.xaml
@@ -2,7 +2,6 @@
     x:Class="Samples.UWP.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Samples.UWP"
-    RequestedTheme="Light">
+    xmlns:local="using:Samples.UWP">
 
 </Application>

--- a/Samples/Samples.iOS/GlobalSuppressions.cs
+++ b/Samples/Samples.iOS/GlobalSuppressions.cs
@@ -4,3 +4,4 @@
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "iOS is what we want.", Scope = "namespace", Target = "~N:Samples.iOS")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "iOS is what we want.", Scope = "namespace", Target = "~N:Samples.iOS.Renderers")]

--- a/Samples/Samples.iOS/Renderers/PageRenderer.cs
+++ b/Samples/Samples.iOS/Renderers/PageRenderer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(ContentPage), typeof(Samples.iOS.Renderers.PageRenderer))]
+
+namespace Samples.iOS.Renderers
+{
+    public class PageRenderer : Xamarin.Forms.Platform.iOS.PageRenderer
+    {
+        public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+        {
+            base.TraitCollectionDidChange(previousTraitCollection);
+
+            Xamarin.Essentials.Platform.TraitCollectionDidChange(TraitCollection);
+        }
+    }
+}

--- a/Samples/Samples.iOS/Samples.iOS.csproj
+++ b/Samples/Samples.iOS/Samples.iOS.csproj
@@ -94,6 +94,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
+    <Compile Include="Renderers\PageRenderer.cs" />
     <None Include="Entitlements.plist" />
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Samples/Samples/View/AppInfoPage.xaml
+++ b/Samples/Samples/View/AppInfoPage.xaml
@@ -17,6 +17,7 @@
                 <Label Text="{Binding AppName, StringFormat='Name: {0}'}" />
                 <Label Text="{Binding AppPackageName, StringFormat='Package Name: {0}'}" />
                 <Label Text="{Binding AppTheme, StringFormat='Theme: {0}'}" />
+                <Label Text="{Binding AppThemeUpdated}" />
 
                 <Label Text="Version Info:" FontAttributes="Bold" Margin="0,6,0,0" />
                 <Label Text="{Binding AppVersion, StringFormat='Version: {0}'}" />

--- a/Samples/Samples/ViewModel/AppInfoViewModel.cs
+++ b/Samples/Samples/ViewModel/AppInfoViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Essentials;
+﻿using System;
+using Xamarin.Essentials;
 using Xamarin.Forms;
 
 namespace Samples.ViewModel
@@ -15,11 +16,32 @@ namespace Samples.ViewModel
 
         public string AppTheme => AppInfo.RequestedTheme.ToString();
 
+        public string AppThemeUpdated { get; set; }
+
         public Command ShowSettingsUICommand { get; }
 
         public AppInfoViewModel()
         {
             ShowSettingsUICommand = new Command(() => AppInfo.ShowSettingsUI());
+        }
+
+        public override void OnAppearing()
+        {
+            base.OnAppearing();
+            AppInfo.RequestedThemeChanged += AppInfoRequestedThemeChanged;
+        }
+
+        public override void OnDisappearing()
+        {
+            base.OnDisappearing();
+            AppInfo.RequestedThemeChanged -= AppInfoRequestedThemeChanged;
+        }
+
+        void AppInfoRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
+        {
+            AppThemeUpdated = $"{DateTime.UtcNow.ToShortTimeString()}: {e.RequestedTheme} updated";
+            OnPropertyChanged(nameof(AppTheme));
+            OnPropertyChanged(nameof(AppThemeUpdated));
         }
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.android.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.android.cs
@@ -57,14 +57,23 @@ namespace Xamarin.Essentials
             context.StartActivity(settingsIntent);
         }
 
-        static AppTheme PlatformRequestedTheme()
-        {
-            return (Platform.AppContext.Resources.Configuration.UiMode & UiMode.NightMask) switch
+        static AppTheme PlatformRequestedTheme() =>
+            PlatformRequestedTheme(Platform.AppContext.Resources.Configuration);
+
+        internal static AppTheme PlatformRequestedTheme(Configuration configuration) =>
+            (configuration.UiMode & UiMode.NightMask) switch
             {
                 UiMode.NightYes => AppTheme.Dark,
                 UiMode.NightNo => AppTheme.Light,
                 _ => AppTheme.Unspecified
             };
+
+        static void StartThemeListeners()
+        {
+        }
+
+        static void StopThemeListeners()
+        {
         }
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.ios.tvos.watchos.cs
@@ -30,19 +30,29 @@ namespace Xamarin.Essentials
             if (!Platform.HasOSVersion(13, 0))
                 return AppTheme.Unspecified;
 
-            var uiStyle = Platform.GetCurrentUIViewController()?.TraitCollection?.UserInterfaceStyle ??
-                UITraitCollection.CurrentTraitCollection.UserInterfaceStyle;
+            return PlatformRequestedTheme(
+                Platform.GetCurrentUIViewController()?.TraitCollection ??
+                UITraitCollection.CurrentTraitCollection);
+        }
 
-            return uiStyle switch
+        internal static AppTheme PlatformRequestedTheme(UITraitCollection uiTraitCollection) =>
+            (uiTraitCollection?.UserInterfaceStyle ?? UIUserInterfaceStyle.Unspecified) switch
             {
                 UIUserInterfaceStyle.Light => AppTheme.Light,
                 UIUserInterfaceStyle.Dark => AppTheme.Dark,
                 _ => AppTheme.Unspecified
             };
-        }
 #else
         static AppTheme PlatformRequestedTheme() =>
             AppTheme.Unspecified;
 #endif
+
+        static void StartThemeListeners()
+        {
+        }
+
+        static void StopThemeListeners()
+        {
+        }
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.netstandard.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.netstandard.cs
@@ -13,5 +13,11 @@
         static void PlatformShowSettingsUI() => throw ExceptionUtils.NotSupportedOrImplementedException;
 
         static AppTheme PlatformRequestedTheme() => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+        static void StartThemeListeners() =>
+            throw ExceptionUtils.NotSupportedOrImplementedException;
+
+        static void StopThemeListeners() =>
+            throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.shared.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.shared.cs
@@ -17,5 +17,55 @@ namespace Xamarin.Essentials
         public static void ShowSettingsUI() => PlatformShowSettingsUI();
 
         public static AppTheme RequestedTheme => PlatformRequestedTheme();
+
+        static AppTheme currentTheme;
+
+        public static event EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged
+        {
+            add
+            {
+                var wasRunning = RequestedThemeChangedInternal != null;
+
+                RequestedThemeChangedInternal += value;
+
+                if (!wasRunning && RequestedThemeChangedInternal != null)
+                {
+                    currentTheme = RequestedTheme;
+                    StartThemeListeners();
+                }
+            }
+
+            remove
+            {
+                var wasRunning = RequestedThemeChangedInternal != null;
+
+                RequestedThemeChangedInternal -= value;
+
+                if (wasRunning && RequestedThemeChangedInternal == null)
+                    StopThemeListeners();
+            }
+        }
+
+        static event EventHandler<AppThemeChangedEventArgs> RequestedThemeChangedInternal;
+
+        internal static void OnAppThemeChanged(AppTheme appTheme)
+        {
+            if (currentTheme == appTheme)
+                return;
+
+            currentTheme = appTheme;
+            OnAppThemeChanged(new AppThemeChangedEventArgs(appTheme));
+        }
+
+        static void OnAppThemeChanged(AppThemeChangedEventArgs e) =>
+            MainThread.BeginInvokeOnMainThread(() => RequestedThemeChangedInternal?.Invoke(null, e));
+    }
+
+    public class AppThemeChangedEventArgs : EventArgs
+    {
+        public AppThemeChangedEventArgs(AppTheme appTheme) =>
+            RequestedTheme = appTheme;
+
+        public AppTheme RequestedTheme { get; }
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.tizen.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.tizen.cs
@@ -23,9 +23,14 @@ namespace Xamarin.Essentials
             AppControl.SendLaunchRequest(new AppControl() { Operation = AppControlOperations.Setting });
         }
 
-        static AppTheme PlatformRequestedTheme()
+        static AppTheme PlatformRequestedTheme() => AppTheme.Unspecified;
+
+        static void StartThemeListeners()
         {
-            return AppTheme.Unspecified;
+        }
+
+        static void StopThemeListeners()
+        {
         }
     }
 }

--- a/Xamarin.Essentials/AppInfo/AppInfo.uwp.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.uwp.cs
@@ -1,11 +1,17 @@
 ﻿using System.Globalization;
 using Windows.ApplicationModel;
+using Windows.UI;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 
 namespace Xamarin.Essentials
 {
     public static partial class AppInfo
     {
+        static UISettings uiSetting;
+
+        static UISettings UISettings => uiSetting ??= new UISettings();
+
         static string PlatformGetPackageName() => Package.Current.Id.Name;
 
         static string PlatformGetName() => Package.Current.DisplayName;
@@ -24,5 +30,19 @@ namespace Xamarin.Essentials
 
         static AppTheme PlatformRequestedTheme() =>
             Application.Current.RequestedTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light;
+
+        static void StartThemeListeners() =>
+            UISettings.ColorValuesChanged += UISettingsColorValuesChanged;
+
+        static void StopThemeListeners() =>
+            UISettings.ColorValuesChanged -= UISettingsColorValuesChanged;
+
+        static void UISettingsColorValuesChanged(UISettings sender, object args)
+        {
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                OnAppThemeChanged(PlatformRequestedTheme());
+            });
+        }
     }
 }

--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
+using Android.Content.Res;
 using Android.Hardware;
 using Android.Hardware.Camera2;
 using Android.Locations;
@@ -77,6 +78,9 @@ namespace Xamarin.Essentials
 
         public static void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults) =>
             Permissions.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        public static void OnConfigurationChanged(Configuration newConfig) =>
+            AppInfo.OnAppThemeChanged(AppInfo.PlatformRequestedTheme(newConfig));
 
         public static void OnResume() =>
             WebAuthenticator.OnResume(null);

--- a/Xamarin.Essentials/Platform/Platform.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Platform/Platform.ios.tvos.watchos.cs
@@ -19,6 +19,9 @@ namespace Xamarin.Essentials
 #if __IOS__ || __TVOS__
         public static bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
             => WebAuthenticator.OpenUrl(new Uri(url.AbsoluteString));
+
+        public static void TraitCollectionDidChange(UITraitCollection currentUITraitCollection) =>
+            AppInfo.OnAppThemeChanged(AppInfo.PlatformRequestedTheme(currentUITraitCollection));
 #endif
 
 #if __IOS__


### PR DESCRIPTION
**NEEDS REVIEW**

### Description of Change ###

Enable developers to subscribe to app theme request changes. Also add in platform helpers on iOS/Android to bubble up platform events.

### API Changes ###
App Info:
* Added: public static EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged
* Added: AppThemeChangedEventArgs

In Platform files:
* Added on iOS & tvOS: public static void TraitCollectionDidChange(UITraitCollection currentUITraitCollection)
* Added on Android:  public static void OnConfigurationChanged(Configuration newConfig)

### Behavioral Changes ###

None.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
