### PR TITLE
[Issue-1509] Change permission request for Photo and Camera

### DIFF
--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -40,11 +40,11 @@ namespace Xamarin.Essentials
             if (!photo)
                 await Permissions.EnsureGrantedAsync<Permissions.Microphone>();
 
-            // permission is not required on iOS 11 for the picker
-            if (!Platform.HasOSVersion(11, 0))
-            {
+            // Check if picking existing or not and ensure permission accordingly as they can be set independently from each other
+            if (pickExisting)
                 await Permissions.EnsureGrantedAsync<Permissions.Photos>();
-            }
+            else
+                await Permissions.EnsureGrantedAsync<Permissions.Camera>();
 
             var vc = Platform.GetCurrentViewController(true);
 

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -41,9 +41,10 @@ namespace Xamarin.Essentials
                 await Permissions.EnsureGrantedAsync<Permissions.Microphone>();
 
             // Check if picking existing or not and ensure permission accordingly as they can be set independently from each other
-            if (pickExisting)
+            if (pickExisting && !Platform.HasOSVersion(11, 0))
                 await Permissions.EnsureGrantedAsync<Permissions.Photos>();
-            else
+
+            if (!pickExisting)
                 await Permissions.EnsureGrantedAsync<Permissions.Camera>();
 
             var vc = Platform.GetCurrentViewController(true);


### PR DESCRIPTION
### Description of Change ###
Explicitly check and ask for permissions as since iOS 11 the UIImagePickerController normally takes care of this. This however can lead to the camera view being open while a user denies the permission and it just showing a black screen. Might be less confusing if it lets the user know that the permission was not granted so they can ask for it again. 

Divided the checks in to camera and photo separately. It could be somebody blocking access to their Photo Library but wanting to access the camera. Therefor check what action they want to perform and check the permission accordingly.

### Bugs Fixed ###

- Related to issue #1509 

### API Changes ###

None

### Behavioral Changes ###

Instead of seeing the UIImagePickerController appearing behind the alert asking for permission and potentially resulting in a black screen, it now asks for the permission before opening UIImagePickerController

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of `main` at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
