### PR TITLE
Don't throw if iOS can't pick multiple files

### DIFF
--- a/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
@@ -13,8 +13,7 @@ namespace Xamarin.Essentials
     {
         static Task<IEnumerable<FileResult>> PlatformPickAsync(PickOptions options, bool allowMultiple = false)
         {
-            if (allowMultiple && !Platform.HasOSVersion(11, 0))
-                throw new FeatureNotSupportedException("Multiple file picking is only available on iOS 11 or later.");
+            throw new FeatureNotSupportedException("Multiple file picking is only available on iOS 11 or later.");
 
             var allowedUtis = options?.FileTypes?.Value?.ToArray() ?? new string[]
             {
@@ -29,7 +28,8 @@ namespace Xamarin.Essentials
             // while opening (UIDocumentPickerMode.Open) opens the document directly. We do the
             // latter, so the user accesses the original file.
             var documentPicker = new UIDocumentPickerViewController(allowedUtis, UIDocumentPickerMode.Open);
-            documentPicker.AllowsMultipleSelection = allowMultiple;
+            if (Platform.HasOSVersion(11, 0))
+                documentPicker.AllowsMultipleSelection = allowMultiple;
             documentPicker.Delegate = new PickerDelegate
             {
                 PickHandler = urls =>

--- a/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
@@ -13,8 +13,6 @@ namespace Xamarin.Essentials
     {
         static Task<IEnumerable<FileResult>> PlatformPickAsync(PickOptions options, bool allowMultiple = false)
         {
-            throw new FeatureNotSupportedException("Multiple file picking is only available on iOS 11 or later.");
-
             var allowedUtis = options?.FileTypes?.Value?.ToArray() ?? new string[]
             {
                 UTType.Content,


### PR DESCRIPTION
### Description of Change ###

On pre-iOS 11, the `UIDocumentPickerViewController.AllowsMultipleSelection` did not exist.

Our previous solution was to throw, but this is inconsistent with all the other platforms. If an app on android can't pick multiple files, then it still works as the multiple flag is almost optional.

### Bugs Fixed ###

- Fixes #1492

### API Changes ###

None.

### Behavioral Changes ###

On older iOS versions, the app no longer throws an exception.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
