### PR TITLE
Fixed bug #1263 (WebAuthenticator - User closes dialog box)

### DIFF
--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.uwp.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.uwp.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Essentials
                     var resultUri = new Uri(r.ResponseData.ToString());
                     return new WebAuthenticatorResult(resultUri);
                 case WebAuthenticationStatus.UserCancel:
-                    return null;
+                    throw new TaskCanceledException();
                 case WebAuthenticationStatus.ErrorHttp:
                     throw new UnauthorizedAccessException();
                 default:

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.uwp.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.uwp.cs
@@ -25,6 +25,8 @@ namespace Xamarin.Essentials
                     // For GET requests this is a URI:
                     var resultUri = new Uri(r.ResponseData.ToString());
                     return new WebAuthenticatorResult(resultUri);
+                case WebAuthenticationStatus.UserCancel:
+                    return null;
                 case WebAuthenticationStatus.ErrorHttp:
                     throw new UnauthorizedAccessException();
                 default:


### PR DESCRIPTION
Fxed the bug where when the user canceled operation, an exception is thrown.

### Description of Change ###

According to documentation,  `WebAuthenticationBroker.AuthenticateAsync` can return `ResponseStatus` with `WebAuthenticationStatus.UserCancel` value.
Now, if that case occours, `null` is returned instead of `Exception(r.ResponseData.ToString())`.

### Bugs Fixed ###

- Related to issue #1263 

### API Changes ###

None.

### Behavioral Changes ###

According the documentation, now the behavior is correct and `WebAuthenticator.AuthenticateAsync` returns `null` when the user canceled the operation in UWP.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
