### PR TITLE
iOS: Fixes leaks in WebAuthenticator

### DIFF
--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -67,21 +67,21 @@ namespace Xamarin.Essentials
                         void_objc_msgSend_IntPtr(was.Handle, ObjCRuntime.Selector.GetHandle("setPresentationContextProvider:"), ctx.Handle);
                     }
 
-                    was.Start();
-                    var result = await tcsResponse.Task;
-                    was?.Dispose();
-                    was = null;
-                    return result;
+                    using (was)
+                    {
+                        was.Start();
+                        return await tcsResponse.Task;
+                    }
                 }
 
                 if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
                 {
                     sf = new SFAuthenticationSession(new NSUrl(url.OriginalString), scheme, AuthSessionCallback);
-                    sf.Start();
-                    var result = await tcsResponse.Task;
-                    sf?.Dispose();
-                    sf = null;
-                    return result;
+                    using (sf)
+                    {
+                        sf.Start();
+                        return await tcsResponse.Task;
+                    }
                 }
 
                 // THis is only on iOS9+ but we only support 10+ in Essentials anyway


### PR DESCRIPTION
The WebAuthenticator leaks the `ASWebAuthenticationSession` or `SFAuthenticationSession` if the login attempt is being cancelled.

### Description of Change ###

Surrounds the awaited task with a `try/finally` to dispose the authentication session even for the cancelled or failed cases.

Adds no tests as this is not automatically reproducible (would require ui test)

### Bugs Fixed ###

- Related to issue #1295
### API Changes ###

None

### Behavioral Changes ###

The `was` and `sf` fields are now disposed and set to null in all cases.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
