### PR TITLE
Location: copy all properties in copy ctor

### DIFF
--- a/Xamarin.Essentials/Types/Location.shared.cs
+++ b/Xamarin.Essentials/Types/Location.shared.cs
@@ -47,8 +47,12 @@ namespace Xamarin.Essentials
             Latitude = point.Latitude;
             Longitude = point.Longitude;
             Timestamp = DateTime.UtcNow;
+            Altitude = point.Altitude;
+            Accuracy = point.Accuracy;
+            VerticalAccuracy = point.VerticalAccuracy;
             Speed = point.Speed;
             Course = point.Course;
+            IsFromMockProvider = point.IsFromMockProvider;
         }
 
         public DateTimeOffset Timestamp { get; set; }


### PR DESCRIPTION
### Description of Change ###

The copy constructor of the Location class currently only copies a few of its properties, namely:

* Latitude, Longitude, Speed, Course

but is failing to copy several others:

* Altitude, Accuracy, VerticalAccuracy, IsFromMockProvider

This PR makes sure that all properties are set in the copy ctor.

### API Changes ###

* None

### Behavioral Changes ###

* None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
