### PR TITLE
Updated Location.Course documentation

### DIFF
--- a/docs/en/Xamarin.Essentials/Location.xml
+++ b/docs/en/Xamarin.Essentials/Location.xml
@@ -279,7 +279,9 @@
         <summary>Degrees relative to true north.</summary>
         <value>0..360 in degrees relative to true north. null if unavailable.</value>
         <remarks>
-          <para></para>
+          <para>
+          Requires a high accuracy query of location and may not be returned by Geolocation.GetLastKnownLocationAsync 
+          </para>
         </remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
### Description of Change ###

Updated Location.Course documentation to show that GetLastKnowLocationAsync wont return a value for Course.

### Bugs Fixed ###

- Related to issue #

https://developercommunity.visualstudio.com/content/problem/1023939/xamarin-essentials-geolocation-course-is-always-nu.html


### PR Checklist ###

- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
