### PR TITLE
[GH-1353] - Put null checks in file path provider on Android.

### DIFF
--- a/Xamarin.Essentials/Types/FileProvider.android.cs
+++ b/Xamarin.Essentials/Types/FileProvider.android.cs
@@ -92,21 +92,24 @@ namespace Xamarin.Essentials
             var publicLocations = new List<string>
             {
 #if __ANDROID_29__
-                Platform.AppContext.GetExternalFilesDir(null).CanonicalPath,
+                Platform.AppContext?.GetExternalFilesDir(null)?.CanonicalPath,
 #else
 #pragma warning disable CS0618 // Type or member is obsolete
-                AndroidEnvironment.ExternalStorageDirectory.CanonicalPath,
+                AndroidEnvironment.ExternalStorageDirectory?.CanonicalPath,
 #pragma warning restore CS0618 // Type or member is obsolete
 #endif
-                Platform.AppContext.ExternalCacheDir.CanonicalPath
+                Platform.AppContext?.ExternalCacheDir?.CanonicalPath
             };
 
             // the internal cache path is available only by file provider in N+
             if (Platform.HasApiLevelN)
-                publicLocations.Add(Platform.AppContext.CacheDir.CanonicalPath);
+                publicLocations.Add(Platform.AppContext?.CacheDir?.CanonicalPath);
 
             foreach (var location in publicLocations)
             {
+                if (string.IsNullOrWhiteSpace(location))
+                    continue;
+
                 // make sure we have a trailing slash
                 var suffixedPath = filename.EndsWith(Java.IO.File.Separator)
                     ? filename


### PR DESCRIPTION
### Description of Change ###

Put null checks in file path provider on Essentials.

### Bugs Fixed ###

- Related to issue  Fixes #1353

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
