### PR TITLE
Audio will stop immediately when the Task is cancelled.

### DIFF
--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Essentials
 
             void TryCancel()
             {
-                speechSynthesizer.Value?.StopSpeaking(AVSpeechBoundary.Word);
+                speechSynthesizer.Value?.StopSpeaking(AVSpeechBoundary.Immediate);
                 tcsUtterance?.TrySetResult(true);
             }
 


### PR DESCRIPTION
In iOS, Speech output continues for some milliseconds and in some rare cases some seconds after the Task is Cancelled, because it attempts to finish the already speaking word. This is in contrary to the Android behaviour, where the speech stops immediately. 
Since TextToSpeech is in a Nuget package, there is no way to detect when the speech stops after it has been cancelled. It will be helpful especially when we have to do "Speech To Text" right after cancelling the ongoing TextToSpeech. Otherwise, parts of the speech output are getting fed to Speech To Text implementation. The only other solution would be to "Task.Delay" for some seconds assuming speech output would finish in that timeframe, which is kind of ugly and bad UX.

### Description of Change ###

_AVSpeechBoundary.Immediate_ is passed as parameter to _AVSpeechSynthesizer.StopSpeaking_  instead of _AVSpeechBoundary.Word_

### Bugs Fixed ###

- Related to issue #1318 


### Behavioral Changes ###

Speech output will stop immediately when Task will be cancelled.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
