### PR TITLE
Get the correct name from the components

### DIFF
--- a/Samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
+++ b/Samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
@@ -44,7 +44,14 @@ namespace Samples.ViewModel
                     && DeviceInfo.Platform == DevicePlatform.iOS
                     && DeviceInfo.Version.Major >= 13)
                 {
-                    r = await AppleSignInAuthenticator.AuthenticateAsync();
+                    // Make sure to enable Apple Sign In in both the
+                    // entitlements and the provisioning profile.
+                    var options = new AppleSignInAuthenticator.Options
+                    {
+                        IncludeEmailScope = true,
+                        IncludeFullNameScope = true,
+                    };
+                    r = await AppleSignInAuthenticator.AuthenticateAsync(options);
                 }
                 else
                 {
@@ -54,7 +61,12 @@ namespace Samples.ViewModel
                     r = await WebAuthenticator.AuthenticateAsync(authUrl, callbackUrl);
                 }
 
-                AuthToken = r?.AccessToken ?? r?.IdToken;
+                AuthToken = string.Empty;
+                if (r.Properties.TryGetValue("name", out var name) && !string.IsNullOrEmpty(name))
+                    AuthToken += $"Name: {name}{Environment.NewLine}";
+                if (r.Properties.TryGetValue("email", out var email) && !string.IsNullOrEmpty(email))
+                    AuthToken += $"Email: {email}{Environment.NewLine}";
+                AuthToken += r?.AccessToken ?? r?.IdToken;
             }
             catch (OperationCanceledException)
             {

--- a/Xamarin.Essentials/WebAuthenticator/AppleSignInAuthenticator.ios.cs
+++ b/Xamarin.Essentials/WebAuthenticator/AppleSignInAuthenticator.ios.cs
@@ -37,18 +37,22 @@ namespace Xamarin.Essentials
 
             controller.PerformRequests();
 
-            var creds = await authManager.Credentials;
+            var creds = await authManager.GetCredentialsAsync();
 
             if (creds == null)
                 return null;
 
+            var idToken = new NSString(creds.IdentityToken, NSStringEncoding.UTF8).ToString();
+            var authCode = new NSString(creds.AuthorizationCode, NSStringEncoding.UTF8).ToString();
+            var name = NSPersonNameComponentsFormatter.GetLocalizedString(creds.FullName, NSPersonNameComponentsFormatterStyle.Default, 0);
+
             var appleAccount = new WebAuthenticatorResult();
-            appleAccount.Properties.Add("id_token", new NSString(creds.IdentityToken, NSStringEncoding.UTF8).ToString());
-            appleAccount.Properties.Add("authorization_code", new NSString(creds.AuthorizationCode, NSStringEncoding.UTF8).ToString());
+            appleAccount.Properties.Add("id_token", idToken);
+            appleAccount.Properties.Add("authorization_code", authCode);
             appleAccount.Properties.Add("state", creds.State);
             appleAccount.Properties.Add("email", creds.Email);
             appleAccount.Properties.Add("user_id", creds.User);
-            appleAccount.Properties.Add("name", NSPersonNameComponentsFormatter.GetLocalizedString(creds.FullName, NSPersonNameComponentsFormatterStyle.Default, NSPersonNameComponentsFormatterOptions.Phonetic));
+            appleAccount.Properties.Add("name", name);
             appleAccount.Properties.Add("realuserstatus", creds.RealUserStatus.ToString());
 
             return appleAccount;
@@ -57,7 +61,7 @@ namespace Xamarin.Essentials
 
     class AuthManager : NSObject, IASAuthorizationControllerDelegate, IASAuthorizationControllerPresentationContextProviding
     {
-        public Task<ASAuthorizationAppleIdCredential> Credentials
+        public Task<ASAuthorizationAppleIdCredential> GetCredentialsAsync()
             => tcsCredential?.Task;
 
         TaskCompletionSource<ASAuthorizationAppleIdCredential> tcsCredential;


### PR DESCRIPTION
### Description of Change ###

Get the correct name from the components. Previously we were retrieving the phonetic name, without first checking for it.  I am not sure we actually want to do that and we rather ant the name as it is specified.

### Bugs Fixed ###

- Fixes #1288

### API Changes ###

None.

### Behavioral Changes ###

The `name` is now correctly parsed from the sign in response.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
