### PR TITLE
[Android] [WebAuth] Rework authentication flow

### DIFF
--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -106,8 +106,6 @@ namespace Xamarin.Essentials
         {
             if (activity != null)
                 CheckAppActions(activity.Intent);
-
-            WebAuthenticator.OnResume(null);
         }
 
         static void CheckAppActions(AndroidIntent intent)

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.android.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.android.cs
@@ -12,15 +12,7 @@ namespace Xamarin.Essentials
     public partial class WebAuthenticator
     {
         static TaskCompletionSource<WebAuthenticatorResult> tcsResponse = null;
-
-        static Uri uri = null;
-
-        static CustomTabsActivityManager CustomTabsActivityManager { get; set; }
-
-        static Uri RedirectUri { get; set; }
-
-        internal static Task<WebAuthenticatorResult> ResponseTask
-            => tcsResponse?.Task;
+        static Uri currentRedirectUri = null;
 
         internal static bool OnResume(Intent intent)
         {
@@ -28,7 +20,7 @@ namespace Xamarin.Essentials
             if (tcsResponse?.Task?.IsCompleted ?? true)
                 return false;
 
-            if (intent == null)
+            if (intent?.Data == null)
             {
                 tcsResponse.TrySetCanceled();
                 return false;
@@ -39,9 +31,9 @@ namespace Xamarin.Essentials
                 var intentUri = new Uri(intent.Data.ToString());
 
                 // Only handle schemes we expect
-                if (!WebUtils.CanHandleCallback(RedirectUri, intentUri))
+                if (!WebUtils.CanHandleCallback(currentRedirectUri, intentUri))
                 {
-                    tcsResponse.TrySetException(new InvalidOperationException($"Invalid Redirect URI, detected `{intentUri}` but expected a URI in the format of `{RedirectUri}`"));
+                    tcsResponse.TrySetException(new InvalidOperationException($"Invalid Redirect URI, detected `{intentUri}` but expected a URI in the format of `{currentRedirectUri}`"));
                     return false;
                 }
 
@@ -55,7 +47,7 @@ namespace Xamarin.Essentials
             }
         }
 
-        static Task<WebAuthenticatorResult> PlatformAuthenticateAsync(Uri url, Uri callbackUrl)
+        static async Task<WebAuthenticatorResult> PlatformAuthenticateAsync(Uri url, Uri callbackUrl)
         {
             var packageName = Platform.AppContext.PackageName;
 
@@ -77,58 +69,68 @@ namespace Xamarin.Essentials
                 tcsResponse.TrySetCanceled();
 
             tcsResponse = new TaskCompletionSource<WebAuthenticatorResult>();
-            tcsResponse.Task.ContinueWith(t =>
+            currentRedirectUri = callbackUrl;
+
+            var parentActivity = Platform.GetCurrentActivity(true);
+
+            var customTabsActivityManager = CustomTabsActivityManager.From(parentActivity);
+            customTabsActivityManager.NavigationEvent += OnNavigationEvent;
+            try
             {
-                // Cleanup when done
-                if (CustomTabsActivityManager != null)
+                if (await BindServiceAsync(customTabsActivityManager))
                 {
-                    CustomTabsActivityManager.NavigationEvent -= CustomTabsActivityManager_NavigationEvent;
-                    CustomTabsActivityManager.CustomTabsServiceConnected -= CustomTabsActivityManager_CustomTabsServiceConnected;
+                    var customTabsIntent = new CustomTabsIntent.Builder(customTabsActivityManager.Session)
+                        .SetShowTitle(true)
+                        .Build();
 
-                    try
-                    {
-                        CustomTabsActivityManager?.Client?.Dispose();
-                    }
-                    finally
-                    {
-                        CustomTabsActivityManager = null;
-                    }
+                    customTabsIntent.Intent.SetData(global::Android.Net.Uri.Parse(url.OriginalString));
+
+                    WebAuthenticatorIntermediateActivity.StartActivity(parentActivity, customTabsIntent.Intent);
                 }
-            });
+                else
+                {
+                    // Fall back to opening the system browser if necessary
+                    var browserIntent = new Intent(Intent.ActionView, global::Android.Net.Uri.Parse(url.OriginalString));
+                    Platform.CurrentActivity.StartActivity(browserIntent);
+                }
 
-            uri = url;
-            RedirectUri = callbackUrl;
-
-            CustomTabsActivityManager = CustomTabsActivityManager.From(Platform.GetCurrentActivity(true));
-            CustomTabsActivityManager.NavigationEvent += CustomTabsActivityManager_NavigationEvent;
-            CustomTabsActivityManager.CustomTabsServiceConnected += CustomTabsActivityManager_CustomTabsServiceConnected;
-
-            if (!CustomTabsActivityManager.BindService())
+                return await tcsResponse.Task;
+            }
+            finally
             {
-                // Fall back to opening the system browser if necessary
-                var browserIntent = new Intent(Intent.ActionView, global::Android.Net.Uri.Parse(url.OriginalString));
-                Platform.CurrentActivity.StartActivity(browserIntent);
+                customTabsActivityManager.NavigationEvent -= OnNavigationEvent;
+                try
+                {
+                    customTabsActivityManager.Client?.Dispose();
+                }
+                finally
+                {
+                }
+            }
+        }
+
+        static void OnNavigationEvent(int navigationEvent, global::Android.OS.Bundle extras) =>
+            System.Diagnostics.Debug.WriteLine($"CustomTabs.NavigationEvent: {navigationEvent}");
+
+        static Task<bool> BindServiceAsync(CustomTabsActivityManager manager)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            manager.CustomTabsServiceConnected += OnCustomTabsServiceConnected;
+
+            if (!manager.BindService())
+            {
+                manager.CustomTabsServiceConnected -= OnCustomTabsServiceConnected;
+                tcs.TrySetResult(false);
             }
 
-            return WebAuthenticator.ResponseTask;
+            return tcs.Task;
+
+            void OnCustomTabsServiceConnected(ComponentName name, CustomTabsClient client)
+            {
+                manager.CustomTabsServiceConnected -= OnCustomTabsServiceConnected;
+                tcs.TrySetResult(true);
+            }
         }
-
-        static void CustomTabsActivityManager_CustomTabsServiceConnected(ComponentName name, CustomTabsClient client)
-        {
-            var builder = new CustomTabsIntent.Builder(CustomTabsActivityManager.Session)
-                                                  .SetShowTitle(true);
-
-            var customTabsIntent = builder.Build();
-            customTabsIntent.Intent.AddFlags(ActivityFlags.SingleTop | ActivityFlags.NoHistory | ActivityFlags.NewTask);
-
-            var ctx = Platform.CurrentActivity;
-
-            CustomTabsHelper.AddKeepAliveExtra(ctx, customTabsIntent.Intent);
-
-            customTabsIntent.LaunchUrl(ctx, global::Android.Net.Uri.Parse(uri.OriginalString));
-        }
-
-        static void CustomTabsActivityManager_NavigationEvent(int navigationEvent, global::Android.OS.Bundle extras) =>
-            System.Diagnostics.Debug.WriteLine($"CustomTabs.NavigationEvent: {navigationEvent}");
     }
 }

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.android.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.android.cs
@@ -74,7 +74,6 @@ namespace Xamarin.Essentials
             var parentActivity = Platform.GetCurrentActivity(true);
 
             var customTabsActivityManager = CustomTabsActivityManager.From(parentActivity);
-            customTabsActivityManager.NavigationEvent += OnNavigationEvent;
             try
             {
                 if (await BindServiceAsync(customTabsActivityManager))
@@ -98,7 +97,6 @@ namespace Xamarin.Essentials
             }
             finally
             {
-                customTabsActivityManager.NavigationEvent -= OnNavigationEvent;
                 try
                 {
                     customTabsActivityManager.Client?.Dispose();
@@ -108,9 +106,6 @@ namespace Xamarin.Essentials
                 }
             }
         }
-
-        static void OnNavigationEvent(int navigationEvent, global::Android.OS.Bundle extras) =>
-            System.Diagnostics.Debug.WriteLine($"CustomTabs.NavigationEvent: {navigationEvent}");
 
         static Task<bool> BindServiceAsync(CustomTabsActivityManager manager)
         {

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Android.App;
+﻿using Android.App;
+using Android.Content;
 using Android.OS;
 
 namespace Xamarin.Essentials
@@ -12,8 +10,13 @@ namespace Xamarin.Essentials
         {
             base.OnCreate(savedInstanceState);
 
-            WebAuthenticator.OnResume(Intent);
+            // start the intermediate activity again with flags to close the custom tabs
+            var intent = new Intent(this, typeof(WebAuthenticatorIntermediateActivity));
+            intent.SetData(Intent.Data);
+            intent.AddFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop);
+            StartActivity(intent);
 
+            // finish this activity
             Finish();
         }
     }

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
@@ -1,0 +1,72 @@
+﻿using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.OS;
+
+namespace Xamarin.Essentials
+{
+    [Activity(ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
+    class WebAuthenticatorIntermediateActivity : Activity
+    {
+        const string launchedExtra = "launched";
+        const string actualIntentExtra = "actual_intent";
+
+        bool launched;
+        Intent actualIntent;
+
+        protected override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+
+            var extras = savedInstanceState ?? Intent.Extras;
+
+            // read the values
+            launched = extras.GetBoolean(launchedExtra, false);
+            actualIntent = extras.GetParcelable(actualIntentExtra) as Intent;
+        }
+
+        protected override void OnResume()
+        {
+            base.OnResume();
+
+            if (!launched)
+            {
+                // if this is the first time, start the authentication flow
+                StartActivity(actualIntent);
+
+                launched = true;
+            }
+            else
+            {
+                // otherwise, resume the auth flow and finish this activity
+                WebAuthenticator.OnResume(Intent);
+
+                Finish();
+            }
+        }
+
+        protected override void OnNewIntent(Intent intent)
+        {
+            base.OnNewIntent(intent);
+
+            Intent = intent;
+        }
+
+        protected override void OnSaveInstanceState(Bundle outState)
+        {
+            // save the values
+            outState.PutBoolean(launchedExtra, launched);
+            outState.PutParcelable(actualIntentExtra, actualIntent);
+
+            base.OnSaveInstanceState(outState);
+        }
+
+        public static void StartActivity(Activity activity, Intent intent)
+        {
+            var intermediateIntent = new Intent(activity, typeof(WebAuthenticatorIntermediateActivity));
+            intermediateIntent.PutExtra(actualIntentExtra, intent);
+
+            activity.StartActivity(intermediateIntent);
+        }
+    }
+}

--- a/build.cake
+++ b/build.cake
@@ -76,7 +76,7 @@ Task("docs")
 	.Does(() =>
 {
 	MSBuild("./Xamarin.Essentials/Xamarin.Essentials.csproj", new MSBuildSettings()
-		.EnableBinaryLogger("./output/binlogs/nugets.binlog")
+		.EnableBinaryLogger("./output/binlogs/docs.binlog")
 		.SetConfiguration("Release")
 		.WithRestore()
 		.WithTarget("mdocupdatedocs"));


### PR DESCRIPTION
### Description of Change ###

Rework the authentication flow to better support interruptions, either by the user or the actual process of authentication via 2FA.

The new flow makes use of 2 "intermediate" activities. The first one, `WebAuthenticatorIntermediateActivity`, represents the container for the actual authentication process and starts the custom tabs. This will then handle the interruptions. The second one, `WebAuthenticatorCallbackActivity`, represents the "authenticated" path. This activity will then re-launch the first activity, but this time with different flags. These new flags will close the custom tabs and then complete the flow. 

### Bugs Fixed ###

- Fixes #1292
- Fixes #1336
- Fixes #1303

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
