### PR TITLE
"preserve" the FileProvider by using it

### DIFF
--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -414,7 +414,7 @@ namespace Xamarin.Essentials
             if (!string.IsNullOrEmpty(output))
             {
                 var javaFile = new Java.IO.File(output);
-                var providerAuthority = Platform.AppContext.PackageName + ".fileProvider";
+                var providerAuthority = FileProvider.Authority;
                 outputUri = FileProvider.GetUriForFile(Platform.AppContext, providerAuthority, javaFile);
                 actualIntent.PutExtra(MediaStore.ExtraOutput, outputUri);
             }

--- a/Xamarin.Essentials/Types/FileProvider.android.cs
+++ b/Xamarin.Essentials/Types/FileProvider.android.cs
@@ -28,6 +28,8 @@ namespace Xamarin.Essentials
         // We can choose external only, or internal only as alternative options
         public static FileProviderLocation TemporaryLocation { get; set; } = FileProviderLocation.PreferExternal;
 
+        internal static string Authority => Platform.AppContext.PackageName + ".fileProvider";
+
         internal static Java.IO.File GetTemporaryDirectory()
         {
             var root = GetTemporaryRootDirectory();


### PR DESCRIPTION
### Description of Change ###

Even though we actually reference it directly in code to get te Uri, this is actually on the base type and thus gets resolved to the base type in IL. As a result, the code never actual references the local type and it gets linked out, the manifest does not have the element and nothing works.

### Bugs Fixed ###

- Fixes #1513

### API Changes ###

None.

### Behavioral Changes ###

No more crashes.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
