### PR TITLE
Ensure we use the same thread when getting a Screenshot in UWP

### DIFF
--- a/Xamarin.Essentials/Screenshot/Screenshot.uwp.cs
+++ b/Xamarin.Essentials/Screenshot/Screenshot.uwp.cs
@@ -21,10 +21,7 @@ namespace Xamarin.Essentials
                 throw new InvalidOperationException("Unable to find main window content.");
 
             var bmp = new RenderTargetBitmap();
-
-            // We must use ConfigureAwait(true), to ensure we keep the same execution context (thread); otherwise we'll get an exception
-            // in the ScreenshotResult constructor, when trying to access the properties of the RendertargetBitmap instance
-            await bmp.RenderAsync(element).AsTask().ConfigureAwait(true);
+            await bmp.RenderAsync(element).AsTask();
 
             return new ScreenshotResult(bmp);
         }

--- a/Xamarin.Essentials/Screenshot/Screenshot.uwp.cs
+++ b/Xamarin.Essentials/Screenshot/Screenshot.uwp.cs
@@ -21,7 +21,10 @@ namespace Xamarin.Essentials
                 throw new InvalidOperationException("Unable to find main window content.");
 
             var bmp = new RenderTargetBitmap();
-            await bmp.RenderAsync(element).AsTask().ConfigureAwait(false);
+
+            // We must use ConfigureAwait(true), to ensure we keep the same execution context (thread); otherwise we'll get an exception
+            // in the ScreenshotResult constructor, when trying to access the properties of the RendertargetBitmap instance
+            await bmp.RenderAsync(element).AsTask().ConfigureAwait(true);
 
             return new ScreenshotResult(bmp);
         }


### PR DESCRIPTION
### Description of Change ###

When generationg the screenshot in UWP, I made sure the execution thread remains the same, by setting `ConfigureAwait(true)`

### Bugs Fixed ###

- Related to issue #1432 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of `main` at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
