### PR TITLE
[macOS] Ensure colorspaces are valid

### DIFF
--- a/Samples/Samples.Mac/Samples.Mac.csproj
+++ b/Samples/Samples.Mac/Samples.Mac.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
+    <Reference Include="OpenTK" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter" Version="3.0.0" />

--- a/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.macos.cs
+++ b/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.macos.cs
@@ -11,6 +11,10 @@ namespace Xamarin.Essentials
             if (color == null)
                 throw new ArgumentNullException(nameof(color));
 
+            // make sure the colorspace is valid for RGBA
+            // we can't check as the check will throw if it is invalid
+            color = color.UsingColorSpace(NSColorSpace.SRGBColorSpace);
+
             color.GetRgba(out var red, out var green, out var blue, out var alpha);
             return Color.FromArgb((int)(alpha * 255), (int)(red * 255), (int)(green * 255), (int)(blue * 255));
         }


### PR DESCRIPTION

### Description of Change ###

Ensure colorspaces are valid

### Bugs Fixed ###

- Fixes #1383

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
