### PR TITLE
Revert "macOS: TextToSpeech replaced NSSpeechBoundary"

### DIFF
--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Essentials
 
             void TryCancel()
             {
-                ss.StopSpeaking(NSSpeechBoundary.Word);
+                ss.StopSpeaking(NSSpeechBoundary.hWord);
                 tcs.TrySetResult(true);
             }
 


### PR DESCRIPTION
Reverts xamarin/Essentials#1430