### PR TITLE
[Enhancement] Make AuthenticationCode and State available on WebAuthenticationResult for AppleAuthenticator

### DIFF
--- a/Xamarin.Essentials/WebAuthenticator/AppleSignInAuthenticator.ios.cs
+++ b/Xamarin.Essentials/WebAuthenticator/AppleSignInAuthenticator.ios.cs
@@ -44,6 +44,8 @@ namespace Xamarin.Essentials
 
             var appleAccount = new WebAuthenticatorResult();
             appleAccount.Properties.Add("id_token", new NSString(creds.IdentityToken, NSStringEncoding.UTF8).ToString());
+            appleAccount.Properties.Add("authorization_code", new NSString(creds.AuthorizationCode, NSStringEncoding.UTF8).ToString());
+            appleAccount.Properties.Add("state", creds.State);
             appleAccount.Properties.Add("email", creds.Email);
             appleAccount.Properties.Add("user_id", creds.User);
             appleAccount.Properties.Add("name", NSPersonNameComponentsFormatter.GetLocalizedString(creds.FullName, NSPersonNameComponentsFormatterStyle.Default, NSPersonNameComponentsFormatterOptions.Phonetic));


### PR DESCRIPTION
### Description of Change ###

Just added AuthenticationCode and State properties to the WebResult.Properties dictionary.

### Bugs Fixed ###

- Related to issue #1253

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
