### PR TITLE
Fixes #1247 Must set SourceRect in iOS 13

### DIFF
--- a/Xamarin.Essentials/Share/Share.ios.cs
+++ b/Xamarin.Essentials/Share/Share.ios.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Essentials
             {
                 activityController.PopoverPresentationController.SourceView = vc.View;
 
-                if (request.PresentationSourceBounds != Rectangle.Empty)
+                if (request.PresentationSourceBounds != Rectangle.Empty || Platform.HasOSVersion(13, 0))
                     activityController.PopoverPresentationController.SourceRect = request.PresentationSourceBounds.ToPlatformRectangle();
             }
 


### PR DESCRIPTION
### Description of Change ###

iPadOS really wants you to set a sourcerect :( it will default to 0,0,0,0, but developers should specify a correct area to open it.

### Bugs Fixed ###

- Related to issue #1247

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###
None

### Behavioral Changes ###

Will now open in the same place on iOS 13 as iOS 12
### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
