### PR TITLE
Add ContinueUserActivity impl for Universal App Links

### DIFF
--- a/Samples/Samples.iOS/AppDelegate.cs
+++ b/Samples/Samples.iOS/AppDelegate.cs
@@ -30,6 +30,14 @@ namespace Samples.iOS
             return base.OpenUrl(app, url, options);
         }
 
+        public override bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity, UIApplicationRestorationHandler completionHandler)
+        {
+            if (Xamarin.Essentials.Platform.ContinueUserActivity(application, userActivity, completionHandler))
+                return true;
+
+            return base.ContinueUserActivity(application, userActivity, completionHandler);
+        }
+
         public override void PerformActionForShortcutItem(UIApplication application, UIApplicationShortcutItem shortcutItem, UIOperationHandler completionHandler)
             => Xamarin.Essentials.Platform.PerformActionForShortcutItem(application, shortcutItem, completionHandler);
     }

--- a/Xamarin.Essentials/Platform/Platform.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Platform/Platform.ios.tvos.watchos.cs
@@ -20,6 +20,9 @@ namespace Xamarin.Essentials
 #if __IOS__ || __TVOS__
         public static bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
             => WebAuthenticator.OpenUrl(new Uri(url.AbsoluteString));
+
+        public static bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity, UIApplicationRestorationHandler completionHandler)
+            => WebAuthenticator.OpenUrl(new Uri(userActivity?.WebPageUrl?.AbsoluteString));
 #endif
 
 #if __IOS__

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -785,6 +785,7 @@
       <Member Id="M:Xamarin.Essentials.PlacemarkExtensions.OpenMapsAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
     </Type>
     <Type Name="Xamarin.Essentials.Platform" Id="T:Xamarin.Essentials.Platform">
+      <Member Id="M:Xamarin.Essentials.Platform.ContinueUserActivity(UIKit.UIApplication,Foundation.NSUserActivity,UIKit.UIApplicationRestorationHandler)" />
       <Member Id="M:Xamarin.Essentials.Platform.GetCurrentUIViewController" />
       <Member Id="M:Xamarin.Essentials.Platform.OpenUrl(UIKit.UIApplication,Foundation.NSUrl,Foundation.NSDictionary)" />
       <Member Id="M:Xamarin.Essentials.Platform.PerformActionForShortcutItem(UIKit.UIApplication,UIKit.UIApplicationShortcutItem,UIKit.UIOperationHandler)" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
@@ -748,6 +748,7 @@
       <Member Id="M:Xamarin.Essentials.PlacemarkExtensions.OpenMapsAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
     </Type>
     <Type Name="Xamarin.Essentials.Platform" Id="T:Xamarin.Essentials.Platform">
+      <Member Id="M:Xamarin.Essentials.Platform.ContinueUserActivity(UIKit.UIApplication,Foundation.NSUserActivity,UIKit.UIApplicationRestorationHandler)" />
       <Member Id="M:Xamarin.Essentials.Platform.GetCurrentUIViewController" />
       <Member Id="M:Xamarin.Essentials.Platform.OpenUrl(UIKit.UIApplication,Foundation.NSUrl,Foundation.NSDictionary)" />
     </Type>

--- a/docs/en/Xamarin.Essentials/Platform.xml
+++ b/docs/en/Xamarin.Essentials/Platform.xml
@@ -56,6 +56,32 @@
         </remarks>
       </Docs>
     </Member>
+    <Member MemberName="ContinueUserActivity">
+      <MemberSignature Language="C#" Value="public static bool ContinueUserActivity (UIKit.UIApplication application, Foundation.NSUserActivity userActivity, UIKit.UIApplicationRestorationHandler completionHandler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool ContinueUserActivity(class UIKit.UIApplication application, class Foundation.NSUserActivity userActivity, class UIKit.UIApplicationRestorationHandler completionHandler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Platform.ContinueUserActivity(UIKit.UIApplication,Foundation.NSUserActivity,UIKit.UIApplicationRestorationHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="application" Type="UIKit.UIApplication" Index="0" FrameworkAlternate="xamarin-essentials-ios;xamarin-essentials-tvos" />
+        <Parameter Name="userActivity" Type="Foundation.NSUserActivity" Index="1" FrameworkAlternate="xamarin-essentials-ios;xamarin-essentials-tvos" />
+        <Parameter Name="completionHandler" Type="UIKit.UIApplicationRestorationHandler" Index="2" FrameworkAlternate="xamarin-essentials-ios;xamarin-essentials-tvos" />
+      </Parameters>
+      <Docs>
+        <param name="application">The application.</param>
+        <param name="userActivity">The user activity instance.</param>
+        <param name="completionHandler">The completion handler.</param>
+        <summary>Callback forwarded from the equivalent iOS AppDelegate method.</summary>
+        <returns>True if the callback was handled.</returns>
+        <remarks></remarks>
+      </Docs>
+    </Member>
     <Member MemberName="CurrentActivity">
       <MemberSignature Language="C#" Value="public static Android.App.Activity CurrentActivity { get; }" />
       <MemberSignature Language="ILAsm" Value=".property class Android.App.Activity CurrentActivity" />

--- a/docs/en/index.xml
+++ b/docs/en/index.xml
@@ -99,7 +99,7 @@
           <AttributeName>System.Runtime.Versioning.TargetFramework("Xamarin.Mac,Version=v2.0", FrameworkDisplayName="Xamarin.Mac")</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Reflection.AssemblyInformationalVersion("1.0.0+a0b12b46c8f7c223eea5c943deaec9724fe5098e")</AttributeName>
+          <AttributeName>System.Reflection.AssemblyInformationalVersion("1.0.0")</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>


### PR DESCRIPTION
This addresses an issue raised in https://github.com/MicrosoftDocs/xamarin-docs/issues/2716

Universal App Links in iOS can callback to the `AppDelegate.ContinueUserActivity` method instead of the OpenUrl.  If you were using Universal App Links on iOS to implement the callback handler for the Authentication API, your app would never see the callback while waiting.

This adds a `Xamarin.Essentials.Platform.ContinueUserActivity` implementation to pass through from the AppDelegate which will in turn call the the `WebAuthenticator.OpenUrl` method and complete the waiting task with the app links callback.

### Bugs Fixed ###

- Related to issue #1456 
- Related to https://github.com/MicrosoftDocs/xamarin-docs/issues/2716
Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.


### PR Checklist ###

- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
