### PR TITLE
Fix crash of clipboard sample when text is null

### DIFF
--- a/Samples/Samples/ViewModel/ClipboardViewModel.cs
+++ b/Samples/Samples/ViewModel/ClipboardViewModel.cs
@@ -59,7 +59,16 @@ namespace Samples.ViewModel
             LastCopied = $"Last copied text at {DateTime.UtcNow:T}";
         }
 
-        async void OnCopy() => await Clipboard.SetTextAsync(FieldValue);
+        async void OnCopy()
+        {
+            if (FieldValue == null)
+            {
+                await DisplayAlertAsync($"Text is null");
+                return;
+            }
+
+            await Clipboard.SetTextAsync(FieldValue);
+        }
 
         async void OnPaste()
         {


### PR DESCRIPTION
### Description of Change ###
This fixes crash of clipboard sample when text is null.

### API Changes ###
None

### Behavioral Changes ###

Sample app doesn't crash anymore.

### PR Checklist ###

- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
