### PR TITLE
GH-1207 - Preserve AVSpeechSynthesizer type when linking

### DIFF
--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -11,12 +11,6 @@ namespace Xamarin.Essentials
     {
         static readonly Lazy<AVSpeechSynthesizer> speechSynthesizer = new Lazy<AVSpeechSynthesizer>();
 
-        static TextToSpeech()
-        {
-            // Since we are using Lazy, this will ensure it doesn't get linked out.
-            var linkerSafe = new AVSpeechSynthesizer();
-        }
-
         internal static Task<IEnumerable<Locale>> PlatformGetLocalesAsync() =>
             Task.FromResult(AVSpeechSynthesisVoice.GetSpeechVoices()
                 .Select(v => new Locale(v.Language, null, v.Language, v.Identifier)));
@@ -57,6 +51,10 @@ namespace Xamarin.Essentials
             var tcsUtterance = new TaskCompletionSource<bool>();
             try
             {
+                // Ensures linker doesn't remove.
+                if (DateTime.UtcNow.Ticks < 0)
+                    new AVSpeechSynthesizer();
+                
                 speechSynthesizer.Value.DidFinishSpeechUtterance += OnFinishedSpeechUtterance;
                 speechSynthesizer.Value.SpeakUtterance(speechUtterance);
                 using (cancelToken.Register(TryCancel))

--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Essentials
                 // Ensures linker doesn't remove.
                 if (DateTime.UtcNow.Ticks < 0)
                     new AVSpeechSynthesizer();
-                
+
                 speechSynthesizer.Value.DidFinishSpeechUtterance += OnFinishedSpeechUtterance;
                 speechSynthesizer.Value.SpeakUtterance(speechUtterance);
                 using (cancelToken.Register(TryCancel))

--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -11,6 +11,12 @@ namespace Xamarin.Essentials
     {
         static readonly Lazy<AVSpeechSynthesizer> speechSynthesizer = new Lazy<AVSpeechSynthesizer>();
 
+        static TextToSpeech()
+        {
+            // Since we are using Lazy, this will ensure it doesn't get linked out.
+            var linkerSafe = typeof(AVSpeechSynthesizer);
+        }
+
         internal static Task<IEnumerable<Locale>> PlatformGetLocalesAsync() =>
             Task.FromResult(AVSpeechSynthesisVoice.GetSpeechVoices()
                 .Select(v => new Locale(v.Language, null, v.Language, v.Identifier)));

--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Essentials
         static TextToSpeech()
         {
             // Since we are using Lazy, this will ensure it doesn't get linked out.
-            var linkerSafe = typeof(AVSpeechSynthesizer);
+            var linkerSafe = new AVSpeechSynthesizer();
         }
 
         internal static Task<IEnumerable<Locale>> PlatformGetLocalesAsync() =>


### PR DESCRIPTION
### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #1207 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
