### PR TITLE
Add comment to Startup.cs

### DIFF
--- a/Samples/Sample.Server.WebAuthenticator/Startup.cs
+++ b/Samples/Sample.Server.WebAuthenticator/Startup.cs
@@ -62,6 +62,11 @@ namespace Sample.Server.WebAuthenticator
                         => WebHostEnvironment.ContentRootFileProvider.GetFileInfo($"AuthKey_{keyId}.p8"));
                     a.SaveTokens = true;
                 });
+            /*** For Apple signin
+If you are running the app on Azure you must add the Configuration setting 
+WEBSITE_LOAD_USER_PROFILE = 1
+Without this setting you will get a File Not Found exception when AppleAuthenticationHandler tries to generate a certificate using your Auth_{keyId].P8 file.
+***/
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
The cert generation step seems to require access to the User Profile as per Microsoft s documentation here.
https://docs.microsoft.com/en-us/azure/app-service/configure-ssl-certificate-in-code

---------------------

(From the Microsoft documentation stated above)
ASP.NET and ASP.NET Core on Windows must access the certificate store even if you load a certificate from a file. 

-----------------------------------------------------------------------------------------------------------------------------

Without setting the WEBSITE_LOAD_USER_PROFILE = 1 in the Azure web app configuration, the Apple sign-in will throw an exception on the server which is not always easy to debug. The app may work perfectly well on the users test IIS Server only to fail when deployed. The exception is a File Not Found exception which is misleading and caused me more than 2 days of chasing dead ends.

### Description of Change ###

Documentation for users of the API doing Apple Sign-in Authentication over an Azure Service App

```

- [X ] Updated documentation ([see walkthrough]
