### PR TITLE
macOS: TextToSpeech replaced NSSpeechBoundary

### DIFF
--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Essentials
 
             void TryCancel()
             {
-                ss.StopSpeaking(NSSpeechBoundary.hWord);
+                ss.StopSpeaking(NSSpeechBoundary.Word);
                 tcs.TrySetResult(true);
             }
 


### PR DESCRIPTION

### Description of Change ###

`hWord` is obsolete, replaced it with `Word`

### Bugs Fixed ###

- Related to issue #1429

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
