### PR TITLE
File picker improvements

### DIFF
--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -91,11 +91,10 @@ namespace Xamarin.Essentials
                 var result = await IntermediateActivity.StartAsync(pickerIntent, requestCodeFilePicker);
 
                 var resultList = new List<FilePickerResult>();
-                for (var index = 0; index < result.ClipData.ItemCount; index++)
-                {
-                    var data = result.ClipData.GetItemAt(index);
 
-                    var contentUri = data.Uri;
+                if (result.ClipData == null)
+                {
+                    var contentUri = result.Data;
 
                     if (Build.VERSION.SdkInt >= BuildVersionCodes.Kitkat)
                     {
@@ -105,6 +104,24 @@ namespace Xamarin.Essentials
                     }
 
                     resultList.Add(new FilePickerResult(contentUri));
+                }
+                else
+                {
+                    for (var index = 0; index < result.ClipData.ItemCount; index++)
+                    {
+                        var data = result.ClipData.GetItemAt(index);
+
+                        var contentUri = data.Uri;
+
+                        if (Build.VERSION.SdkInt >= BuildVersionCodes.Kitkat)
+                        {
+                            Platform.AppContext.ContentResolver.TakePersistableUriPermission(
+                                contentUri,
+                                ActivityFlags.GrantReadUriPermission);
+                        }
+
+                        resultList.Add(new FilePickerResult(contentUri));
+                    }
                 }
 
                 return resultList;

--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -165,10 +165,15 @@ namespace Xamarin.Essentials
             // resolve file name by querying content provider for display name
             var filename = QueryContentResolverColumn(contentUri, MediaStore.MediaColumns.DisplayName);
 
-            if (!string.IsNullOrWhiteSpace(filename))
-                return filename;
+            if (string.IsNullOrWhiteSpace(filename))
+            {
+                filename = Path.GetFileName(WebUtility.UrlDecode(contentUri.ToString()));
+            }
 
-            return Path.GetFileName(WebUtility.UrlDecode(contentUri.ToString()));
+            if (!Path.HasExtension(filename))
+                filename = filename.TrimEnd('.') + '.' + GetFileExtensionFromUri(contentUri);
+
+            return filename;
         }
 
         static string QueryContentResolverColumn(global::Android.Net.Uri contentUri, string columnName)
@@ -185,6 +190,12 @@ namespace Xamarin.Essentials
             }
 
             return text;
+        }
+
+        static string GetFileExtensionFromUri(global::Android.Net.Uri uri)
+        {
+            var mimeType = Application.Context.ContentResolver.GetType(uri);
+            return mimeType != null ? global::Android.Webkit.MimeTypeMap.Singleton.GetExtensionFromMimeType(mimeType) : string.Empty;
         }
 
         Task<Stream> PlatformOpenReadStreamAsync()

--- a/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
@@ -22,8 +22,8 @@ namespace Xamarin.Essentials
 
             // Note: Importing (UIDocumentPickerMode.Import) makes a local copy of the document,
             // while opening (UIDocumentPickerMode.Open) opens the document directly. We do the
-            // first, so the user has to read the file immediately.
-            var documentPicker = new DocumentPicker(allowedUtis, UIDocumentPickerMode.Import);
+            // latter, so the user accesses the original file.
+            var documentPicker = new DocumentPicker(allowedUtis, UIDocumentPickerMode.Open);
 
             var tcs = new TaskCompletionSource<FilePickerResult>();
 
@@ -69,8 +69,8 @@ namespace Xamarin.Essentials
 
             // Note: Importing (UIDocumentPickerMode.Import) makes a local copy of the document,
             // while opening (UIDocumentPickerMode.Open) opens the document directly. We do the
-            // first, so the user has to read the file immediately.
-            var documentPicker = new DocumentPicker(allowedUtis, UIDocumentPickerMode.Import);
+            // latter, so the user accesses the original file.
+            var documentPicker = new DocumentPicker(allowedUtis, UIDocumentPickerMode.Open);
             documentPicker.AllowsMultipleSelection = true;
 
             var tcs = new TaskCompletionSource<IEnumerable<FilePickerResult>>();


### PR DESCRIPTION
### Description of Change ###

This is a PR with improvements of the FilePicker implementation on the 'dev/file-picker' branch. Some of the changesets are ports from [jfversluis' FilePicker implementation](https://github.com/jfversluis/FilePicker-Plugin-for-Xamarin-and-Windows).

### Bugs Fixed ###

- 0d24658 fixes Android permission handling; one user reported that using `ActionOpenDocument` and calling `TakePersistableUriPermission` fixes a permission issue on newer Android version
- 7e6237f  uses the MIME type when the file name doesn't contain a file extension yet. This is for users that determine what to do with the picked file based on the file extension and the content provider doesn't provide the filename.
- e84334d: When using multi-file picking, Android returns data in `ClipData`, except for when the user only selects one file (duh!)
- f378202 adds the change from #1194 to use UIDocumentPickerMode.Open on iOS

### API Changes ###

None

### Behavioral Changes ###

The returned picked file patjs should now be accessible even after app restarts.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
