### PR TITLE
add new property Location.AltitudeReferenceSystem

### DIFF
--- a/Samples/Samples/ViewModel/GeolocationViewModel.cs
+++ b/Samples/Samples/ViewModel/GeolocationViewModel.cs
@@ -100,6 +100,7 @@ namespace Samples.ViewModel
                 $"Longitude: {location.Longitude}\n" +
                 $"HorizontalAccuracy: {location.Accuracy}\n" +
                 $"Altitude: {(location.Altitude.HasValue ? location.Altitude.Value.ToString() : notAvailable)}\n" +
+                $"AltitudeRefSys: {location.AltitudeReferenceSystem.ToString()}\n" +
                 $"VerticalAccuracy: {(location.VerticalAccuracy.HasValue ? location.VerticalAccuracy.Value.ToString() : notAvailable)}\n" +
                 $"Heading: {(location.Course.HasValue ? location.Course.Value.ToString() : notAvailable)}\n" +
                 $"Speed: {(location.Speed.HasValue ? location.Speed.Value.ToString() : notAvailable)}\n" +

--- a/Xamarin.Essentials/Types/Location.shared.cs
+++ b/Xamarin.Essentials/Types/Location.shared.cs
@@ -10,6 +10,15 @@ namespace Xamarin.Essentials
         Miles
     }
 
+    public enum AltitudeReferenceSystem
+    {
+        Unspecified = 0,
+        Terrain = 1,
+        Ellipsoid = 2,
+        Geoid = 3,
+        Surface = 4
+    }
+
     public class Location
     {
         public Location()
@@ -59,6 +68,8 @@ namespace Xamarin.Essentials
         public double? Course { get; set; }
 
         public bool IsFromMockProvider { get; set; }
+
+        public AltitudeReferenceSystem AltitudeReferenceSystem { get; set; }
 
         public static double CalculateDistance(double latitudeStart, double longitudeStart, Location locationEnd, DistanceUnits units) =>
             CalculateDistance(latitudeStart, longitudeStart, locationEnd.Latitude, locationEnd.Longitude, units);

--- a/Xamarin.Essentials/Types/LocationExtensions.android.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.android.cs
@@ -36,7 +36,8 @@ namespace Xamarin.Essentials
 #endif
                 Course = location.HasBearing ? location.Bearing : default(double?),
                 Speed = location.HasSpeed ? location.Speed : default(double?),
-                IsFromMockProvider = Platform.HasApiLevel(global::Android.OS.BuildVersionCodes.JellyBeanMr2) ? location.IsFromMockProvider : false
+                IsFromMockProvider = Platform.HasApiLevel(global::Android.OS.BuildVersionCodes.JellyBeanMr2) ? location.IsFromMockProvider : false,
+                AltitudeReferenceSystem = AltitudeReferenceSystem.Ellipsoid
             };
 
         static readonly DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/Xamarin.Essentials/Types/LocationExtensions.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.ios.tvos.watchos.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Essentials
                 Latitude = placemark.Location.Coordinate.Latitude,
                 Longitude = placemark.Location.Coordinate.Longitude,
                 Altitude = placemark.Location.Altitude,
+                AltitudeReferenceSystem = AltitudeReferenceSystem.Geoid,
                 Timestamp = DateTimeOffset.UtcNow
             };
 
@@ -33,7 +34,8 @@ namespace Xamarin.Essentials
                 Course = location.Course < 0 ? default(double?) : location.Course,
                 Speed = location.Speed < 0 ? default(double?) : location.Speed,
 #endif
-                IsFromMockProvider = DeviceInfo.DeviceType == DeviceType.Virtual
+                IsFromMockProvider = DeviceInfo.DeviceType == DeviceType.Virtual,
+                AltitudeReferenceSystem = AltitudeReferenceSystem.Geoid
             };
 
         internal static DateTimeOffset ToDateTime(this NSDate timestamp)

--- a/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
@@ -8,13 +8,21 @@ namespace Xamarin.Essentials
 {
     public static partial class LocationExtensions
     {
+        internal static AltitudeReferenceSystem ConvertRefSys(Windows.Devices.Geolocation.AltitudeReferenceSystem refsys)
+        {
+            if (Enum.IsDefined(typeof(AltitudeReferenceSystem), refsys))
+                return (AltitudeReferenceSystem)refsys;
+            else
+                return AltitudeReferenceSystem.Unspecified;
+        }
+
         internal static Location ToLocation(this MapLocation mapLocation) =>
             new Location
             {
                 Latitude = mapLocation.Point.Position.Latitude,
                 Longitude = mapLocation.Point.Position.Longitude,
                 Altitude = mapLocation.Point.Position.Altitude,
-                AltitudeReferenceSystem = (AltitudeReferenceSystem)mapLocation.Point.AltitudeReferenceSystem,
+                AltitudeReferenceSystem = ConvertRefSys(mapLocation.Point.AltitudeReferenceSystem),
                 Timestamp = DateTimeOffset.UtcNow
             };
 
@@ -36,7 +44,7 @@ namespace Xamarin.Essentials
                 Speed = (!location.Coordinate.Speed.HasValue || double.IsNaN(location.Coordinate.Speed.Value)) ? default : location.Coordinate.Speed,
                 Course = (!location.Coordinate.Heading.HasValue || double.IsNaN(location.Coordinate.Heading.Value)) ? default : location.Coordinate.Heading,
                 IsFromMockProvider = false,
-                AltitudeReferenceSystem = (AltitudeReferenceSystem)location.Coordinate.Point.AltitudeReferenceSystem
+                AltitudeReferenceSystem = ConvertRefSys(location.Coordinate.Point.AltitudeReferenceSystem)
             };
 
         internal static Location ToLocation(this Geocoordinate coordinate) =>
@@ -50,7 +58,7 @@ namespace Xamarin.Essentials
                  VerticalAccuracy = coordinate.AltitudeAccuracy,
                  Speed = (!coordinate.Speed.HasValue || double.IsNaN(coordinate.Speed.Value)) ? default : coordinate.Speed,
                  Course = (!coordinate.Heading.HasValue || double.IsNaN(coordinate.Heading.Value)) ? default : coordinate.Heading,
-                 AltitudeReferenceSystem = (AltitudeReferenceSystem)coordinate.Point.AltitudeReferenceSystem
+                 AltitudeReferenceSystem = ConvertRefSys(coordinate.Point.AltitudeReferenceSystem)
              };
     }
 }

--- a/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Essentials
                 Latitude = mapLocation.Point.Position.Latitude,
                 Longitude = mapLocation.Point.Position.Longitude,
                 Altitude = mapLocation.Point.Position.Altitude,
+                AltitudeReferenceSystem = mapLocation.Point.AltitudeReferenceSystem,
                 Timestamp = DateTimeOffset.UtcNow
             };
 
@@ -34,7 +35,8 @@ namespace Xamarin.Essentials
                 VerticalAccuracy = location.Coordinate.AltitudeAccuracy,
                 Speed = (!location.Coordinate.Speed.HasValue || double.IsNaN(location.Coordinate.Speed.Value)) ? default : location.Coordinate.Speed,
                 Course = (!location.Coordinate.Heading.HasValue || double.IsNaN(location.Coordinate.Heading.Value)) ? default : location.Coordinate.Heading,
-                IsFromMockProvider = false
+                IsFromMockProvider = false,
+                AltitudeReferenceSystem = location.Coordinate.Point.AltitudeReferenceSystem
             };
 
         internal static Location ToLocation(this Geocoordinate coordinate) =>
@@ -47,7 +49,8 @@ namespace Xamarin.Essentials
                  Accuracy = coordinate.Accuracy,
                  VerticalAccuracy = coordinate.AltitudeAccuracy,
                  Speed = (!coordinate.Speed.HasValue || double.IsNaN(coordinate.Speed.Value)) ? default : coordinate.Speed,
-                 Course = (!coordinate.Heading.HasValue || double.IsNaN(coordinate.Heading.Value)) ? default : coordinate.Heading
+                 Course = (!coordinate.Heading.HasValue || double.IsNaN(coordinate.Heading.Value)) ? default : coordinate.Heading,
+                 AltitudeReferenceSystem = coordinate.Point.AltitudeReferenceSystem
              };
     }
 }

--- a/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
@@ -3,26 +3,19 @@ using System.Collections.Generic;
 using System.Linq;
 using Windows.Devices.Geolocation;
 using Windows.Services.Maps;
+using WindowsARS = Windows.Devices.Geolocation.AltitudeReferenceSystem;
 
 namespace Xamarin.Essentials
 {
     public static partial class LocationExtensions
     {
-        internal static AltitudeReferenceSystem ConvertRefSys(Windows.Devices.Geolocation.AltitudeReferenceSystem refsys)
-        {
-            if (Enum.IsDefined(typeof(AltitudeReferenceSystem), refsys))
-                return (AltitudeReferenceSystem)refsys;
-            else
-                return AltitudeReferenceSystem.Unspecified;
-        }
-
         internal static Location ToLocation(this MapLocation mapLocation) =>
             new Location
             {
                 Latitude = mapLocation.Point.Position.Latitude,
                 Longitude = mapLocation.Point.Position.Longitude,
                 Altitude = mapLocation.Point.Position.Altitude,
-                AltitudeReferenceSystem = ConvertRefSys(mapLocation.Point.AltitudeReferenceSystem),
+                AltitudeReferenceSystem = mapLocation.Point.AltitudeReferenceSystem.ToEssentials(),
                 Timestamp = DateTimeOffset.UtcNow
             };
 
@@ -44,7 +37,7 @@ namespace Xamarin.Essentials
                 Speed = (!location.Coordinate.Speed.HasValue || double.IsNaN(location.Coordinate.Speed.Value)) ? default : location.Coordinate.Speed,
                 Course = (!location.Coordinate.Heading.HasValue || double.IsNaN(location.Coordinate.Heading.Value)) ? default : location.Coordinate.Heading,
                 IsFromMockProvider = false,
-                AltitudeReferenceSystem = ConvertRefSys(location.Coordinate.Point.AltitudeReferenceSystem)
+                AltitudeReferenceSystem = location.Coordinate.Point.AltitudeReferenceSystem.ToEssentials()
             };
 
         internal static Location ToLocation(this Geocoordinate coordinate) =>
@@ -58,7 +51,17 @@ namespace Xamarin.Essentials
                  VerticalAccuracy = coordinate.AltitudeAccuracy,
                  Speed = (!coordinate.Speed.HasValue || double.IsNaN(coordinate.Speed.Value)) ? default : coordinate.Speed,
                  Course = (!coordinate.Heading.HasValue || double.IsNaN(coordinate.Heading.Value)) ? default : coordinate.Heading,
-                 AltitudeReferenceSystem = ConvertRefSys(coordinate.Point.AltitudeReferenceSystem)
+                 AltitudeReferenceSystem = coordinate.Point.AltitudeReferenceSystem.ToEssentials()
              };
+
+        internal static AltitudeReferenceSystem ToEssentials(this WindowsARS altitudeReferenceSystem) =>
+            altitudeReferenceSystem switch
+            {
+                WindowsARS.Ellipsoid => AltitudeReferenceSystem.Ellipsoid,
+                WindowsARS.Geoid => AltitudeReferenceSystem.Geoid,
+                WindowsARS.Surface => AltitudeReferenceSystem.Surface,
+                WindowsARS.Terrain => AltitudeReferenceSystem.Terrain,
+                _ => AltitudeReferenceSystem.Unspecified
+            };
     }
 }

--- a/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.uwp.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Essentials
                 Latitude = mapLocation.Point.Position.Latitude,
                 Longitude = mapLocation.Point.Position.Longitude,
                 Altitude = mapLocation.Point.Position.Altitude,
-                AltitudeReferenceSystem = mapLocation.Point.AltitudeReferenceSystem,
+                AltitudeReferenceSystem = (AltitudeReferenceSystem)mapLocation.Point.AltitudeReferenceSystem,
                 Timestamp = DateTimeOffset.UtcNow
             };
 
@@ -36,7 +36,7 @@ namespace Xamarin.Essentials
                 Speed = (!location.Coordinate.Speed.HasValue || double.IsNaN(location.Coordinate.Speed.Value)) ? default : location.Coordinate.Speed,
                 Course = (!location.Coordinate.Heading.HasValue || double.IsNaN(location.Coordinate.Heading.Value)) ? default : location.Coordinate.Heading,
                 IsFromMockProvider = false,
-                AltitudeReferenceSystem = location.Coordinate.Point.AltitudeReferenceSystem
+                AltitudeReferenceSystem = (AltitudeReferenceSystem)location.Coordinate.Point.AltitudeReferenceSystem
             };
 
         internal static Location ToLocation(this Geocoordinate coordinate) =>
@@ -50,7 +50,7 @@ namespace Xamarin.Essentials
                  VerticalAccuracy = coordinate.AltitudeAccuracy,
                  Speed = (!coordinate.Speed.HasValue || double.IsNaN(coordinate.Speed.Value)) ? default : coordinate.Speed,
                  Course = (!coordinate.Heading.HasValue || double.IsNaN(coordinate.Heading.Value)) ? default : coordinate.Heading,
-                 AltitudeReferenceSystem = coordinate.Point.AltitudeReferenceSystem
+                 AltitudeReferenceSystem = (AltitudeReferenceSystem)coordinate.Point.AltitudeReferenceSystem
              };
     }
 }

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -38,6 +38,13 @@
       <Member Id="P:Xamarin.Essentials.ActivityStateChangedEventArgs.Activity" />
       <Member Id="P:Xamarin.Essentials.ActivityStateChangedEventArgs.State" />
     </Type>
+    <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Unspecified" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Terrain" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Geoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Surface" />
+    </Type>xx
     <Type Name="Xamarin.Essentials.AppInfo" Id="T:Xamarin.Essentials.AppInfo">
       <Member Id="M:Xamarin.Essentials.AppInfo.ShowSettingsUI" />
       <Member Id="P:Xamarin.Essentials.AppInfo.BuildString" />
@@ -438,6 +445,7 @@
       <Member Id="M:Xamarin.Essentials.Location.ToString" />
       <Member Id="P:Xamarin.Essentials.Location.Accuracy" />
       <Member Id="P:Xamarin.Essentials.Location.Altitude" />
+      <Member Id="P:Xamarin.Essentials.Location.AltitudeReferenceSystem" />
       <Member Id="P:Xamarin.Essentials.Location.Course" />
       <Member Id="P:Xamarin.Essentials.Location.IsFromMockProvider" />
       <Member Id="P:Xamarin.Essentials.Location.Latitude" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -25,6 +25,13 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
     </Type>
+    <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Unspecified" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Terrain" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Geoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Surface" />
+    </Type>
     <Type Name="Xamarin.Essentials.AppInfo" Id="T:Xamarin.Essentials.AppInfo">
       <Member Id="M:Xamarin.Essentials.AppInfo.ShowSettingsUI" />
       <Member Id="P:Xamarin.Essentials.AppInfo.BuildString" />
@@ -417,6 +424,7 @@
       <Member Id="M:Xamarin.Essentials.Location.ToString" />
       <Member Id="P:Xamarin.Essentials.Location.Accuracy" />
       <Member Id="P:Xamarin.Essentials.Location.Altitude" />
+      <Member Id="P:Xamarin.Essentials.Location.AltitudeReferenceSystem" />
       <Member Id="P:Xamarin.Essentials.Location.Course" />
       <Member Id="P:Xamarin.Essentials.Location.IsFromMockProvider" />
       <Member Id="P:Xamarin.Essentials.Location.Latitude" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
@@ -25,6 +25,13 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
     </Type>
+    <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Unspecified" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Terrain" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Geoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Surface" />
+    </Type>
     <Type Name="Xamarin.Essentials.AppInfo" Id="T:Xamarin.Essentials.AppInfo">
       <Member Id="M:Xamarin.Essentials.AppInfo.ShowSettingsUI" />
       <Member Id="P:Xamarin.Essentials.AppInfo.BuildString" />
@@ -416,6 +423,7 @@
       <Member Id="M:Xamarin.Essentials.Location.ToString" />
       <Member Id="P:Xamarin.Essentials.Location.Accuracy" />
       <Member Id="P:Xamarin.Essentials.Location.Altitude" />
+      <Member Id="P:Xamarin.Essentials.Location.AltitudeReferenceSystem" />
       <Member Id="P:Xamarin.Essentials.Location.Course" />
       <Member Id="P:Xamarin.Essentials.Location.IsFromMockProvider" />
       <Member Id="P:Xamarin.Essentials.Location.Latitude" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -25,6 +25,13 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
     </Type>
+    <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Unspecified" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Terrain" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Geoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Surface" />
+    </Type>
     <Type Name="Xamarin.Essentials.AppInfo" Id="T:Xamarin.Essentials.AppInfo">
       <Member Id="M:Xamarin.Essentials.AppInfo.ShowSettingsUI" />
       <Member Id="P:Xamarin.Essentials.AppInfo.BuildString" />
@@ -416,6 +423,7 @@
       <Member Id="M:Xamarin.Essentials.Location.ToString" />
       <Member Id="P:Xamarin.Essentials.Location.Accuracy" />
       <Member Id="P:Xamarin.Essentials.Location.Altitude" />
+      <Member Id="P:Xamarin.Essentials.Location.AltitudeReferenceSystem" />
       <Member Id="P:Xamarin.Essentials.Location.Course" />
       <Member Id="P:Xamarin.Essentials.Location.IsFromMockProvider" />
       <Member Id="P:Xamarin.Essentials.Location.Latitude" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
@@ -25,6 +25,13 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
     </Type>
+    <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Unspecified" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Terrain" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Geoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Surface" />
+    </Type>
     <Type Name="Xamarin.Essentials.AppInfo" Id="T:Xamarin.Essentials.AppInfo">
       <Member Id="M:Xamarin.Essentials.AppInfo.ShowSettingsUI" />
       <Member Id="P:Xamarin.Essentials.AppInfo.BuildString" />
@@ -416,6 +423,7 @@
       <Member Id="M:Xamarin.Essentials.Location.ToString" />
       <Member Id="P:Xamarin.Essentials.Location.Accuracy" />
       <Member Id="P:Xamarin.Essentials.Location.Altitude" />
+      <Member Id="P:Xamarin.Essentials.Location.AltitudeReferenceSystem" />
       <Member Id="P:Xamarin.Essentials.Location.Course" />
       <Member Id="P:Xamarin.Essentials.Location.IsFromMockProvider" />
       <Member Id="P:Xamarin.Essentials.Location.Latitude" />

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -25,6 +25,13 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
     </Type>
+    <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Unspecified" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Terrain" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Geoid" />
+      <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Surface" />
+    </Type>
     <Type Name="Xamarin.Essentials.AppInfo" Id="T:Xamarin.Essentials.AppInfo">
       <Member Id="M:Xamarin.Essentials.AppInfo.ShowSettingsUI" />
       <Member Id="P:Xamarin.Essentials.AppInfo.BuildString" />
@@ -415,6 +422,7 @@
       <Member Id="M:Xamarin.Essentials.Location.ToString" />
       <Member Id="P:Xamarin.Essentials.Location.Accuracy" />
       <Member Id="P:Xamarin.Essentials.Location.Altitude" />
+      <Member Id="P:Xamarin.Essentials.Location.AltitudeReferenceSystem" />
       <Member Id="P:Xamarin.Essentials.Location.Course" />
       <Member Id="P:Xamarin.Essentials.Location.IsFromMockProvider" />
       <Member Id="P:Xamarin.Essentials.Location.Latitude" />

--- a/docs/en/Xamarin.Essentials/AltitudeReferenceSystem.xml
+++ b/docs/en/Xamarin.Essentials/AltitudeReferenceSystem.xml
@@ -1,0 +1,105 @@
+<Type Name="AltitudeReferenceSystem" FullName="Xamarin.Essentials.AltitudeReferenceSystem">
+  <TypeSignature Language="C#" Value="public enum AltitudeReferenceSystem" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed AltitudeReferenceSystem extends System.Enum" />
+  <TypeSignature Language="DocId" Value="T:Xamarin.Essentials.AltitudeReferenceSystem" />
+  <AssemblyInfo>
+    <AssemblyName>Xamarin.Essentials</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>Indicates the altitude reference system to be used in defining a location.</summary>
+    <remarks>
+      <para>This enum is a copy of Windows.Devices.Geolocation.AltitudeReferenceSystem.</para>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Unspecified">
+      <MemberSignature Language="C#" Value="Unspecified" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Essentials.AltitudeReferenceSystem Unspecified = int32(0)" />
+      <MemberSignature Language="DocId" Value="F:Xamarin.Essentials.AltitudeReferenceSystem.Unspecified" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Essentials.AltitudeReferenceSystem</ReturnType>
+      </ReturnValue>
+      <MemberValue>0</MemberValue>
+      <Docs>
+        <summary>The altitude reference system was not specified.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Terrain">
+      <MemberSignature Language="C#" Value="Terrain" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Essentials.AltitudeReferenceSystem Terrain = int32(1)" />
+      <MemberSignature Language="DocId" Value="F:Xamarin.Essentials.AltitudeReferenceSystem.Terrain" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Essentials.AltitudeReferenceSystem</ReturnType>
+      </ReturnValue>
+      <MemberValue>1</MemberValue>
+      <Docs>
+        <summary>The altitude reference system is based on distance above terrain or ground level.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Ellipsoid">
+      <MemberSignature Language="C#" Value="Ellipsoid" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Essentials.AltitudeReferenceSystem Ellipsoid = int32(2)" />
+      <MemberSignature Language="DocId" Value="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Essentials.AltitudeReferenceSystem</ReturnType>
+      </ReturnValue>
+      <MemberValue>2</MemberValue>
+      <Docs>
+        <summary>The altitude reference system is based on an ellipsoid (usually WGS84), which is a mathematical approximation of the shape of the Earth.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Geoid">
+      <MemberSignature Language="C#" Value="Geoid" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Essentials.AltitudeReferenceSystem Geoid = int32(3)" />
+      <MemberSignature Language="DocId" Value="F:Xamarin.Essentials.AltitudeReferenceSystem.Geoid" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Essentials.AltitudeReferenceSystem</ReturnType>
+      </ReturnValue>
+      <MemberValue>3</MemberValue>
+      <Docs>
+        <summary>The altitude reference system is based on the distance above sea level (parametrized by a so-called Geoid).</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Surface">
+      <MemberSignature Language="C#" Value="Surface" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Essentials.AltitudeReferenceSystem Surface = int32(4)" />
+      <MemberSignature Language="DocId" Value="F:Xamarin.Essentials.AltitudeReferenceSystem.Surface" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Essentials.AltitudeReferenceSystem</ReturnType>
+      </ReturnValue>
+      <MemberValue>4</MemberValue>
+      <Docs>
+        <summary>The altitude reference system is based on the distance above the tallest surface structures, such as buildings, trees, roads, etc., above terrain or ground level.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/docs/en/Xamarin.Essentials/Location.xml
+++ b/docs/en/Xamarin.Essentials/Location.xml
@@ -133,14 +133,26 @@
         <ReturnType>System.Nullable&lt;System.Double&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the altitude in meters (if available). The reference system is platform specific.</summary>
+        <summary>Gets the altitude in meters (if available) in a reference system which is specified by AltitudeReferenceSystem.</summary>
         <value>Altitude of location if available.</value>
-        <remarks>
-          <para>Returns 0 or no value if not available. The reference system is different for each platform:</para>
-          <para>- Android: Altitude is returned in meters above the WGS 84 reference ellipsoid. If this location does not have an altitude then 0.0 is returned.</para>
-          <para>- iOS: Altitude is returned in meters above mean sea level (MSL, parametrized by a geoid).</para>
-          <para>- UWP: Altitude can be returned in different reference systems. See Windows.Devices.Geolocation.Geopoint.AltitudeReferenceSystem.</para>
-        </remarks>
+        <remarks>Returns 0 or no value if not available.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AltitudeReferenceSystem">
+      <MemberSignature Language="C#" Value="public AltitudeReferenceSystem AltitudeReferenceSystem { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance valuetype Xamarin.Essentials.AltitudeReferenceSystem AltitudeReferenceSystem" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.Location.AltitudeReferenceSystem" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Essentials.AltitudeReferenceSystem</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Specifies the reference system in which the altitude value is given.</summary>
+        <value>The altitude reference system.</value>
       </Docs>
     </Member>
     <Member MemberName="CalculateDistance">


### PR DESCRIPTION
### Description of Change ###

In order to deal with platform differences of Location.Altitude, this PR adds a new property Location.AltitudeReferenceSystem and a corresponding enum, which is a copy of [Windows.Devices.Geolocation.AltitudeReferenceSystem](https://docs.microsoft.com/en-us/uwp/api/windows.devices.geolocation.altitudereferencesystem).

### Bugs Fixed ###

- Related to issue #1177

### API Changes ###

Added: 

- `enum AltitudeReferenceSystem`
- `AltitudeReferenceSystem Location.AltitudeReferenceSystem { get; set; }`

Changed:

 - None.

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
