### PR TITLE
Make sure that there is always a valid Intent

### DIFF
--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -13,7 +13,6 @@ using Android.Net;
 using Android.Net.Wifi;
 using Android.OS;
 using Android.Provider;
-using Android.Util;
 using Android.Views;
 using AndroidIntent = Android.Content.Intent;
 using AndroidUri = Android.Net.Uri;
@@ -455,7 +454,10 @@ namespace Xamarin.Essentials
                 else
                 {
                     if (outputUri != null)
+                    {
+                        data ??= new AndroidIntent();
                         data.PutExtra(OutputUriExtra, outputUri);
+                    }
 
                     tcs.TrySetResult(data);
                 }


### PR DESCRIPTION
### Description of Change ###

Make sure that there is always a valid Intent when the intermediate activity returns.

### Bugs Fixed ###

- Fixes #1397

### API Changes ###

None.

### Behavioral Changes ###

If the intent is null, then create one and not crash.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
