### PR TITLE
Adding an IsSupported property

### DIFF
--- a/Samples/Samples/View/ScreenshotPage.xaml
+++ b/Samples/Samples/View/ScreenshotPage.xaml
@@ -22,7 +22,7 @@
                 <Image VerticalOptions="FillAndExpand"
                        MinimumHeightRequest="400"
                        MinimumWidthRequest="400"
-                       Source="{Binding Screenshot}" />
+                       Source="{Binding Image}" />
 
             </StackLayout>
         </ScrollView>

--- a/Samples/Samples/ViewModel/MediaPickerViewModel.cs
+++ b/Samples/Samples/ViewModel/MediaPickerViewModel.cs
@@ -18,10 +18,10 @@ namespace Samples.ViewModel
         public MediaPickerViewModel()
         {
             PickPhotoCommand = new Command(DoPickPhoto);
-            CapturePhotoCommand = new Command(DoCapturePhoto);
+            CapturePhotoCommand = new Command(DoCapturePhoto, () => MediaPicker.IsCaptureSupported);
 
             PickVideoCommand = new Command(DoPickVideo);
-            CaptureVideoCommand = new Command(DoCaptureVideo);
+            CaptureVideoCommand = new Command(DoCaptureVideo, () => MediaPicker.IsCaptureSupported);
         }
 
         public ICommand PickPhotoCommand { get; }

--- a/Samples/Samples/ViewModel/ScreenshotViewModel.cs
+++ b/Samples/Samples/ViewModel/ScreenshotViewModel.cs
@@ -12,15 +12,15 @@ namespace Samples.ViewModel
 
         public ScreenshotViewModel()
         {
-            ScreenshotCommand = new Command(async () => await CaptureScreenshot());
-            EmailCommand = new Command(async () => await EmailScreenshot());
+            ScreenshotCommand = new Command(async () => await CaptureScreenshot(), () => Screenshot.IsCaptureSupported);
+            EmailCommand = new Command(async () => await EmailScreenshot(), () => Screenshot.IsCaptureSupported);
         }
 
         public ICommand ScreenshotCommand { get; }
 
         public ICommand EmailCommand { get; }
 
-        public ImageSource Screenshot
+        public ImageSource Image
         {
             get => screenshot;
             set => SetProperty(ref screenshot, value);
@@ -28,15 +28,15 @@ namespace Samples.ViewModel
 
         async Task CaptureScreenshot()
         {
-            var mediaFile = await Xamarin.Essentials.Screenshot.CaptureAsync();
+            var mediaFile = await Screenshot.CaptureAsync();
             var stream = await mediaFile.OpenReadAsync(ScreenshotFormat.Png);
 
-            Screenshot = ImageSource.FromStream(() => stream);
+            Image = ImageSource.FromStream(() => stream);
         }
 
         async Task EmailScreenshot()
         {
-            var mediaFile = await Xamarin.Essentials.Screenshot.CaptureAsync();
+            var mediaFile = await Screenshot.CaptureAsync();
 
             var temp = Path.Combine(FileSystem.CacheDirectory, "screenshot.jpg");
             using (var stream = await mediaFile.OpenReadAsync(ScreenshotFormat.Jpeg))

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Essentials
 {
     public static partial class MediaPicker
     {
-        static bool PlatformIsCaptureAvailable
+        static bool PlatformIsCaptureSupported
             => Platform.AppContext.PackageManager.HasSystemFeature(PackageManager.FeatureCameraAny);
 
         static Task<FileResult> PlatformPickPhotoAsync(MediaPickerOptions options)

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Essentials
     {
         static UIImagePickerController picker;
 
-        static bool PlatformIsCaptureAvailable
+        static bool PlatformIsCaptureSupported
             => UIImagePickerController.IsSourceTypeAvailable(UIImagePickerControllerSourceType.Camera);
 
         static Task<FileResult> PlatformPickPhotoAsync(MediaPickerOptions options)

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.macos.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.macos.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Essentials
 {
     public static partial class MediaPicker
     {
-        static bool PlatformIsCaptureAvailable
+        static bool PlatformIsCaptureSupported
             => false;
 
         static async Task<FileResult> PlatformPickPhotoAsync(MediaPickerOptions options)

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.netstandard.watchos.tvos.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.netstandard.watchos.tvos.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Essentials
 {
     public static partial class MediaPicker
     {
-        static bool PlatformIsCaptureAvailable =>
+        static bool PlatformIsCaptureSupported =>
             throw new NotImplementedInReferenceAssemblyException();
 
         static Task<FileResult> PlatformPickPhotoAsync(MediaPickerOptions options) =>

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.shared.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.shared.cs
@@ -6,20 +6,30 @@ namespace Xamarin.Essentials
 {
     public static partial class MediaPicker
     {
-        public static bool IsCaptureAvailable
-            => PlatformIsCaptureAvailable;
+        public static bool IsCaptureSupported
+            => PlatformIsCaptureSupported;
 
         public static Task<FileResult> PickPhotoAsync(MediaPickerOptions options = null) =>
             PlatformPickPhotoAsync(options);
 
-        public static Task<FileResult> CapturePhotoAsync(MediaPickerOptions options = null) =>
-            PlatformCapturePhotoAsync(options);
+        public static Task<FileResult> CapturePhotoAsync(MediaPickerOptions options = null)
+        {
+            if (!IsCaptureSupported)
+                throw new FeatureNotSupportedException();
+
+            return PlatformCapturePhotoAsync(options);
+        }
 
         public static Task<FileResult> PickVideoAsync(MediaPickerOptions options = null) =>
             PlatformPickVideoAsync(options);
 
-        public static Task<FileResult> CaptureVideoAsync(MediaPickerOptions options = null) =>
-            PlatformCaptureVideoAsync(options);
+        public static Task<FileResult> CaptureVideoAsync(MediaPickerOptions options = null)
+        {
+            if (!IsCaptureSupported)
+                throw new FeatureNotSupportedException();
+
+            return PlatformCaptureVideoAsync(options);
+        }
     }
 
     public class MediaPickerOptions

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.tizen.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.tizen.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Essentials
 {
     public static partial class MediaPicker
     {
-        static bool PlatformIsCaptureAvailable
+        static bool PlatformIsCaptureSupported
                => true;
 
         static async Task<FileResult> PlatformPickPhotoAsync(MediaPickerOptions options)

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.uwp.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.uwp.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Essentials
 {
     public static partial class MediaPicker
     {
-        static bool PlatformIsCaptureAvailable
+        static bool PlatformIsCaptureSupported
             => true;
 
         static Task<FileResult> PlatformPickPhotoAsync(MediaPickerOptions options)

--- a/Xamarin.Essentials/Screenshot/Screenshot.android.cs
+++ b/Xamarin.Essentials/Screenshot/Screenshot.android.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Essentials
         static Task<ScreenshotResult> PlatformCaptureAsync()
         {
             if (Platform.WindowManager?.DefaultDisplay?.Flags.HasFlag(DisplayFlags.Secure) == true)
-                throw new FeatureNotSupportedException("Unable to take a screenshot of a secure window.");
+                throw new UnauthorizedAccessException("Unable to take a screenshot of a secure window.");
 
             var view = Platform.GetCurrentActivity(true)?.Window?.DecorView?.RootView;
             if (view == null)

--- a/Xamarin.Essentials/Screenshot/Screenshot.android.cs
+++ b/Xamarin.Essentials/Screenshot/Screenshot.android.cs
@@ -8,11 +8,14 @@ namespace Xamarin.Essentials
 {
     public static partial class Screenshot
     {
-        static bool PlatformCanCapture =>
-            Platform.WindowManager.DefaultDisplay?.Flags.HasFlag(DisplayFlags.Secure) == false;
+        static bool PlatformIsCaptureSupported =>
+            true;
 
         static Task<ScreenshotResult> PlatformCaptureAsync()
         {
+            if (Platform.WindowManager?.DefaultDisplay?.Flags.HasFlag(DisplayFlags.Secure) == true)
+                throw new FeatureNotSupportedException("Unable to take a screenshot of a secure window.");
+
             var view = Platform.GetCurrentActivity(true)?.Window?.DecorView?.RootView;
             if (view == null)
                 throw new NullReferenceException("Unable to find the main window.");

--- a/Xamarin.Essentials/Screenshot/Screenshot.ios.tvos.cs
+++ b/Xamarin.Essentials/Screenshot/Screenshot.ios.tvos.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Screenshot
     {
-        internal static bool PlatformCanCapture =>
+        internal static bool PlatformIsCaptureSupported =>
             UIScreen.MainScreen != null;
 
         static Task<ScreenshotResult> PlatformCaptureAsync()

--- a/Xamarin.Essentials/Screenshot/Screenshot.netstandard.tizen.watchos.macos.cs
+++ b/Xamarin.Essentials/Screenshot/Screenshot.netstandard.tizen.watchos.macos.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Screenshot
     {
-        static bool PlatformCanCapture =>
+        static bool PlatformIsCaptureSupported =>
             throw ExceptionUtils.NotSupportedOrImplementedException;
 
         static Task<ScreenshotResult> PlatformCaptureAsync() =>

--- a/Xamarin.Essentials/Screenshot/Screenshot.shared.cs
+++ b/Xamarin.Essentials/Screenshot/Screenshot.shared.cs
@@ -5,11 +5,16 @@ namespace Xamarin.Essentials
 {
     public static partial class Screenshot
     {
-        public static bool IsCaptureAvailable
-            => PlatformCanCapture;
+        public static bool IsCaptureSupported
+            => PlatformIsCaptureSupported;
 
         public static Task<ScreenshotResult> CaptureAsync()
-            => PlatformCaptureAsync();
+        {
+            if (!IsCaptureSupported)
+                throw new FeatureNotSupportedException();
+
+            return PlatformCaptureAsync();
+        }
     }
 
     public partial class ScreenshotResult

--- a/Xamarin.Essentials/Screenshot/Screenshot.uwp.cs
+++ b/Xamarin.Essentials/Screenshot/Screenshot.uwp.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Essentials
 {
     public static partial class Screenshot
     {
-        internal static bool PlatformCanCapture =>
+        internal static bool PlatformIsCaptureSupported =>
             true;
 
         static async Task<ScreenshotResult> PlatformCaptureAsync()


### PR DESCRIPTION
### Description of Change ###

Adding an `IsSupported` property to `MediaPicker` and `Screenshot`.

I also moved the check for Android to the actual inline logic because this is a window flag that can change at any time, so rather check when using it. This is also not available when navigating, so any view setup logic will be incorrect.

### Bugs Fixed ###

- Related to issue #

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
