### PR TITLE
[Tizen] Update the FilePicker implementation

### DIFF
--- a/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
@@ -11,10 +11,12 @@ namespace Xamarin.Essentials
 {
     public static partial class FilePicker
     {
-        static Task<IEnumerable<FilePickerResult>> PlatformPickAsync(PickOptions options, bool allowMultiple = false)
+        static List<FilePickerResult> resultFiles = new List<FilePickerResult>();
+
+        static async Task<IEnumerable<FilePickerResult>> PlatformPickAsync(PickOptions options, bool allowMultiple = false)
         {
             Permissions.EnsureDeclared<Permissions.LaunchApp>();
-            Permissions.EnsureDeclared<Permissions.StorageRead>();
+            await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
 
             var tcs = new TaskCompletionSource<IEnumerable<FilePickerResult>>();
 
@@ -30,8 +32,6 @@ namespace Xamarin.Essentials
 
             AppControl.SendLaunchRequest(appControl, (request, reply, result) =>
             {
-                var resultFiles = new List<FilePickerResult>();
-
                 if (result == AppControlReplyResult.Succeeded)
                 {
                     if (reply.ExtraData.Count() > 0)
@@ -44,7 +44,8 @@ namespace Xamarin.Essentials
                 tcs.TrySetResult(resultFiles);
             });
 
-            return tcs.Task;
+            await tcs.Task;
+            return resultFiles;
         }
     }
 

--- a/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
@@ -42,8 +42,7 @@ namespace Xamarin.Essentials
                 tcs.TrySetResult(fileResults);
             });
 
-            await tcs.Task;
-            return fileResults;
+            return await tcs.Task;
         }
     }
 

--- a/Xamarin.Essentials/Permissions/Permissions.tizen.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.tizen.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Tizen.Security;
 
@@ -43,7 +42,8 @@ namespace Xamarin.Essentials
 
                 foreach (var (tizenPrivilege, isRuntime) in tizenPrivileges)
                 {
-                    if (PrivacyPrivilegeManager.CheckPermission(tizenPrivilege) == CheckResult.Ask)
+                    var checkResult = PrivacyPrivilegeManager.CheckPermission(tizenPrivilege);
+                    if (checkResult == CheckResult.Ask)
                     {
                         if (ask)
                         {
@@ -63,7 +63,7 @@ namespace Xamarin.Essentials
                         }
                         return PermissionStatus.Denied;
                     }
-                    else if (PrivacyPrivilegeManager.CheckPermission(tizenPrivilege) == CheckResult.Deny)
+                    else if (checkResult == CheckResult.Deny)
                     {
                         return PermissionStatus.Denied;
                     }
@@ -193,10 +193,14 @@ namespace Xamarin.Essentials
 
         public partial class StorageRead : BasePlatformPermission
         {
+            public override (string tizenPrivilege, bool isRuntime)[] RequiredPrivileges =>
+                new[] { ("http://tizen.org/privilege/mediastorage", true) };
         }
 
         public partial class StorageWrite : BasePlatformPermission
         {
+            public override (string tizenPrivilege, bool isRuntime)[] RequiredPrivileges =>
+                new[] { ("http://tizen.org/privilege/mediastorage", true) };
         }
 
         public partial class Vibrate : BasePlatformPermission


### PR DESCRIPTION
### Description of Change ###

This is a fix for requesting permission in order for the file picker to work properly in Tizen.
As of Tizen 4.0 and later, media storage privilege (`http://tizen.org/privilege/mediastorage`) should be treated as user privacy privilege.
 - http://tizen.org/privilege/mediastorage
   - Allows the application to read and write files in media folders.
 - See [here ](https://www.tizen.org/privilege)full privilege.

<img src="https://user-images.githubusercontent.com/1029134/88169667-48927400-cc57-11ea-9f97-2412c1b18ed7.gif" width=320/>


### Bugs Fixed ###

None

### API Changes ###

None


### Behavioral Changes ###

In tizen, FilePicker requesting the user's consent to use.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
