### PR TITLE
[iOS] [WebAuth] Correctly interpret iOS WebAuthenticator errors

### DIFF
--- a/DeviceTests/DeviceTests.Shared/Launcher_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Launcher_Tests.cs
@@ -74,7 +74,7 @@ namespace DeviceTests
         [InlineData("https://maps.apple.com", "https://maps.apple.com")]
         public void GetNativeUrl(string uri, string expected)
         {
-            var url = Launcher.GetNativeUrl(new Uri(uri));
+            var url = WebUtils.GetNativeUrl(new Uri(uri));
             Assert.Equal(expected, url.AbsoluteString);
         }
 #endif

--- a/Samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
+++ b/Samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
@@ -56,8 +56,17 @@ namespace Samples.ViewModel
 
                 AuthToken = r?.AccessToken ?? r?.IdToken;
             }
+            catch (OperationCanceledException)
+            {
+                Console.WriteLine("Login canceled.");
+
+                AuthToken = string.Empty;
+                await DisplayAlertAsync("Login canceled.");
+            }
             catch (Exception ex)
             {
+                Console.WriteLine($"Failed: {ex.Message}");
+
                 AuthToken = string.Empty;
                 await DisplayAlertAsync($"Failed: {ex.Message}");
             }

--- a/Xamarin.Essentials/Launcher/Launcher.ios.tvos.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.ios.tvos.cs
@@ -9,14 +9,14 @@ namespace Xamarin.Essentials
     public static partial class Launcher
     {
         static Task<bool> PlatformCanOpenAsync(Uri uri) =>
-            Task.FromResult(UIApplication.SharedApplication.CanOpenUrl(GetNativeUrl(uri)));
+            Task.FromResult(UIApplication.SharedApplication.CanOpenUrl(WebUtils.GetNativeUrl(uri)));
 
         static Task PlatformOpenAsync(Uri uri) =>
-            UIApplication.SharedApplication.OpenUrlAsync(GetNativeUrl(uri), new UIApplicationOpenUrlOptions());
+            UIApplication.SharedApplication.OpenUrlAsync(WebUtils.GetNativeUrl(uri), new UIApplicationOpenUrlOptions());
 
         static Task<bool> PlatformTryOpenAsync(Uri uri)
         {
-            var nativeUrl = GetNativeUrl(uri);
+            var nativeUrl = WebUtils.GetNativeUrl(uri);
             var canOpen = UIApplication.SharedApplication.CanOpenUrl(nativeUrl);
 
             if (canOpen)
@@ -28,19 +28,6 @@ namespace Xamarin.Essentials
             }
 
             return Task.FromResult(canOpen);
-        }
-
-        internal static NSUrl GetNativeUrl(Uri uri)
-        {
-            try
-            {
-                return new NSUrl(uri.OriginalString);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine("Unable to create Url from Original string, try absolute Uri: " + ex.Message);
-                return new NSUrl(uri.AbsoluteUri);
-            }
         }
 
 #if __IOS__

--- a/Xamarin.Essentials/Launcher/Launcher.macos.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.macos.cs
@@ -9,33 +9,20 @@ namespace Xamarin.Essentials
     public static partial class Launcher
     {
         static Task<bool> PlatformCanOpenAsync(Uri uri) =>
-            Task.FromResult(NSWorkspace.SharedWorkspace.UrlForApplication(GetNativeUrl(uri)) != null);
+            Task.FromResult(NSWorkspace.SharedWorkspace.UrlForApplication(WebUtils.GetNativeUrl(uri)) != null);
 
         static Task PlatformOpenAsync(Uri uri) =>
-            Task.FromResult(NSWorkspace.SharedWorkspace.OpenUrl(GetNativeUrl(uri)));
+            Task.FromResult(NSWorkspace.SharedWorkspace.OpenUrl(WebUtils.GetNativeUrl(uri)));
 
         static Task<bool> PlatformTryOpenAsync(Uri uri)
         {
-            var nativeUrl = GetNativeUrl(uri);
+            var nativeUrl = WebUtils.GetNativeUrl(uri);
             var canOpen = NSWorkspace.SharedWorkspace.UrlForApplication(nativeUrl) != null;
 
             if (canOpen)
                 return Task.FromResult(NSWorkspace.SharedWorkspace.OpenUrl(nativeUrl));
 
             return Task.FromResult(canOpen);
-        }
-
-        internal static NSUrl GetNativeUrl(Uri uri)
-        {
-            try
-            {
-                return new NSUrl(uri.OriginalString);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine("Unable to create Url from Original string, try absolute Uri: " + ex.Message);
-                return new NSUrl(uri.AbsoluteUri);
-            }
         }
 
         static Task PlatformOpenAsync(OpenFileRequest request) =>

--- a/Xamarin.Essentials/Types/Shared/WebUtils.shared.cs
+++ b/Xamarin.Essentials/Types/Shared/WebUtils.shared.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -54,5 +55,20 @@ namespace Xamarin.Essentials
 
             return true;
         }
+
+#if __IOS__ || __TVOS__ || __MACOS__
+        internal static Foundation.NSUrl GetNativeUrl(Uri uri)
+        {
+            try
+            {
+                return new Foundation.NSUrl(uri.OriginalString);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Unable to create NSUrl from Original string, trying Absolute URI: {ex.Message}");
+                return new Foundation.NSUrl(uri.AbsoluteUri);
+            }
+        }
+#endif
     }
 }

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Essentials
 
             if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
             {
-                was = new ASWebAuthenticationSession(new NSUrl(url.OriginalString), scheme, AuthSessionCallback);
+                was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
 
                 if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
                 {
@@ -84,7 +84,7 @@ namespace Xamarin.Essentials
 
             if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
             {
-                sf = new SFAuthenticationSession(new NSUrl(url.OriginalString), scheme, AuthSessionCallback);
+                sf = new SFAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
                 using (sf)
                 {
                     sf.Start();
@@ -93,7 +93,7 @@ namespace Xamarin.Essentials
             }
 
             // This is only on iOS9+ but we only support 10+ in Essentials anyway
-            var controller = new SFSafariViewController(new NSUrl(url.OriginalString), false)
+            var controller = new SFSafariViewController(WebUtils.GetNativeUrl(url), false)
             {
                 Delegate = new NativeSFSafariViewControllerDelegate
                 {

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Essentials
         static TaskCompletionSource<WebAuthenticatorResult> tcsResponse;
         static UIViewController currentViewController;
         static Uri redirectUri;
+
 #if __IOS__
         static ASWebAuthenticationSession was;
         static SFAuthenticationSession sf;
@@ -46,7 +47,6 @@ namespace Xamarin.Essentials
 
             tcsResponse = new TaskCompletionSource<WebAuthenticatorResult>();
             redirectUri = callbackUrl;
-
             var scheme = redirectUri.Scheme;
 
 #if __IOS__
@@ -60,6 +60,9 @@ namespace Xamarin.Essentials
                     tcsResponse.TrySetCanceled();
                 else
                     tcsResponse.TrySetException(new NSErrorException(error));
+
+                was = null;
+                sf = null;
             }
 
             if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -19,6 +19,12 @@ namespace Xamarin.Essentials
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Required for iOS Export")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Required for iOS Export")]
         static extern void void_objc_msgSend_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
+
+        const int asWebAuthenticationSessionErrorCodeCanceledLogin = 1;
+        const string asWebAuthenticationSessionErrorDomain = "com.apple.AuthenticationServices.WebAuthenticationSession";
+
+        const int sfAuthenticationErrorCanceledLogin = 1;
+        const string sfAuthenticationErrorDomain = "com.apple.SafariServices.Authentication";
 #endif
 
         static TaskCompletionSource<WebAuthenticatorResult> tcsResponse;
@@ -31,6 +37,9 @@ namespace Xamarin.Essentials
 
         internal static async Task<WebAuthenticatorResult> PlatformAuthenticateAsync(Uri url, Uri callbackUrl)
         {
+            if (!VerifyHasUrlSchemeOrDoesntRequire(callbackUrl.Scheme))
+                throw new InvalidOperationException("You must register your URL Scheme handler in your app's Info.plist.");
+
             // Cancel any previous task that's still pending
             if (tcsResponse?.Task != null && !tcsResponse.Task.IsCompleted)
                 tcsResponse.TrySetCanceled();
@@ -38,79 +47,69 @@ namespace Xamarin.Essentials
             tcsResponse = new TaskCompletionSource<WebAuthenticatorResult>();
             redirectUri = callbackUrl;
 
-            try
-            {
-                var scheme = redirectUri.Scheme;
-
-                if (!VerifyHasUrlSchemeOrDoesntRequire(scheme))
-                {
-                    tcsResponse.TrySetException(new InvalidOperationException("You must register your URL Scheme handler in your app's Info.plist!"));
-                    return await tcsResponse.Task;
-                }
+            var scheme = redirectUri.Scheme;
 
 #if __IOS__
-                void AuthSessionCallback(NSUrl cbUrl, NSError error)
-                {
-                    if (error == null)
-                        OpenUrl(cbUrl);
-                    else
-                        tcsResponse.TrySetException(new NSErrorException(error));
-                }
-
-                if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
-                {
-                    was = new ASWebAuthenticationSession(new NSUrl(url.OriginalString), scheme, AuthSessionCallback);
-
-                    if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
-                    {
-                        var ctx = new ContextProvider(Platform.GetCurrentWindow());
-                        void_objc_msgSend_IntPtr(was.Handle, ObjCRuntime.Selector.GetHandle("setPresentationContextProvider:"), ctx.Handle);
-                    }
-
-                    using (was)
-                    {
-                        was.Start();
-                        return await tcsResponse.Task;
-                    }
-                }
-
-                if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
-                {
-                    sf = new SFAuthenticationSession(new NSUrl(url.OriginalString), scheme, AuthSessionCallback);
-                    using (sf)
-                    {
-                        sf.Start();
-                        return await tcsResponse.Task;
-                    }
-                }
-
-                // THis is only on iOS9+ but we only support 10+ in Essentials anyway
-                var controller = new SFSafariViewController(new NSUrl(url.OriginalString), false)
-                {
-                    Delegate = new NativeSFSafariViewControllerDelegate
-                    {
-                        DidFinishHandler = (svc) =>
-                        {
-                            // Cancel our task if it wasn't already marked as completed
-                            if (!(tcsResponse?.Task?.IsCompleted ?? true))
-                                tcsResponse.TrySetException(new OperationCanceledException());
-                        }
-                    },
-                };
-
-                currentViewController = controller;
-                await Platform.GetCurrentUIViewController().PresentViewControllerAsync(controller, true);
-                return await tcsResponse.Task;
-#else
-                var opened = UIApplication.SharedApplication.OpenUrl(url);
-                if (!opened)
-                    tcsResponse.TrySetException(new Exception("Error opening Safari"));
-#endif
-            }
-            catch (Exception ex)
+            static void AuthSessionCallback(NSUrl cbUrl, NSError error)
             {
-                tcsResponse.TrySetException(ex);
+                if (error == null)
+                    OpenUrl(cbUrl);
+                else if (error.Domain == asWebAuthenticationSessionErrorDomain && error.Code == asWebAuthenticationSessionErrorCodeCanceledLogin)
+                    tcsResponse.TrySetCanceled();
+                else if (error.Domain == sfAuthenticationErrorDomain && error.Code == sfAuthenticationErrorCanceledLogin)
+                    tcsResponse.TrySetCanceled();
+                else
+                    tcsResponse.TrySetException(new NSErrorException(error));
             }
+
+            if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
+            {
+                was = new ASWebAuthenticationSession(new NSUrl(url.OriginalString), scheme, AuthSessionCallback);
+
+                if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+                {
+                    var ctx = new ContextProvider(Platform.GetCurrentWindow());
+                    void_objc_msgSend_IntPtr(was.Handle, ObjCRuntime.Selector.GetHandle("setPresentationContextProvider:"), ctx.Handle);
+                }
+
+                using (was)
+                {
+                    was.Start();
+                    return await tcsResponse.Task;
+                }
+            }
+
+            if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+            {
+                sf = new SFAuthenticationSession(new NSUrl(url.OriginalString), scheme, AuthSessionCallback);
+                using (sf)
+                {
+                    sf.Start();
+                    return await tcsResponse.Task;
+                }
+            }
+
+            // This is only on iOS9+ but we only support 10+ in Essentials anyway
+            var controller = new SFSafariViewController(new NSUrl(url.OriginalString), false)
+            {
+                Delegate = new NativeSFSafariViewControllerDelegate
+                {
+                    DidFinishHandler = (svc) =>
+                    {
+                        // Cancel our task if it wasn't already marked as completed
+                        if (!(tcsResponse?.Task?.IsCompleted ?? true))
+                            tcsResponse.TrySetCanceled();
+                    }
+                },
+            };
+
+            currentViewController = controller;
+            await Platform.GetCurrentUIViewController().PresentViewControllerAsync(controller, true);
+#else
+            var opened = UIApplication.SharedApplication.OpenUrl(url);
+            if (!opened)
+                tcsResponse.TrySetException(new Exception("Error opening Safari"));
+#endif
 
             return await tcsResponse.Task;
         }

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.macos.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.macos.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Essentials
                             tcsResponse.TrySetException(new NSErrorException(error));
                     }
 
-                    var was = new ASWebAuthenticationSession(new NSUrl(url.OriginalString), scheme, AuthSessionCallback);
+                    var was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
 
                     var ctx = new ContextProvider(Platform.GetCurrentWindow());
                     was.PresentationContextProvider = ctx;
@@ -116,7 +116,8 @@ namespace Xamarin.Essentials
             public void HandleAppleEvent(NSAppleEventDescriptor evt, NSAppleEventDescriptor replyEvt)
             {
                 var url = evt.ParamDescriptorForKeyword(DirectObject).StringValue;
-                OpenUrl(new NSUrl(url));
+                var uri = new Uri(url);
+                OpenUrl(WebUtils.GetNativeUrl(uri));
             }
 
             static uint GetDescriptor(string s) =>

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.macos.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.macos.cs
@@ -8,10 +8,15 @@ namespace Xamarin.Essentials
 {
     public static partial class WebAuthenticator
     {
+        const int asWebAuthenticationSessionErrorCodeCanceledLogin = 1;
+        const string asWebAuthenticationSessionErrorDomain = "com.apple.AuthenticationServices.WebAuthenticationSession";
+
         static readonly CallBackHelper callbackHelper = new CallBackHelper();
 
         static TaskCompletionSource<WebAuthenticatorResult> tcsResponse;
         static Uri redirectUri;
+
+        static ASWebAuthenticationSession was;
 
         static WebAuthenticator()
         {
@@ -20,50 +25,46 @@ namespace Xamarin.Essentials
 
         internal static async Task<WebAuthenticatorResult> PlatformAuthenticateAsync(Uri url, Uri callbackUrl)
         {
+            if (!AppInfo.VerifyHasUrlScheme(callbackUrl.Scheme))
+                throw new InvalidOperationException("You must register your URL Scheme handler in your app's Info.plist!");
+
             // Cancel any previous task that's still pending
             if (tcsResponse?.Task != null && !tcsResponse.Task.IsCompleted)
                 tcsResponse.TrySetCanceled();
 
             tcsResponse = new TaskCompletionSource<WebAuthenticatorResult>();
             redirectUri = callbackUrl;
+            var scheme = redirectUri.Scheme;
 
-            try
+            if (DeviceInfo.Version >= new Version(10, 15))
             {
-                var scheme = redirectUri.Scheme;
-
-                if (!AppInfo.VerifyHasUrlScheme(scheme))
+                static void AuthSessionCallback(NSUrl cbUrl, NSError error)
                 {
-                    tcsResponse.TrySetException(new InvalidOperationException("You must register your URL Scheme handler in your app's Info.plist!"));
-                    return await tcsResponse.Task;
+                    if (error == null)
+                        OpenUrl(cbUrl);
+                    else if (error.Domain == asWebAuthenticationSessionErrorDomain && error.Code == asWebAuthenticationSessionErrorCodeCanceledLogin)
+                        tcsResponse.TrySetCanceled();
+                    else
+                        tcsResponse.TrySetException(new NSErrorException(error));
+
+                    was = null;
                 }
 
-                if (DeviceInfo.Version >= new Version(10, 15))
+                was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
+
+                using (was)
                 {
-                    static void AuthSessionCallback(NSUrl cbUrl, NSError error)
-                    {
-                        if (error == null)
-                            OpenUrl(cbUrl);
-                        else
-                            tcsResponse.TrySetException(new NSErrorException(error));
-                    }
-
-                    var was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
-
                     var ctx = new ContextProvider(Platform.GetCurrentWindow());
                     was.PresentationContextProvider = ctx;
 
                     was.Start();
                     return await tcsResponse.Task;
                 }
+            }
 
-                var opened = NSWorkspace.SharedWorkspace.OpenUrl(url);
-                if (!opened)
-                    tcsResponse.TrySetException(new Exception("Error opening Safari"));
-            }
-            catch (Exception ex)
-            {
-                tcsResponse.TrySetException(ex);
-            }
+            var opened = NSWorkspace.SharedWorkspace.OpenUrl(url);
+            if (!opened)
+                tcsResponse.TrySetException(new Exception("Error opening Safari"));
 
             return await tcsResponse.Task;
         }


### PR DESCRIPTION
### Description of Change ###

When using `ASWebAuthenticationSession` and `SFAuthenticationSession`, the cancellation operations are marked by iOS throwing an exception. This PR catches those errors and then converts them into cancellation exceptions.

I also removed the containing try/catch block as that was actually catching the exceptions that were set in the `TaskCompletionSource` and then re-throwing them.

### Bugs Fixed ###

- Don't catch our own errors and then throw them
- Correctly convert from cancellation NSErrors into .NET cancellation exceptions
- Fixes #1240
- Related to #1295
- Fixes #1307

### API Changes ###

None.

### Behavioral Changes ###

iOS cancellation errors are now exposed as .NET cancellation exceptions.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
