### PR TITLE
FileNotFoundException thrown by Web Authenticator in UWP. Fixed #1357

### DIFF
--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.uwp.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.uwp.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -17,20 +19,27 @@ namespace Xamarin.Essentials
             if (!IsUriProtocolDeclared(callbackUrl.Scheme))
                 throw new InvalidOperationException($"You need to declare the windows.protocol usage of the protocol/scheme `{callbackUrl.Scheme}` in your AppxManifest.xml file");
 
-            var r = await WebAuthenticationBroker.AuthenticateAsync(WebAuthenticationOptions.None, url, callbackUrl);
-
-            switch (r.ResponseStatus)
+            try
             {
-                case WebAuthenticationStatus.Success:
-                    // For GET requests this is a URI:
-                    var resultUri = new Uri(r.ResponseData.ToString());
-                    return new WebAuthenticatorResult(resultUri);
-                case WebAuthenticationStatus.UserCancel:
-                    throw new TaskCanceledException();
-                case WebAuthenticationStatus.ErrorHttp:
-                    throw new UnauthorizedAccessException();
-                default:
-                    throw new Exception(r.ResponseData.ToString());
+                var r = await WebAuthenticationBroker.AuthenticateAsync(WebAuthenticationOptions.None, url, callbackUrl);
+
+                switch (r.ResponseStatus)
+                {
+                    case WebAuthenticationStatus.Success:
+                        // For GET requests this is a URI:
+                        var resultUri = new Uri(r.ResponseData.ToString());
+                        return new WebAuthenticatorResult(resultUri);
+                    case WebAuthenticationStatus.UserCancel:
+                        throw new TaskCanceledException();
+                    case WebAuthenticationStatus.ErrorHttp:
+                        throw new HttpRequestException("Error: " + r.ResponseErrorDetail);
+                    default:
+                        throw new Exception("Response: " + r.ResponseData.ToString() + "\nStatus: " + r.ResponseStatus);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                throw new TaskCanceledException();
             }
         }
 


### PR DESCRIPTION
When internet is turned off and user closes the WAB dialog in uwp, FileNotFoundException is thrown.

### Description of Change ###
Describe your changes here. 

### Bugs Fixed ###
- Related to issue #1357 

### API Changes ###
None

### Behavioral Changes ###
Like android and ios do, when dialog is closed, a TaskCanceledException is thrown.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
