### PR TITLE
GH-1207 iOS TTS - Don't use lazy as it isn't linker safe :(

### DIFF
--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Essentials
 {
     public static partial class TextToSpeech
     {
-        static readonly Lazy<AVSpeechSynthesizer> speechSynthesizer = new Lazy<AVSpeechSynthesizer>();
+        static AVSpeechSynthesizer speechSynthesizer;
 
         internal static Task<IEnumerable<Locale>> PlatformGetLocalesAsync() =>
             Task.FromResult(AVSpeechSynthesisVoice.GetSpeechVoices()
@@ -51,8 +51,10 @@ namespace Xamarin.Essentials
             var tcsUtterance = new TaskCompletionSource<bool>();
             try
             {
-                speechSynthesizer.Value.DidFinishSpeechUtterance += OnFinishedSpeechUtterance;
-                speechSynthesizer.Value.SpeakUtterance(speechUtterance);
+                speechSynthesizer ??= new AVSpeechSynthesizer();
+
+                speechSynthesizer.DidFinishSpeechUtterance += OnFinishedSpeechUtterance;
+                speechSynthesizer.SpeakUtterance(speechUtterance);
                 using (cancelToken.Register(TryCancel))
                 {
                     await tcsUtterance.Task;
@@ -60,12 +62,12 @@ namespace Xamarin.Essentials
             }
             finally
             {
-                speechSynthesizer.Value.DidFinishSpeechUtterance -= OnFinishedSpeechUtterance;
+                speechSynthesizer.DidFinishSpeechUtterance -= OnFinishedSpeechUtterance;
             }
 
             void TryCancel()
             {
-                speechSynthesizer.Value?.StopSpeaking(AVSpeechBoundary.Word);
+                speechSynthesizer?.StopSpeaking(AVSpeechBoundary.Word);
                 tcsUtterance?.TrySetResult(true);
             }
 


### PR DESCRIPTION
### Description of Change ###

Seems as thought he lazy isn't linker safe, which makes sense, so re-architect as it isn't buying us anything.

### Bugs Fixed ###

- Related to issue #1207

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
