### PR TITLE
Turn off feedback control for ref docs.

### DIFF
--- a/docs/en/docfx.json
+++ b/docs/en/docfx.json
@@ -50,6 +50,7 @@
       "ms.topic": "managed-reference",
       "ms.prod": "xamarin",
       "ms.technology":"xamarin-essentials",
+      "feedback_system": "GitHub",      
       "feedback_product_url": "https://github.com/xamarin/Essentials/blob/main/PRODUCT-FEEDBACK.md"
     },
     "fileMetadata": {

--- a/docs/en/docfx.json
+++ b/docs/en/docfx.json
@@ -50,7 +50,7 @@
       "ms.topic": "managed-reference",
       "ms.prod": "xamarin",
       "ms.technology":"xamarin-essentials",
-      "feedback_system": "None",      
+      "feedback_system": "GitHub",      
       "feedback_product_url": "https://github.com/xamarin/Essentials/blob/main/PRODUCT-FEEDBACK.md"
     },
     "fileMetadata": {

--- a/docs/en/docfx.json
+++ b/docs/en/docfx.json
@@ -50,7 +50,7 @@
       "ms.topic": "managed-reference",
       "ms.prod": "xamarin",
       "ms.technology":"xamarin-essentials",
-      "feedback_system": "GitHub",      
+      "feedback_system": "None",      
       "feedback_product_url": "https://github.com/xamarin/Essentials/blob/main/PRODUCT-FEEDBACK.md"
     },
     "fileMetadata": {

--- a/docs/en/docfx.json
+++ b/docs/en/docfx.json
@@ -50,8 +50,6 @@
       "ms.topic": "managed-reference",
       "ms.prod": "xamarin",
       "ms.technology":"xamarin-essentials",
-      "feedback_system": "GitHub",
-      "feedback_github_repo": "MicrosoftDocs/xamarin-docs",
       "feedback_product_url": "https://github.com/xamarin/Essentials/blob/main/PRODUCT-FEEDBACK.md"
     },
     "fileMetadata": {


### PR DESCRIPTION
### Description of Change ###

Turn off the feedback control for API docs.

There's currently no way of turning off page feedback and leaving the product feedback button in place. However, in case DCM ever supports this I've left the product feedback config in place.