### PR TITLE
SensorSpeed: use the same intervals on all platforms

### DIFF
--- a/Samples/Samples/View/OrientationSensorPage.xaml
+++ b/Samples/Samples/View/OrientationSensorPage.xaml
@@ -22,6 +22,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -43,6 +44,8 @@
 
                 <Button Grid.Row="5" Grid.Column="1" Text="Stop" Command="{Binding StopCommand}"
                     IsEnabled="{Binding IsActive}" />
+
+                <Label Grid.Row="6" Grid.ColumnSpan="2" Text="{Binding Interval, StringFormat='Interval: {0:N} ms'}" />
             </Grid>
         </ScrollView>
     </StackLayout>

--- a/Samples/Samples/ViewModel/OrientationSensorViewModel.cs
+++ b/Samples/Samples/ViewModel/OrientationSensorViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Windows.Input;
 using Xamarin.Essentials;
 using Xamarin.Forms;
@@ -14,6 +15,11 @@ namespace Samples.ViewModel
         double w;
         bool isActive;
         int speed = 0;
+
+        double i;
+        int cnt = 0;
+        double sum = 0;
+        Stopwatch sw = new Stopwatch();
 
         public OrientationSensorViewModel()
         {
@@ -64,6 +70,12 @@ namespace Samples.ViewModel
             set => SetProperty(ref speed, value);
         }
 
+        public double Interval
+        {
+            get => i;
+            set => SetProperty(ref i, value);
+        }
+
         public override void OnAppearing()
         {
             OrientationSensor.ReadingChanged += OnReadingChanged;
@@ -80,6 +92,9 @@ namespace Samples.ViewModel
 
         async void OnStart()
         {
+            cnt = 0;
+            sum = 0;
+            sw.Reset();
             try
             {
                 OrientationSensor.Start((SensorSpeed)Speed);
@@ -95,10 +110,22 @@ namespace Samples.ViewModel
         {
             IsActive = false;
             OrientationSensor.Stop();
+            sw.Stop();
         }
 
         void OnReadingChanged(object sender, OrientationSensorChangedEventArgs e)
         {
+            sw.Stop();
+            var ms = sw.Elapsed.TotalMilliseconds;
+            if (ms > 0)
+            {
+                sum += ms;
+                cnt += 1;
+                Interval = sum / cnt;
+            }
+            sw.Reset();
+            sw.Start();
+
             var data = e.Reading;
             switch ((SensorSpeed)Speed)
             {

--- a/Xamarin.Essentials/Types/SensorSpeed.android.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.android.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Essentials
 {
-    static class SensorSpeedExtensions
+    internal static partial class SensorSpeedExtensions
     {
         internal static SensorDelay ToPlatform(this SensorSpeed sensorSpeed)
         {

--- a/Xamarin.Essentials/Types/SensorSpeed.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.ios.tvos.watchos.cs
@@ -4,17 +4,19 @@
     {
         internal static double ToPlatform(this SensorSpeed sensorSpeed)
         {
+            // Timing intervals to match Android sensor speeds in seconds
+            // https://developer.android.com/guide/topics/sensors/sensors_overview
             switch (sensorSpeed)
             {
                 case SensorSpeed.Fastest:
-                    return .02;
+                    return .005;
                 case SensorSpeed.Game:
-                    return .04;
+                    return .020;
                 case SensorSpeed.UI:
-                    return .08;
+                    return .060;
             }
 
-            return .225;
+            return .200;
         }
     }
 }

--- a/Xamarin.Essentials/Types/SensorSpeed.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.ios.tvos.watchos.cs
@@ -1,22 +1,20 @@
 ﻿namespace Xamarin.Essentials
 {
-    static class SensorSpeedExtensions
+    internal static partial class SensorSpeedExtensions
     {
         internal static double ToPlatform(this SensorSpeed sensorSpeed)
         {
-            // Timing intervals to match Android sensor speeds in seconds
-            // https://developer.android.com/guide/topics/sensors/sensors_overview
             switch (sensorSpeed)
             {
                 case SensorSpeed.Fastest:
-                    return .005;
+                    return sensorIntervalFastest / 1000.0;
                 case SensorSpeed.Game:
-                    return .020;
+                    return sensorIntervalGame / 1000.0;
                 case SensorSpeed.UI:
-                    return .060;
+                    return sensorIntervalUI / 1000.0;
             }
 
-            return .200;
+            return sensorIntervalDefault / 1000.0;
         }
     }
 }

--- a/Xamarin.Essentials/Types/SensorSpeed.shared.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.shared.cs
@@ -7,4 +7,14 @@
         Game = 2,
         Fastest = 3,
     }
+
+    internal static partial class SensorSpeedExtensions
+    {
+        // Timing intervals to match Android sensor speeds in milliseconds
+        // https://developer.android.com/guide/topics/sensors/sensors_overview
+        internal const uint sensorIntervalDefault = 200;
+        internal const uint sensorIntervalUI = 60;
+        internal const uint sensorIntervalGame = 20;
+        internal const uint sensorIntervalFastest = 5;
+    }
 }

--- a/Xamarin.Essentials/Types/SensorSpeed.tizen.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.tizen.cs
@@ -1,22 +1,20 @@
 ﻿namespace Xamarin.Essentials
 {
-    static class SensorSpeedExtensions
+    internal static partial class SensorSpeedExtensions
     {
         internal static uint ToPlatform(this SensorSpeed sensorSpeed)
         {
-            // Timing intervals to match Android sensor speeds in milliseconds
-            // https://developer.android.com/guide/topics/sensors/sensors_overview
             switch (sensorSpeed)
             {
                 case SensorSpeed.Fastest:
-                    return 5;
+                    return sensorIntervalFastest;
                 case SensorSpeed.Game:
-                    return 20;
+                    return sensorIntervalGame;
                 case SensorSpeed.UI:
-                    return 60;
+                    return sensorIntervalUI;
             }
 
-            return 200;
+            return sensorIntervalDefault;
         }
     }
 }

--- a/Xamarin.Essentials/Types/SensorSpeed.tizen.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.tizen.cs
@@ -4,17 +4,19 @@
     {
         internal static uint ToPlatform(this SensorSpeed sensorSpeed)
         {
+            // Timing intervals to match Android sensor speeds in milliseconds
+            // https://developer.android.com/guide/topics/sensors/sensors_overview
             switch (sensorSpeed)
             {
                 case SensorSpeed.Fastest:
-                    return 10;
+                    return 5;
                 case SensorSpeed.Game:
                     return 20;
                 case SensorSpeed.UI:
                     return 60;
             }
 
-            return 100;
+            return 200;
         }
     }
 }

--- a/Xamarin.Essentials/Types/SensorSpeed.uwp.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.uwp.cs
@@ -4,17 +4,19 @@
     {
         internal static uint ToPlatform(this SensorSpeed sensorSpeed)
         {
+            // Timing intervals to match Android sensor speeds in milliseconds
+            // https://developer.android.com/guide/topics/sensors/sensors_overview
             switch (sensorSpeed)
             {
                 case SensorSpeed.Fastest:
-                    return 20;
+                    return 5;
                 case SensorSpeed.Game:
-                    return 40;
+                    return 20;
                 case SensorSpeed.UI:
-                    return 80;
+                    return 60;
             }
 
-            return 225;
+            return 200;
         }
     }
 }

--- a/Xamarin.Essentials/Types/SensorSpeed.uwp.cs
+++ b/Xamarin.Essentials/Types/SensorSpeed.uwp.cs
@@ -1,22 +1,20 @@
 ﻿namespace Xamarin.Essentials
 {
-    static class SensorSpeedExtensions
+    internal static partial class SensorSpeedExtensions
     {
         internal static uint ToPlatform(this SensorSpeed sensorSpeed)
         {
-            // Timing intervals to match Android sensor speeds in milliseconds
-            // https://developer.android.com/guide/topics/sensors/sensors_overview
             switch (sensorSpeed)
             {
                 case SensorSpeed.Fastest:
-                    return 5;
+                    return sensorIntervalFastest;
                 case SensorSpeed.Game:
-                    return 20;
+                    return sensorIntervalGame;
                 case SensorSpeed.UI:
-                    return 60;
+                    return sensorIntervalUI;
             }
 
-            return 200;
+            return sensorIntervalDefault;
         }
     }
 }

--- a/docs/en/Xamarin.Essentials/SensorSpeed.xml
+++ b/docs/en/Xamarin.Essentials/SensorSpeed.xml
@@ -28,7 +28,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The default sensor speed.</summary>
+        <summary>The default sensor rate (5 Hz, corresponding to an interval of 200 ms).</summary>
       </Docs>
     </Member>
     <Member MemberName="Fastest">
@@ -45,7 +45,7 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>Get the sensor data as fast as possible.</summary>
+        <summary>Get the sensor data as fast as possible (the actual rate is platform-dependent).</summary>
       </Docs>
     </Member>
     <Member MemberName="Game">
@@ -62,7 +62,7 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>Rate suitable for games.</summary>
+        <summary>Rate suitable for games (50 Hz, corresponding to an interval of 20 ms).</summary>
       </Docs>
     </Member>
     <Member MemberName="UI">
@@ -79,7 +79,7 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>Rate suitable for general user interface.</summary>
+        <summary>Rate suitable for general user interface (16.6 Hz, corresponding to an interval of 60 ms).</summary>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
### Description of Change ###

* the intervals are matching those of Android, see https://developer.android.com/guide/topics/sensors/sensors_overview
* note that we do not use a zero-interval for SensorSpeed.Fastest (since this might turn off the sensor, in particular on UWP); instead we use 5ms, which is roughly what I have measured on Android 10 for SensorSpeed.Fastest

### Bugs Fixed ###

- Related to issue #1438

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of `main` at time of PR
- [X] Changes adhere to coding standard
- [X] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
