### PR TITLE
Implement the MediaPicker with PHPickerConfiguration

### DIFF
--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -178,7 +178,7 @@ namespace Xamarin.Essentials
             public Action<PHPickerResult[]> CompletedHandler { get; set; }
 
             public override void DidFinishPicking(PHPickerViewController picker, PHPickerResult[] results) =>
-                CompletedHandler?.Invoke(results.Length == 0 ? null : results);
+                CompletedHandler?.Invoke(results?.Length > 0 ? results : null);
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Implement the `MediaPicker` with `PHPickerConfiguration` for iOS 14+.

### Bugs Fixed ###

- Fixes #1402

### API Changes ###

None.


### Behavioral Changes ###

On iOS 14+, the new photos picker will be used.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
