### PR TITLE
Include the OpenTK reference in macOS for System.Drawing.Color

### DIFF
--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -119,6 +119,7 @@
     <Compile Include="**\*.macos.*.cs" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors" />
+    <Reference Include="OpenTK-1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="mdoc.targets" />


### PR DESCRIPTION
### Description of Change ###

Adds a reference to OpenTK in the macOS project which should make it through to the nuget package.

### Bugs Fixed ###

- #1383 

