### PR TITLE
Use the correct return for ShouldShowRationale

### DIFF
--- a/Xamarin.Essentials/Permissions/Permissions.shared.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Essentials
             where TPermission : BasePermission, new() =>
                 new TPermission().RequestAsync();
 
-        public static void ShouldShowRationale<TPermission>()
+        public static bool ShouldShowRationale<TPermission>()
             where TPermission : BasePermission, new() =>
                 new TPermission().ShouldShowRationale();
 


### PR DESCRIPTION
### Description of Change ###

Use the correct return type for `ShouldShowRationale<T>()` on the `Permissions` API.

### Bugs Fixed ###

- Related to issue #1200


### API Changes ###

`Permissions.ShouldShowRationale<TPermission>()`

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
