### PR TITLE
Throw Exception instead of NullReferenceException in Screenshot.PlatformCaptureAsync()

### DIFF
--- a/Xamarin.Essentials/Screenshot/Screenshot.android.cs
+++ b/Xamarin.Essentials/Screenshot/Screenshot.android.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Essentials
 
             var view = Platform.GetCurrentActivity(true)?.Window?.DecorView?.RootView;
             if (view == null)
-                throw new NullReferenceException("Unable to find the main window.");
+                throw new Exception("Unable to find the main window.");
 
             var bitmap = Bitmap.CreateBitmap(view.Width, view.Height, Bitmap.Config.Argb8888);
 


### PR DESCRIPTION
fixes #1498

### Description of Change ###

Throw Exception instead of NullReferenceException

### Bugs Fixed ###

- Related to issue #1498

### API Changes ###

none


### Behavioral Changes ###

Throw Exception instead of NullReferenceException


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
