### PR TITLE
Add id_token property

### DIFF
--- a/Samples/Samples/View/WebAuthenticatorPage.xaml
+++ b/Samples/Samples/View/WebAuthenticatorPage.xaml
@@ -19,8 +19,8 @@
                 <Button Text="Facebook" Command="{Binding FacebookCommand}" BackgroundColor="#3b5998" TextColor="White" />
                 <Button Text="Apple" Command="{Binding AppleCommand}" BackgroundColor="Black" TextColor="White" />
 
-                <Label Text="Access Token:" FontAttributes="Bold" Margin="12,12,12,0" />
-                <Label Text="{Binding AccessToken}" TextColor="Red" FontAttributes="Italic" />
+                <Label Text="Auth Token:" FontAttributes="Bold" Margin="12,12,12,0" />
+                <Label Text="{Binding AuthToken}" TextColor="Red" FontAttributes="Italic" />
             </StackLayout>
         </ScrollView>
     </StackLayout>

--- a/Samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
+++ b/Samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
@@ -28,7 +28,7 @@ namespace Samples.ViewModel
 
         string accessToken = string.Empty;
 
-        public string AccessToken
+        public string AuthToken
         {
             get => accessToken;
             set => SetProperty(ref accessToken, value);
@@ -54,11 +54,11 @@ namespace Samples.ViewModel
                     r = await WebAuthenticator.AuthenticateAsync(authUrl, callbackUrl);
                 }
 
-                AccessToken = r?.AccessToken;
+                AuthToken = r?.AccessToken ?? r?.IdToken;
             }
             catch (Exception ex)
             {
-                AccessToken = string.Empty;
+                AuthToken = string.Empty;
                 await DisplayAlertAsync($"Failed: {ex.Message}");
             }
         }

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorResult.shared.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorResult.shared.cs
@@ -46,6 +46,9 @@ namespace Xamarin.Essentials
         public string RefreshToken
             => Get("refresh_token");
 
+        public string IdToken
+            => Get("id_token");
+
         public DateTimeOffset? RefreshTokenExpiresIn
         {
             get

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -879,6 +879,7 @@
       <Member Id="M:Xamarin.Essentials.WebAuthenticatorResult.Put(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.AccessToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.ExpiresIn" />
+      <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.IdToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.Properties" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshTokenExpiresIn" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -874,6 +874,7 @@
       <Member Id="M:Xamarin.Essentials.WebAuthenticatorResult.Put(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.AccessToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.ExpiresIn" />
+      <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.IdToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.Properties" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshTokenExpiresIn" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
@@ -836,6 +836,7 @@
       <Member Id="M:Xamarin.Essentials.WebAuthenticatorResult.Put(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.AccessToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.ExpiresIn" />
+      <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.IdToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.Properties" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshTokenExpiresIn" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -835,6 +835,7 @@
       <Member Id="M:Xamarin.Essentials.WebAuthenticatorResult.Put(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.AccessToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.ExpiresIn" />
+      <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.IdToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.Properties" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshTokenExpiresIn" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
@@ -845,6 +845,7 @@
       <Member Id="M:Xamarin.Essentials.WebAuthenticatorResult.Put(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.AccessToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.ExpiresIn" />
+      <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.IdToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.Properties" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshTokenExpiresIn" />

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -809,6 +809,7 @@
       <Member Id="M:Xamarin.Essentials.WebAuthenticatorResult.Put(System.String,System.String)" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.AccessToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.ExpiresIn" />
+      <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.IdToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.Properties" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshToken" />
       <Member Id="P:Xamarin.Essentials.WebAuthenticatorResult.RefreshTokenExpiresIn" />

--- a/docs/en/Xamarin.Essentials/WebAuthenticatorResult.xml
+++ b/docs/en/Xamarin.Essentials/WebAuthenticatorResult.xml
@@ -27,7 +27,7 @@
       <Parameters />
       <Docs>
         <summary>
-          <para />
+          <para></para>
         </summary>
         <remarks>To be added.</remarks>
       </Docs>
@@ -127,11 +127,29 @@
         <param name="key">Key from the callback URI's query string.</param>
         <summary>Gets a value for a given key from the dictionary.</summary>
         <returns>
-          <para />
+          <para></para>
         </returns>
         <remarks>
-          <para />
+          <para></para>
         </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IdToken">
+      <MemberSignature Language="C#" Value="public string IdToken { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string IdToken" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.WebAuthenticatorResult.IdToken" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>The value for the `id_token` key.</summary>
+        <value>The value for the `id_token` key.</value>
+        <remarks>Apple doesn't return an access token on iOS native sign in, but it does return id_token as a JWT.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Properties">
@@ -149,10 +167,10 @@
       <Docs>
         <summary>The dictionary of key/value pairs parsed form the callback URI's querystring.</summary>
         <value>
-          <para />
+          <para></para>
         </value>
         <remarks>
-          <para />
+          <para></para>
         </remarks>
       </Docs>
     </Member>
@@ -174,14 +192,14 @@
       </Parameters>
       <Docs>
         <param name="key">
-          <para />
+          <para></para>
         </param>
         <param name="value">
-          <para />
+          <para></para>
         </param>
         <summary>Puts a key/value pair into the dictionary.</summary>
         <remarks>
-          <para />
+          <para></para>
         </remarks>
       </Docs>
     </Member>
@@ -201,7 +219,7 @@
         <summary>The value for the `refresh_token` key.</summary>
         <value>Refresh Token parsed from the callback URI refresh_token parameter.</value>
         <remarks>
-          <para />
+          <para></para>
         </remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
Apple doesn't return an access token on iOS native sign in, but it does return id_token as a JWT.  This adds a property to the auth result to access IdToken easily and then changes the sample to try and use IdToken if AccessToken is null.

### PR Checklist ###

- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
