### PR TITLE
Correct image rotation when taking a photo on iOS

### DIFF
--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using CoreGraphics;
 using Foundation;
 using MobileCoreServices;
 using Photos;
@@ -116,9 +117,14 @@ namespace Xamarin.Essentials
             if (phAsset == null || assetUrl == null)
             {
                 var img = info.ValueForKey(UIImagePickerController.OriginalImage) as UIImage;
+                var imgUrl = info.ValueForKey(UIImagePickerController.ImageUrl) as NSString;
 
                 if (img != null)
-                    return new UIImageFileResult(img);
+                {
+                    var rotatedImg = CorrectImageRotation(img);
+
+                    return new UIImageFileResult(rotatedImg ?? img);
+                }
             }
 
             if (phAsset == null || assetUrl == null)
@@ -132,6 +138,91 @@ namespace Xamarin.Essentials
                 originalFilename = phAsset.ValueForKey(new NSString("filename")) as NSString;
 
             return new PHAssetFileResult(assetUrl, phAsset, originalFilename);
+        }
+
+        public static UIImage CorrectImageRotation(UIImage image)
+        {
+            UIImage imageToReturn = null;
+            if (image.Orientation == UIImageOrientation.Up)
+            {
+                imageToReturn = image;
+            }
+            else
+            {
+                var transform = CGAffineTransform.MakeIdentity();
+
+                switch (image.Orientation)
+                {
+                    case UIImageOrientation.Down:
+                    case UIImageOrientation.DownMirrored:
+                        transform.Rotate((float)Math.PI);
+                        transform.Translate(image.Size.Width, image.Size.Height);
+                        break;
+
+                    case UIImageOrientation.Left:
+                    case UIImageOrientation.LeftMirrored:
+                        transform.Rotate((float)Math.PI / 2);
+                        transform.Translate(image.Size.Width, 0);
+                        break;
+
+                    case UIImageOrientation.Right:
+                    case UIImageOrientation.RightMirrored:
+                        transform.Rotate(-(float)Math.PI / 2);
+                        transform.Translate(0, image.Size.Height);
+                        break;
+                    case UIImageOrientation.Up:
+                    case UIImageOrientation.UpMirrored:
+                        break;
+                }
+
+                switch (image.Orientation)
+                {
+                    case UIImageOrientation.UpMirrored:
+                    case UIImageOrientation.DownMirrored:
+                        transform.Translate(image.Size.Width, 0);
+                        transform.Scale(-1, 1);
+                        break;
+
+                    case UIImageOrientation.LeftMirrored:
+                    case UIImageOrientation.RightMirrored:
+                        transform.Translate(image.Size.Height, 0);
+                        transform.Scale(-1, 1);
+                        break;
+                    case UIImageOrientation.Up:
+                    case UIImageOrientation.Down:
+                    case UIImageOrientation.Left:
+                    case UIImageOrientation.Right:
+                        break;
+                }
+
+                using var context = new CGBitmapContext(
+                    IntPtr.Zero,
+                    (int)image.Size.Width,
+                    (int)image.Size.Height,
+                    image.CGImage.BitsPerComponent,
+                    image.CGImage.BytesPerRow,
+                    image.CGImage.ColorSpace,
+                    image.CGImage.BitmapInfo);
+
+                context.ConcatCTM(transform);
+                switch (image.Orientation)
+                {
+                    case UIImageOrientation.Left:
+                    case UIImageOrientation.LeftMirrored:
+                    case UIImageOrientation.Right:
+                    case UIImageOrientation.RightMirrored:
+                        context.DrawImage(new CGRect(0, 0, image.Size.Height, image.Size.Width), image.CGImage);
+                        break;
+                    default:
+                        context.DrawImage(new CGRect(0, 0, image.Size.Width, image.Size.Height), image.CGImage);
+                        break;
+                }
+
+                using var imageRef = context.ToImage();
+                imageToReturn = new UIImage(imageRef, 1, UIImageOrientation.Up);
+            }
+
+            return imageToReturn;
         }
 
         class PhotoPickerDelegate : UIImagePickerControllerDelegate


### PR DESCRIPTION
### Description of Change ###

When taking a photo on iOS the resulting image is rotated by 90 degrees. This code change uses the same technique as this RotateImage method https://github.com/jamesmontemagno/MediaPlugin/blob/4b57e71d9b242ec7ae2d2bd4758f77e4535bc011/src/Media.Plugin/iOS/MediaPickerDelegate.cs#L743

No unit tests added as no existing tests for media picker in solution, presumably it is not possible to unit test the action of taking  a photo.

### Bugs Fixed ###

Relates to issue #1514 whereby when taking a photo on iOS the resulting image is incorrecrtly rotated by 90 degrees. 

### API Changes ###

None

### Behavioral Changes ###

Taking a photo may take slightly longer as the image manipulation is applied

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of `main` at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
