### PR TITLE
Fixed wrong device name issue

### DIFF
--- a/Samples/Samples.Mac/Samples.Mac.csproj
+++ b/Samples/Samples.Mac/Samples.Mac.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
+    <Reference Include="OpenTK" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AppCenter" Version="3.0.0" />

--- a/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.macos.cs
+++ b/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.macos.cs
@@ -11,6 +11,10 @@ namespace Xamarin.Essentials
             if (color == null)
                 throw new ArgumentNullException(nameof(color));
 
+            // make sure the colorspace is valid for RGBA
+            // we can't check as the check will throw if it is invalid
+            color = color.UsingColorSpace(NSColorSpace.SRGBColorSpace);
+
             color.GetRgba(out var red, out var green, out var blue, out var alpha);
             return Color.FromArgb((int)(alpha * 255), (int)(red * 255), (int)(green * 255), (int)(blue * 255));
         }


### PR DESCRIPTION
DeviceInfo API was returning device model as a device name.

Description of Change
Describe your changes here.

Bugs Fixed
Related to issue #
#1417

API Changes
DeviceInfo

Added:

if (Essentials.Platform.HasApiLevelNMr1)
return Settings.Global.GetString(Essentials.Platform.AppContext.ContentResolver, name);

Behavioral Changes
Now user will get correct device name if device OS version is 7.1 or later