### PR TITLE
Apple does not use the "?to=xxx" version of the mailto

### DIFF
--- a/Samples/Samples.Android/Properties/AndroidManifest.xml
+++ b/Samples/Samples.Android/Properties/AndroidManifest.xml
@@ -12,32 +12,30 @@
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
-  <queries>
-    <intent>
-      <action android:name="android.intent.action.SENDTO" />
-      <data android:scheme="mailto" />
-    </intent>
-    <intent>
-      <action android:name="android.intent.action.VIEW" />
-      <data android:scheme="http"/>
-    </intent>
-    <intent>
-      <action android:name="android.intent.action.VIEW" />
-      <data android:scheme="https"/>
-    </intent>
-    <intent>
-      <action android:name="android.intent.action.VIEW" />
-      <data android:scheme="smsto"/>
-    </intent>
-    <intent>
-      <action android:name="android.intent.action.DIAL" />
-      <data android:scheme="tel"/>
-    </intent>
-  </queries>
+	<queries>
+		<intent>
+			<action android:name="android.intent.action.SENDTO" />
+			<data android:scheme="mailto" />
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="http" />
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="https" />
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="smsto" />
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.DIAL" />
+			<data android:scheme="tel" />
+		</intent>
+	</queries>
 	<uses-feature android:name="android.hardware.location" android:required="false" />
 	<uses-feature android:name="android.hardware.location.gps" android:required="false" />
 	<uses-feature android:name="android.hardware.location.network" android:required="false" />
-	<application android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/MainTheme" android:fullBackupContent="@xml/my_backup_rules">
-   
-  </application>
+	<application android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/MainTheme" android:fullBackupContent="@xml/my_backup_rules"></application>
 </manifest>

--- a/Samples/Samples.iOS/Info.plist
+++ b/Samples/Samples.iOS/Info.plist
@@ -74,5 +74,9 @@
 	<string>Contacts</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>mailto</string>
+	</array>
 </dict>
 </plist>

--- a/Xamarin.Essentials/Email/Email.shared.cs
+++ b/Xamarin.Essentials/Email/Email.shared.cs
@@ -31,16 +31,19 @@ namespace Xamarin.Essentials
                 parts.Add("body=" + Uri.EscapeDataString(message.Body));
             if (!string.IsNullOrEmpty(message?.Subject))
                 parts.Add("subject=" + Uri.EscapeDataString(message.Subject));
-            if (message?.To?.Count > 0)
-                parts.Add("to=" + Uri.EscapeDataString(string.Join(",", message.To)));
             if (message?.Cc?.Count > 0)
                 parts.Add("cc=" + Uri.EscapeDataString(string.Join(",", message.Cc)));
             if (message?.Bcc?.Count > 0)
                 parts.Add("bcc=" + Uri.EscapeDataString(string.Join(",", message.Bcc)));
 
             var uri = "mailto:";
+
+            if (message?.To?.Count > 0)
+                uri += Uri.EscapeDataString(string.Join(",", message.To));
+
             if (parts.Count > 0)
                 uri += "?" + string.Join("&", parts);
+
             return uri;
         }
     }

--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
@@ -51,7 +51,10 @@ namespace Xamarin.Essentials
 
             void TryCancel()
             {
+#pragma warning disable 0618
+                // hWord is obsolete, but only just the latest release
                 ss.StopSpeaking(NSSpeechBoundary.hWord);
+#pragma warning restore 0618
                 tcs.TrySetResult(true);
             }
 


### PR DESCRIPTION
### Description of Change ###

According to the spec: https://www.ietf.org/rfc/rfc2368.html#page-2

```
   Also note that it is legal to specify both "to" and an "hname" whose
   value is "to". That is,

     mailto:addr1%2C%20addr2

     is equivalent to

     mailto:?to=addr1%2C%20addr2

     is equivalent to

     mailto:addr1?to=addr2
```

But not for Google on iOS.

### Bugs Fixed ###

- Related to issue #1401

### API Changes ###

None.

### Behavioral Changes ###

mailto URI used now has the "to" as the first part.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
