### PR TITLE
[Issue-1493] iOS MediaPicker.PickPhotoAsync() never returns 

### DIFF
--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -68,11 +68,14 @@ namespace Xamarin.Essentials
                     tcs.TrySetResult(DictionaryToMediaFile(info))
             };
 
-            picker.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
+            if (picker.PresentationController != null)
             {
-                CompletedHandler = info =>
-                    tcs.TrySetResult(DictionaryToMediaFile(info))
-            };
+                picker.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
+                {
+                    CompletedHandler = info =>
+                        tcs.TrySetResult(DictionaryToMediaFile(info))
+                };
+            }
 
             await vc.PresentViewControllerAsync(picker, true);
 

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -68,6 +68,12 @@ namespace Xamarin.Essentials
                     tcs.TrySetResult(DictionaryToMediaFile(info))
             };
 
+            picker.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
+            {
+                CompletedHandler = info =>
+                    tcs.TrySetResult(DictionaryToMediaFile(info))
+            };
+
             await vc.PresentViewControllerAsync(picker, true);
 
             var result = await tcs.Task;
@@ -142,6 +148,14 @@ namespace Xamarin.Essentials
                 CompletedHandler?.Invoke(info);
 
             public override void Canceled(UIImagePickerController picker) =>
+                CompletedHandler?.Invoke(null);
+        }
+
+        class PhotoPickerPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate
+        {
+            public Action<NSDictionary> CompletedHandler { get; set; }
+
+            public override void DidDismiss(UIPresentationController presentationController) =>
                 CompletedHandler?.Invoke(null);
         }
     }


### PR DESCRIPTION
### Description of Change ###

Attaching a `UIAdaptivePresentationControllerDelegate` to the `picker.PresentationController.Delegate` property so we can hook into the `DidDismiss()` method and fire a cancel action when the user dismisses the picker when swiping down

### Bugs Fixed ###

- Related to issue #1493 

### API Changes ###

None

### Behavioral Changes ###

The library now returns `null` when a user dismisses the picker by swiping down.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of `main` at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
