### PR TITLE
Add ability to send SMS in background. (see #1130)

### DIFF
--- a/Xamarin.Essentials/Sms/Sms.android.cs
+++ b/Xamarin.Essentials/Sms/Sms.android.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Android.Content;
 using Android.OS;
 using Android.Provider;
-
+using Android.Telephony;
 using AndroidUri = Android.Net.Uri;
 
 namespace Xamarin.Essentials
@@ -15,6 +15,9 @@ namespace Xamarin.Essentials
 
         internal static bool IsComposeSupported
             => Platform.IsIntentSupported(CreateIntent(null, new List<string> { "0000000000" }));
+
+        internal static bool IsComposeInBackgroundSupported
+            => true;
 
         static Task PlatformComposeAsync(SmsMessage message)
         {
@@ -28,6 +31,14 @@ namespace Xamarin.Essentials
             intent.SetFlags(flags);
 
             Platform.AppContext.StartActivity(intent);
+
+            return Task.FromResult(true);
+        }
+
+        static Task PlatformComposeInBackgroundAsync(SmsMessage message)
+        {
+            var messageParts = SmsManager.Default.DivideMessage(message.Body);
+            SmsManager.Default.SendMultipartTextMessage(message.Recipients.First(), null, messageParts, null, null);
 
             return Task.FromResult(true);
         }

--- a/Xamarin.Essentials/Sms/Sms.ios.cs
+++ b/Xamarin.Essentials/Sms/Sms.ios.cs
@@ -9,6 +9,9 @@ namespace Xamarin.Essentials
         internal static bool IsComposeSupported
             => MFMessageComposeViewController.CanSendText;
 
+        internal static bool IsComposeInBackgroundSupported
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
+
         static Task PlatformComposeAsync(SmsMessage message)
         {
             // do this first so we can throw as early as possible
@@ -32,5 +35,8 @@ namespace Xamarin.Essentials
 
             return tcs.Task;
         }
+
+        static Task PlatformComposeInBackgroundAsync(SmsMessage message)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 }

--- a/Xamarin.Essentials/Sms/Sms.macos.cs
+++ b/Xamarin.Essentials/Sms/Sms.macos.cs
@@ -11,6 +11,9 @@ namespace Xamarin.Essentials
         internal static bool IsComposeSupported =>
             MainThread.InvokeOnMainThread(() => NSWorkspace.SharedWorkspace.UrlForApplication(NSUrl.FromString("sms:")) != null);
 
+        internal static bool IsComposeInBackgroundSupported
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
+
         static Task PlatformComposeAsync(SmsMessage message)
         {
             var recipients = string.Join(",", message.Recipients.Select(r => Uri.EscapeDataString(r)));
@@ -24,5 +27,8 @@ namespace Xamarin.Essentials
             NSWorkspace.SharedWorkspace.OpenUrl(nsurl);
             return Task.CompletedTask;
         }
+
+        static Task PlatformComposeInBackgroundAsync(SmsMessage message)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 }

--- a/Xamarin.Essentials/Sms/Sms.netstandard.tvos.watchos.cs
+++ b/Xamarin.Essentials/Sms/Sms.netstandard.tvos.watchos.cs
@@ -7,7 +7,13 @@ namespace Xamarin.Essentials
         internal static bool IsComposeSupported
             => throw ExceptionUtils.NotSupportedOrImplementedException;
 
+        internal static bool IsComposeInBackgroundSupported
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
+
         static Task PlatformComposeAsync(SmsMessage message)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+        static Task PlatformComposeInBackgroundAsync(SmsMessage message)
             => throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 }

--- a/Xamarin.Essentials/Sms/Sms.shared.cs
+++ b/Xamarin.Essentials/Sms/Sms.shared.cs
@@ -14,13 +14,28 @@ namespace Xamarin.Essentials
             if (!IsComposeSupported)
                 throw new FeatureNotSupportedException();
 
+            FillMessageIfAnyMandatoryFieldsIsNull(message);
+
+            return PlatformComposeAsync(message);
+        }
+
+        public static Task ComposeInBackgroundAsync(SmsMessage message)
+        {
+            if (!IsComposeInBackgroundSupported)
+                throw new FeatureNotSupportedException();
+
+            FillMessageIfAnyMandatoryFieldsIsNull(message);
+
+            return PlatformComposeInBackgroundAsync(message);
+        }
+
+        static void FillMessageIfAnyMandatoryFieldsIsNull(SmsMessage message)
+        {
             if (message == null)
                 message = new SmsMessage();
 
             if (message?.Recipients == null)
                 message.Recipients = new List<string>();
-
-            return PlatformComposeAsync(message);
         }
     }
 

--- a/Xamarin.Essentials/Sms/Sms.tizen.cs
+++ b/Xamarin.Essentials/Sms/Sms.tizen.cs
@@ -8,6 +8,9 @@ namespace Xamarin.Essentials
         internal static bool IsComposeSupported
             => Platform.GetFeatureInfo<bool>("network.telephony.sms");
 
+        internal static bool IsComposeInBackgroundSupported
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
+
         static Task PlatformComposeAsync(SmsMessage message)
         {
             Permissions.EnsureDeclared<Permissions.LaunchApp>();
@@ -27,5 +30,8 @@ namespace Xamarin.Essentials
 
             return Task.CompletedTask;
         }
+
+        static Task PlatformComposeInBackgroundAsync(SmsMessage message)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 }

--- a/Xamarin.Essentials/Sms/Sms.uwp.cs
+++ b/Xamarin.Essentials/Sms/Sms.uwp.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Chat;
+using Windows.Devices.Sms;
 using Windows.Foundation.Metadata;
 
 namespace Xamarin.Essentials
@@ -8,6 +10,9 @@ namespace Xamarin.Essentials
     public static partial class Sms
     {
         internal static bool IsComposeSupported
+            => ApiInformation.IsTypePresent("Windows.ApplicationModel.Chat.ChatMessageManager");
+
+        internal static bool IsComposeInBackgroundSupported
             => ApiInformation.IsTypePresent("Windows.ApplicationModel.Chat.ChatMessageManager");
 
         static Task PlatformComposeAsync(SmsMessage message)
@@ -20,6 +25,17 @@ namespace Xamarin.Essentials
                 chat.Recipients.Add(recipient);
 
             return ChatMessageManager.ShowComposeSmsMessageAsync(chat).AsTask();
+        }
+
+        static Task PlatformComposeInBackgroundAsync(SmsMessage message)
+        {
+            var sendingMessage = new SmsTextMessage2()
+            {
+                Body = message.Body,
+                To = message.Recipients.First()
+            };
+
+            return SmsDevice2.GetDefault().SendMessageAndGetResultAsync(sendingMessage).AsTask();
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

This PR complete some of requirements in #1130 
In this PR we have support send SMS silently in Android and UWP.

### API Changes ###

Added: 
 
- `static Task ComposeInBackgroundAsync(SmsMessage message)`
- `static bool IsComposeInBackgroundSupported`

Changed:

 - None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
