### PR TITLE
Patch 1

### DIFF
--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
@@ -112,6 +112,13 @@ namespace Xamarin.Essentials
         }
 
         static string GetSystemSetting(string name)
-           => Settings.System.GetString(Essentials.Platform.AppContext.ContentResolver, name);
+        {
+            //DEVICE_NAME added in System.Global in API level 25
+            //https://developer.android.com/reference/android/provider/Settings.Global#DEVICE_NAME
+            if(Platform.HasApiLevelNMr1)
+                return Settings.Global.GetString(Essentials.Platform.AppContext.ContentResolver, name);
+            else
+                return Settings.System.GetString(Essentials.Platform.AppContext.ContentResolver, name);
+        }
     }
 }

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
@@ -115,7 +115,7 @@ namespace Xamarin.Essentials
         {
             //DEVICE_NAME added in System.Global in API level 25
             //https://developer.android.com/reference/android/provider/Settings.Global#DEVICE_NAME
-            if(Platform.HasApiLevelNMr1)
+            if(Essentials.Platform.HasApiLevelNMr1)
                 return Settings.Global.GetString(Essentials.Platform.AppContext.ContentResolver, name);
             else
                 return Settings.System.GetString(Essentials.Platform.AppContext.ContentResolver, name);


### PR DESCRIPTION
Setting.System doesn't have "device_name" preferences. Use Settings.Global instead to resolve this problem.
https://developer.android.com/reference/android/provider/Settings.Global#DEVICE_NAME

### Description of Change ###

Describe your changes here. 

### Bugs Fixed ###

- Related to issue #

https://github.com/xamarin/Essentials/issues/1417

### API Changes ###
DeviceInfo

Added:

 if (Essentials.Platform.HasApiLevelNMr1)
                return Settings.Global.GetString(Essentials.Platform.AppContext.ContentResolver, name);
 
### Behavioral Changes ###

Now user will get correct device name if device OS version is 7.1 or later

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
