### PR TITLE
Handle new iOS location permission event (issue 1390)

### DIFF
--- a/Xamarin.Essentials/Types/LocationExtensions.ios.tvos.watchos.macos.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.ios.tvos.watchos.macos.cs
@@ -49,5 +49,20 @@ namespace Xamarin.Essentials
                 return DateTimeOffset.UtcNow;
             }
         }
+
+        internal static CLAuthorizationStatus GetAuthorizationStatus(this CLLocationManager locationManager)
+        {
+#if !__MACOS__ // this is coming in macOS 11
+#if __WATCHOS__
+            if (Platform.HasOSVersion(7, 0))
+#else
+            if (Platform.HasOSVersion(14, 0))
+#endif
+                return locationManager.AuthorizationStatus;
+
+#endif
+
+            return CLLocationManager.Status;
+        }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Adapts code to new CLLocationManager APIs in iOS 14 (tvOS 14, watchOS 7) while keeping existing logic for older versions.

### Bugs Fixed ###

- Fixes #1390 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
