### PR TITLE
Return user's email as part of the properties.

### DIFF
--- a/Samples/Sample.Server.WebAuthenticator/Controllers/MobileAuthController.cs
+++ b/Samples/Sample.Server.WebAuthenticator/Controllers/MobileAuthController.cs
@@ -33,7 +33,7 @@ namespace Sample.Server.WebAuthenticator
             {
                var claims = auth.Principal.Identities.FirstOrDefault()?.Claims;
                     string email = string.Empty;
-                    email = claims?.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")?.Value;
+                    email = claims?.FirstOrDefault(c => c.Type == System.Security.Claims.ClaimTypes.Email)?.Value;
                 // Get parameters to send back to the callback
                 var qs = new Dictionary<string, string>
             {

--- a/Samples/Sample.Server.WebAuthenticator/Controllers/MobileAuthController.cs
+++ b/Samples/Sample.Server.WebAuthenticator/Controllers/MobileAuthController.cs
@@ -31,12 +31,16 @@ namespace Sample.Server.WebAuthenticator
             }
             else
             {
+               var claims = auth.Principal.Identities.FirstOrDefault()?.Claims;
+                    string email = string.Empty;
+                    email = claims?.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")?.Value;
                 // Get parameters to send back to the callback
                 var qs = new Dictionary<string, string>
             {
                 { "access_token", auth.Properties.GetTokenValue("access_token") },
                 { "refresh_token", auth.Properties.GetTokenValue("refresh_token") ?? string.Empty },
-                { "expires", (auth.Properties.ExpiresUtc?.ToUnixTimeSeconds() ?? -1).ToString() }
+                { "expires", (auth.Properties.ExpiresUtc?.ToUnixTimeSeconds() ?? -1).ToString() },
+                {"email", email}
             };
 
                 // Build the result url


### PR DESCRIPTION
get the email from the Claims (not sure in what situation multiple identities would be returned, but I am taking the Claims from the first one,  then add the email to the returning Dictionary.

On the Client the user can retrieve the email with....

WebAuthenticatorResult result = await WebAuthenticator.AuthenticateAsync(authUrl, callbackUrl);
if (result.Properties.Contains("email"))
    string email = Uri.UnescapeDataString(result.Properties["email"]);

### Description of Change ###

Return email with auth properties.


