### PR TITLE
Correct the AppAction param order

### DIFF
--- a/DeviceTests/DeviceTests.Shared/AppActions_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/AppActions_Tests.cs
@@ -26,18 +26,22 @@ namespace DeviceTests
 
 #if __ANDROID_25__ || __IOS__
         [Fact]
-        public void GetSetItems()
+        public async Task GetSetItems()
         {
-            if (AppActions.IsSupported)
-            {
-                AppActions.Actions = new List<AppAction>
-                {
-                    new AppAction("TEST1", "Test 1", "This is a test", new System.Uri("myapp://test1")),
-                    new AppAction("TEST2", "Test 2", "This is a test 2", new System.Uri("myapp://test2")),
-                };
+            if (!AppActions.IsSupported)
+                return;
 
-                Assert.Contains(AppActions.Actions, a => a.ActionType == "TEST1");
-            }
+            var actions = new List<AppAction>
+            {
+                new AppAction("TEST1", "Test 1", "This is a test", "myapp://test1"),
+                new AppAction("TEST2", "Test 2", "This is a test 2", "myapp://test2"),
+            };
+
+            await AppActions.SetAsync(actions);
+
+            var get = await AppActions.GetAsync();
+
+            Assert.Contains(get, a => a.Id == "TEST1");
         }
 #endif
     }

--- a/Samples/Samples/App.xaml.cs
+++ b/Samples/Samples/App.xaml.cs
@@ -49,8 +49,8 @@ namespace Samples
             }
 
             await AppActions.SetAsync(
-                new AppAction("App Info", id: "app_info", icon: "app_info_action_icon"),
-                new AppAction("Battery Info", id: "battery_info"));
+                new AppAction("app_info", "App Info", icon: "app_info_action_icon"),
+                new AppAction("battery_info", "Battery Info"));
         }
 
         void AppActions_OnAppAction(object sender, AppActionEventArgs e)

--- a/Tests/AppActions_Tests.cs
+++ b/Tests/AppActions_Tests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using Xamarin.Essentials;
 using Xunit;
 
@@ -10,11 +8,11 @@ namespace Tests
     {
         [Fact]
         public void AppActions_SetActions() =>
-            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => AppActions.Actions = new List<AppAction>());
+            Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => AppActions.SetAsync(new List<AppAction>()));
 
         [Fact]
         public void AppActions_GetActions() =>
-            Assert.Throws<NotImplementedInReferenceAssemblyException>(() => AppActions.Actions);
+            Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => AppActions.GetAsync());
 
         [Fact]
         public void AppActions_IsSupported() =>

--- a/Xamarin.Essentials/AppActions/AppActions.android.cs
+++ b/Xamarin.Essentials/AppActions/AppActions.android.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Android.Content;
 using Android.Content.PM;
-using Android.Content.Res;
 using Android.Graphics.Drawables;
-using AndroidUri = Android.Net.Uri;
 
 namespace Xamarin.Essentials
 {
@@ -39,7 +36,7 @@ namespace Xamarin.Essentials
         }
 
         static AppAction ToAppAction(this ShortcutInfo shortcutInfo) =>
-            new AppAction(shortcutInfo.ShortLabel, shortcutInfo.LongLabel, shortcutInfo.Id);
+            new AppAction(shortcutInfo.Id, shortcutInfo.ShortLabel, shortcutInfo.LongLabel);
 
         const string extraAppActionId = "EXTRA_XE_APP_ACTION_ID";
         const string extraAppActionTitle = "EXTRA_XE_APP_ACTION_TITLE";
@@ -48,8 +45,8 @@ namespace Xamarin.Essentials
 
         internal static AppAction ToAppAction(this Intent intent)
             => new AppAction(
-                intent.GetStringExtra(extraAppActionTitle),
                 intent.GetStringExtra(extraAppActionId),
+                intent.GetStringExtra(extraAppActionTitle),
                 intent.GetStringExtra(extraAppActionSubtitle),
                 intent.GetStringExtra(extraAppActionIcon));
 

--- a/Xamarin.Essentials/AppActions/AppActions.ios.cs
+++ b/Xamarin.Essentials/AppActions/AppActions.ios.cs
@@ -37,15 +37,35 @@ namespace Xamarin.Essentials
             if (shortcutItem.UserInfo.TryGetValue((NSString)"id", out var idObj))
                 id = idObj?.ToString();
 
-            return new AppAction(shortcutItem.Type, id, shortcutItem.LocalizedTitle, shortcutItem.LocalizedSubtitle);
+            string icon = null;
+            if (shortcutItem.UserInfo.TryGetValue((NSString)"icon", out var iconObj))
+                icon = iconObj?.ToString();
+
+            return new AppAction(id, shortcutItem.LocalizedTitle, shortcutItem.LocalizedSubtitle, icon);
         }
 
-        static UIApplicationShortcutItem ToShortcutItem(this AppAction action) =>
-            new UIApplicationShortcutItem(
+        static UIApplicationShortcutItem ToShortcutItem(this AppAction action)
+        {
+            var keys = new List<NSString>();
+            var values = new List<NSObject>();
+
+            // id
+            keys.Add((NSString)"id");
+            values.Add((NSString)action.Id);
+
+            // icon
+            if (!string.IsNullOrEmpty(action.Icon))
+            {
+                keys.Add((NSString)"icon");
+                values.Add((NSString)action.Icon);
+            }
+
+            return new UIApplicationShortcutItem(
                 AppActions.Type,
                 action.Title,
                 action.Subtitle,
                 action.Icon != null ? UIApplicationShortcutIcon.FromTemplateImageName(action.Icon) : null,
-                new NSDictionary<NSString, NSObject>((NSString)"id", (NSString)action.Id.ToString()));
+                new NSDictionary<NSString, NSObject>(keys.ToArray(), values.ToArray()));
+        }
     }
 }

--- a/Xamarin.Essentials/AppActions/AppActions.shared.cs
+++ b/Xamarin.Essentials/AppActions/AppActions.shared.cs
@@ -34,12 +34,13 @@ namespace Xamarin.Essentials
 
     public class AppAction
     {
-        public AppAction(string title, string id, string subtitle = null, string icon = null)
+        public AppAction(string id, string title, string subtitle = null, string icon = null)
         {
-            Title = title;
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+            Title = title ?? throw new ArgumentNullException(nameof(title));
+
             Subtitle = subtitle;
             Icon = icon;
-            Id = id;
         }
 
         public string Title { get; set; }

--- a/Xamarin.Essentials/AppActions/AppActions.uwp.cs
+++ b/Xamarin.Essentials/AppActions/AppActions.uwp.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Essentials
         }
 
         static AppAction ToAction(this JumpListItem item)
-            => new AppAction(item.DisplayName, ArgumentsToId(item.Arguments), item.Description);
+            => new AppAction(ArgumentsToId(item.Arguments), item.DisplayName, item.Description);
 
         static string ArgumentsToId(string arguments)
         {


### PR DESCRIPTION
### Description of Change ###

- Tweak the AppAction param order
- Also fix the build error

### Bugs Fixed ###

- Related to issue #

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
