### PR TITLE
Flish/#1225 default mime type for attachments

### DIFF
--- a/Xamarin.Essentials/FileSystem/FileSystem.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.ios.tvos.watchos.cs
@@ -50,14 +50,7 @@ namespace Xamarin.Essentials
 
             var id = UTType.CreatePreferredIdentifier(UTType.TagClassFilenameExtension, extension, null);
             var mimeTypes = UTType.CopyAllTags(id, UTType.TagClassMIMEType);
-            if (mimeTypes != null && mimeTypes.Length > 0)
-            {
-                return mimeTypes[0];
-            }
-            else
-            {
-                return null;
-            }
+            return mimeTypes?.Length > 0 ? mimeTypes[0] : null;
         }
 
         internal void PlatformInit(FileBase file)

--- a/Xamarin.Essentials/FileSystem/FileSystem.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.ios.tvos.watchos.cs
@@ -50,7 +50,14 @@ namespace Xamarin.Essentials
 
             var id = UTType.CreatePreferredIdentifier(UTType.TagClassFilenameExtension, extension, null);
             var mimeTypes = UTType.CopyAllTags(id, UTType.TagClassMIMEType);
-            return mimeTypes.Length > 0 ? mimeTypes[0] : null;
+            if (mimeTypes != null && mimeTypes.Length > 0)
+            {
+                return mimeTypes[0];
+            }
+            else
+            {
+                return null;
+            }
         }
 
         internal void PlatformInit(FileBase file)

--- a/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
@@ -73,7 +73,9 @@ namespace Xamarin.Essentials
 
             // we haven't been able to determine this
             // leave it up to the sender
-            return null;
+            // return null;
+            // Instead of returning null return a catch all mime-type - see #1225
+            return "application/octet-stream";
         }
 
         string attachmentName;

--- a/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
@@ -70,11 +70,6 @@ namespace Xamarin.Essentials
                 if (!string.IsNullOrWhiteSpace(content))
                     return content;
             }
-
-            // we haven't been able to determine this
-            // leave it up to the sender
-            // return null;
-            // Instead of returning null return a catch all mime-type - see #1225
             return "application/octet-stream";
         }
 


### PR DESCRIPTION
### Description of Change ###

- Fixed Mimetypes being null and throwing a null exception if mimetype not found on iOS / TVOS
- default Mimetype if not found (null) to be "application/octet-stream" as suggested

No new tests or documentation changes required, sample / test app can be provided.  Simple test is to try an attach a file with .log or .db extension to an email, which are not dound as mimetypes so woudl not be attached (exception)

```
var message = new EmailMessage
{
	Subject = "TEST", Body = "BODY", To = new List<string> {"help@xyroh.com"}
};

message.BodyFormat = EmailBodyFormat.PlainText;
if (File.Exists(attachmentPath))
{
	Console.WriteLine("FILE " + attachmentPath + " FOUND");
	message.Attachments.Add(
		new EmailAttachment(attachmentPath)); //works as long as extension is txt (mime types!)
}

try
{
	foreach (var attach in message.Attachments)
	{
		Console.WriteLine("Type " + attach.ContentType.ToString());
	}
	await Email.ComposeAsync(message);
}
```

### Bugs Fixed ###

- Related to issue #1225 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

None

### Behavioral Changes ###

If you were checking for null as as the ContentType (on non iOS platforms) then you will now always get a result, iOS / tvOS was throwing an exception anyway

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
