### PR TITLE
Email: Open only email apps

### DIFF
--- a/Xamarin.Essentials/Email/Email.android.cs
+++ b/Xamarin.Essentials/Email/Email.android.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Android.Content;
+using Android.Net;
 using Android.OS;
 using Android.Text;
 using Android.Webkit;
@@ -36,6 +37,7 @@ namespace Xamarin.Essentials
             var action = message?.Attachments?.Count > 1 ? Intent.ActionSendMultiple : Intent.ActionSend;
             var intent = new Intent(action);
             intent.SetType("message/rfc822");
+			intent.SetData(Uri.Parse("mailto:")); // only email apps should handle this
 
             if (!string.IsNullOrEmpty(message?.Body))
             {

--- a/Xamarin.Essentials/Email/Email.android.cs
+++ b/Xamarin.Essentials/Email/Email.android.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Android.Content;
-using Android.Net;
 using Android.OS;
 using Android.Text;
 using Android.Webkit;
+using Uri = Android.Net.Uri;
 
 namespace Xamarin.Essentials
 {

--- a/Xamarin.Essentials/Email/Email.android.cs
+++ b/Xamarin.Essentials/Email/Email.android.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Essentials
             var action = message?.Attachments?.Count > 1 ? Intent.ActionSendMultiple : Intent.ActionSend;
             var intent = new Intent(action);
             intent.SetType("message/rfc822");
-			intent.SetData(Uri.Parse("mailto:")); // only email apps should handle this
+            intent.SetData(Uri.Parse("mailto:")); // only email apps should handle this
 
             if (!string.IsNullOrEmpty(message?.Body))
             {


### PR DESCRIPTION
### Description of Change ###

open email applications only when call Email.ComposeAsync(). 
related issue #1081 
ref:
https://developer.android.com/guide/components/intents-common#Email

### API Changes ###

none


### Behavioral Changes ###

open email applications only.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
