### PR TITLE
make the samples app run on Android 6, MacOS, Tizen

### DIFF
--- a/Samples/Samples/App.xaml.cs
+++ b/Samples/Samples/App.xaml.cs
@@ -48,9 +48,12 @@ namespace Samples
                 typeof(Distribute));
             }
 
-            await AppActions.SetAsync(
-                new AppAction("app_info", "App Info", icon: "app_info_action_icon"),
-                new AppAction("battery_info", "Battery Info"));
+            if (AppActions.IsSupported)
+            {
+                await AppActions.SetAsync(
+                    new AppAction("app_info", "App Info", icon: "app_info_action_icon"),
+                    new AppAction("battery_info", "Battery Info"));
+            }
         }
 
         void AppActions_OnAppAction(object sender, AppActionEventArgs e)

--- a/Xamarin.Essentials/AppActions/AppActions.netstandard.tvos.watchos.macos.tizen.cs
+++ b/Xamarin.Essentials/AppActions/AppActions.netstandard.tvos.watchos.macos.tizen.cs
@@ -6,8 +6,7 @@ namespace Xamarin.Essentials
 {
     public static partial class AppActions
     {
-        internal static bool PlatformIsSupported
-            => throw ExceptionUtils.NotSupportedOrImplementedException;
+        internal static bool PlatformIsSupported => false;
 
         static Task<IEnumerable<AppAction>> PlatformGetAsync() =>
             throw ExceptionUtils.NotSupportedOrImplementedException;

--- a/Xamarin.Essentials/AppActions/AppActions.shared.cs
+++ b/Xamarin.Essentials/AppActions/AppActions.shared.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Essentials
 {
     public static partial class AppActions
     {
-        internal static bool IsSupported
+        public static bool IsSupported
             => PlatformIsSupported;
 
         public static Task<IEnumerable<AppAction>> GetAsync()


### PR DESCRIPTION
### Description of Change ###

* make AppActions.IsSupported public
* use it in the Samples app to get rid of a FeatureNotSupportedException

### Bugs Fixed ###

- Related to issue #1441 

### API Changes ###

Changed:

 - `internal static bool AppActions.IsSupported` => `public static bool AppActions.IsSupported`


### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of `main` at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
