### PR TITLE
Rework the "picker" results to correctly manage files

### DIFF
--- a/Samples/Samples.Android/Properties/AndroidManifest.xml
+++ b/Samples/Samples.Android/Properties/AndroidManifest.xml
@@ -13,25 +13,34 @@
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<queries>
+		<!-- Email -->
 		<intent>
 			<action android:name="android.intent.action.SENDTO" />
 			<data android:scheme="mailto" />
 		</intent>
+		<!-- Browser -->
 		<intent>
 			<action android:name="android.intent.action.VIEW" />
 			<data android:scheme="http" />
 		</intent>
+		<!-- Browser -->
 		<intent>
 			<action android:name="android.intent.action.VIEW" />
 			<data android:scheme="https" />
 		</intent>
+		<!-- Sms -->
 		<intent>
 			<action android:name="android.intent.action.VIEW" />
 			<data android:scheme="smsto" />
 		</intent>
+		<!-- PhoneDialer -->
 		<intent>
 			<action android:name="android.intent.action.DIAL" />
 			<data android:scheme="tel" />
+		</intent>
+		<!-- MediaPicker -->
+		<intent>
+			<action android:name="android.media.action.IMAGE_CAPTURE" />
 		</intent>
 	</queries>
 	<uses-feature android:name="android.hardware.location" android:required="false" />

--- a/Samples/Samples/ViewModel/ShareViewModel.cs
+++ b/Samples/Samples/ViewModel/ShareViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Windows.Input;
 using Samples.Helpers;
 using Xamarin.Essentials;
@@ -157,7 +158,7 @@ namespace Samples.ViewModel
             await Share.RequestAsync(new ShareMultipleFilesRequest
             {
                 Title = ShareFilesTitle,
-                Files = new ShareFile[] { new ShareFile(file1), new ShareFile(file2) },
+                Files = new List<ShareFile> { new ShareFile(file1), new ShareFile(file2) },
                 PresentationSourceBounds = GetRectangle(element)
             });
         }

--- a/Tests/FileSystem_Tests.cs
+++ b/Tests/FileSystem_Tests.cs
@@ -17,5 +17,26 @@ namespace Tests
         {
             await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => FileSystem.OpenAppPackageFileAsync("filename.txt"));
         }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData(".", ".")]
+        [InlineData(".txt", ".txt")]
+        [InlineData("*.txt", ".txt")]
+        [InlineData("*.*", ".*")]
+        [InlineData("txt", ".txt")]
+        [InlineData("test.txt", ".test.txt")]
+        [InlineData("test.", ".test.")]
+        [InlineData("....txt", ".txt")]
+        [InlineData("******txt", ".txt")]
+        [InlineData("******.txt", ".txt")]
+        [InlineData("******.......txt", ".txt")]
+        public void Extensions_Clean_Correctly_Cleans_Extensions(string input, string output)
+        {
+            var cleaned = FileSystem.Extensions.Clean(input);
+
+            Assert.Equal(output, cleaned);
+        }
     }
 }

--- a/Xamarin.Essentials/Email/Email.android.cs
+++ b/Xamarin.Essentials/Email/Email.android.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Essentials
             if (action == Intent.ActionSendto)
                 intent.SetData(Uri.Parse("mailto:"));
             else
-                intent.SetType("message/rfc822");
+                intent.SetType(FileSystem.MimeTypes.EmailMessage);
 
             if (!string.IsNullOrEmpty(message?.Body))
             {

--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Essentials
             var action = Intent.ActionOpenDocument;
 
             var intent = new Intent(action);
-            intent.SetType("*/*");
+            intent.SetType(FileSystem.MimeTypes.All);
             intent.PutExtra(Intent.ExtraAllowMultiple, allowMultiple);
 
             var allowedTypes = options?.FileTypes?.Value?.ToArray();
@@ -69,31 +69,31 @@ namespace Xamarin.Essentials
         static FilePickerFileType PlatformImageFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "image/png", "image/jpeg" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.ImagePng, FileSystem.MimeTypes.ImageJpg } }
             });
 
         static FilePickerFileType PlatformPngFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "image/png" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.ImagePng } }
             });
 
         static FilePickerFileType PlatformJpegFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "image/jpeg" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.ImageJpg } }
             });
 
         static FilePickerFileType PlatformVideoFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "video/*" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.VideoAll } }
             });
 
         static FilePickerFileType PlatformPdfFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "application/pdf" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.Pdf } }
             });
     }
 }

--- a/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
@@ -34,11 +34,7 @@ namespace Xamarin.Essentials
                 {
                     try
                     {
-                        // there was a cancellation
-                        if (urls?.Any() ?? false)
-                            tcs.TrySetResult(urls.Select(url => new UIDocumentFileResult(url)));
-                        else
-                            tcs.TrySetResult(Enumerable.Empty<FileResult>());
+                        tcs.TrySetResult(GetFiles(urls));
                     }
                     catch (Exception ex)
                     {
@@ -63,9 +59,14 @@ namespace Xamarin.Essentials
             return tcs.Task;
         }
 
+        static IEnumerable<FileResult> GetFiles(NSUrl[] urls) =>
+            urls?.Length > 0
+                ? urls.Select(url => new UIDocumentFileResult(url))
+                : Enumerable.Empty<FileResult>();
+
         class PickerDelegate : UIDocumentPickerDelegate
         {
-            public Action<IEnumerable<NSUrl>> PickHandler { get; set; }
+            public Action<NSUrl[]> PickHandler { get; set; }
 
             public override void WasCancelled(UIDocumentPickerViewController controller)
                 => PickHandler?.Invoke(null);
@@ -74,7 +75,7 @@ namespace Xamarin.Essentials
                 => PickHandler?.Invoke(urls);
 
             public override void DidPickDocument(UIDocumentPickerViewController controller, NSUrl url)
-                => PickHandler?.Invoke(new List<NSUrl> { url });
+                => PickHandler?.Invoke(new NSUrl[] { url });
         }
 
         class PickerPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate

--- a/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Essentials
             appControl.LaunchMode = AppControlLaunchMode.Single;
 
             var fileType = options?.FileTypes?.Value?.FirstOrDefault();
-            appControl.Mime = fileType ?? "*/*";
+            appControl.Mime = fileType ?? FileSystem.MimeTypes.All;
 
             var fileResults = new List<FileResult>();
 
@@ -51,31 +51,31 @@ namespace Xamarin.Essentials
         static FilePickerFileType PlatformImageFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "image/*" } },
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.ImageAll } },
             });
 
         static FilePickerFileType PlatformPngFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "image/png" } }
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.ImagePng } }
             });
 
         static FilePickerFileType PlatformJpegFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "image/jpeg" } }
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.ImageJpg } }
             });
 
         static FilePickerFileType PlatformVideoFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "video/*" } }
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.VideoAll } }
             });
 
         static FilePickerFileType PlatformPdfFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "application/pdf" } }
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.Pdf } }
             });
     }
 }

--- a/Xamarin.Essentials/FilePicker/FilePicker.uwp.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.uwp.cs
@@ -49,9 +49,10 @@ namespace Xamarin.Essentials
             {
                 foreach (var type in options.FileTypes.Value)
                 {
-                    if (type.StartsWith(".") || type.StartsWith("*."))
+                    var ext = FileSystem.Extensions.Clean(type);
+                    if (!string.IsNullOrWhiteSpace(ext))
                     {
-                        picker.FileTypeFilter.Add(type.TrimStart('*'));
+                        picker.FileTypeFilter.Add(ext);
                         hasAtLeastOneType = true;
                     }
                 }
@@ -67,31 +68,31 @@ namespace Xamarin.Essentials
         static FilePickerFileType PlatformImageFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.UWP, new[] { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp" } }
+                { DevicePlatform.UWP, FileSystem.Extensions.AllImage }
             });
 
         static FilePickerFileType PlatformPngFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.UWP, new[] { "*.png" } }
+                { DevicePlatform.UWP, new[] { FileSystem.Extensions.Png } }
             });
 
         static FilePickerFileType PlatformJpegFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.UWP, new[] { "*.jpg", "*.jpeg" } }
+                { DevicePlatform.UWP, FileSystem.Extensions.AllJpeg }
             });
 
         static FilePickerFileType PlatformVideoFileType() =>
            new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
            {
-                { DevicePlatform.UWP, new[] { "*.mp4", "*.mov", "*.avi", "*.wmv", "*.m4v", "*.mpg", "*.mpeg", "*.mp2", "*.mkv", "*.flv", "*.gifv", "*.qt" } }
+                { DevicePlatform.UWP, FileSystem.Extensions.AllVideo }
            });
 
         static FilePickerFileType PlatformPdfFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.UWP, new[] { "*.pdf" } }
+                { DevicePlatform.UWP, new[] { FileSystem.Extensions.Pdf } }
             });
     }
 }

--- a/Xamarin.Essentials/FileSystem/FileSystem.android.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.android.cs
@@ -1,10 +1,10 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Threading.Tasks;
-using Android.App;
 using Android.Provider;
 using Android.Webkit;
+using AndroidUri = Android.Net.Uri;
 
 namespace Xamarin.Essentials
 {
@@ -31,67 +31,299 @@ namespace Xamarin.Essentials
                 throw new FileNotFoundException(ex.Message, filename, ex);
             }
         }
-    }
 
-    public partial class FileBase
-    {
-        internal FileBase(Java.IO.File file)
-            : this(file?.Path)
+        internal static Java.IO.File GetEssentialsTemporaryFile(Java.IO.File root, string fileName)
         {
+            // create the directory for all Essentials files
+            var rootDir = new Java.IO.File(root, "2203693cc04e0be7f4f024d5f9499e13");
+            rootDir.Mkdirs();
+            rootDir.DeleteOnExit();
+
+            // create a unique directory just in case there are multiple file with the same name
+            var tmpDir = new Java.IO.File(rootDir, Guid.NewGuid().ToString("N"));
+            tmpDir.Mkdirs();
+            tmpDir.DeleteOnExit();
+
+            // create the new temporary file
+            var tmpFile = new Java.IO.File(tmpDir, fileName);
+            tmpFile.DeleteOnExit();
+
+            return tmpFile;
         }
 
-        internal FileBase(global::Android.Net.Uri contentUri)
-           : this(GetFullPath(contentUri))
-        {
-            this.contentUri = contentUri;
-            FileName = GetFileName(contentUri);
-        }
-
-        readonly global::Android.Net.Uri contentUri;
-
-        internal static string PlatformGetContentType(string extension) =>
-            MimeTypeMap.Singleton.GetMimeTypeFromExtension(extension.TrimStart('.'));
-
-        static string GetFullPath(global::Android.Net.Uri contentUri)
+        internal static string EnsurePhysicalPath(AndroidUri uri)
         {
             // if this is a file, use that
-            if (contentUri.Scheme == "file")
-                return contentUri.Path;
+            if (uri.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase))
+                return uri.Path;
 
-            // ask the content provider for the data column, which may contain the actual file path
+            // try resolve using the content provider
+            var absolute = ResolvePhysicalPath(uri);
+            if (!string.IsNullOrWhiteSpace(absolute) && Path.IsPathRooted(absolute))
+                return absolute;
+
+            // fall back to just copying it
+            absolute = CacheContentFile(uri);
+            if (!string.IsNullOrWhiteSpace(absolute) && Path.IsPathRooted(absolute))
+                return absolute;
+
+            throw new FileNotFoundException($"Unable to resolve absolute path or retrieve contents of URI '{uri}'.");
+        }
+
+        static string ResolvePhysicalPath(AndroidUri uri)
+        {
+            if (Platform.HasApiLevelKitKat && DocumentsContract.IsDocumentUri(Platform.AppContext, uri))
+            {
+                var resolved = ResolveDocumentPath(uri);
+                if (File.Exists(resolved))
+                    return resolved;
+            }
+
+            if (uri.Scheme.Equals("content", StringComparison.OrdinalIgnoreCase))
+            {
+                var resolved = ResolveContentPath(uri);
+                if (File.Exists(resolved))
+                    return resolved;
+            }
+            else if (uri.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase))
+            {
+                var resolved = uri.Path;
+                if (File.Exists(resolved))
+                    return resolved;
+            }
+
+            return null;
+        }
+
+        static string ResolveDocumentPath(AndroidUri uri)
+        {
+            Debug.WriteLine($"Trying to resolve document URI: '{uri}'");
+
+            var docId = DocumentsContract.GetDocumentId(uri);
+
+            var docIdParts = docId?.Split(':');
+            if (docIdParts == null || docIdParts.Length == 0)
+                return null;
+
+            if (uri.Authority.Equals("com.android.externalstorage.documents", StringComparison.OrdinalIgnoreCase))
+            {
+                Debug.WriteLine($"Resolving external storage URI: '{uri}'");
+
+                if (docIdParts.Length == 2)
+                {
+                    var storageType = docIdParts[0];
+                    var uriPath = docIdParts[1];
+
+                    // This is the internal "external" memory, NOT the SD Card
+                    if (storageType.Equals("primary", StringComparison.OrdinalIgnoreCase))
+                    {
 #pragma warning disable CS0618 // Type or member is obsolete
-            var path = QueryContentResolverColumn(contentUri, MediaStore.Files.FileColumns.Data);
+                        var root = global::Android.OS.Environment.ExternalStorageDirectory.Path;
 #pragma warning restore CS0618 // Type or member is obsolete
 
+                        return Path.Combine(root, uriPath);
+                    }
+
+                    // TODO: support other types, such as actual SD Cards
+                }
+            }
+            else if (uri.Authority.Equals("com.android.providers.downloads.documents", StringComparison.OrdinalIgnoreCase))
+            {
+                Debug.WriteLine($"Resolving downloads URI: '{uri}'");
+
+                // NOTE: This only really applies to older Android vesions since the privacy changes
+
+                if (docIdParts.Length == 2)
+                {
+                    var storageType = docIdParts[0];
+                    var uriPath = docIdParts[1];
+
+                    if (storageType.Equals("raw", StringComparison.OrdinalIgnoreCase))
+                        return uriPath;
+                }
+
+                var contentUriPrefixes = new[]
+                {
+                    "content://downloads/public_downloads",
+                    "content://downloads/my_downloads",
+                    "content://downloads/all_downloads",
+                };
+
+                // ID could be "###" or "msf:###"
+                var fileId = docIdParts.Length == 2
+                    ? docIdParts[1]
+                    : docIdParts[0];
+
+                foreach (var prefix in contentUriPrefixes)
+                {
+                    var uriString = prefix + "/" + fileId;
+                    var contentUri = AndroidUri.Parse(uriString);
+
+                    if (GetDataFilePath(contentUri) is string filePath)
+                        return filePath;
+                }
+            }
+            else if (uri.Authority.Equals("com.android.providers.media.documents", StringComparison.OrdinalIgnoreCase))
+            {
+                Debug.WriteLine($"Resolving media URI: '{uri}'");
+
+                if (docIdParts.Length == 2)
+                {
+                    var storageType = docIdParts[0];
+                    var uriPath = docIdParts[1];
+
+                    AndroidUri contentUri = null;
+                    if (storageType.Equals("image", StringComparison.OrdinalIgnoreCase))
+                        contentUri = MediaStore.Images.Media.ExternalContentUri;
+                    else if (storageType.Equals("video", StringComparison.OrdinalIgnoreCase))
+                        contentUri = MediaStore.Video.Media.ExternalContentUri;
+                    else if (storageType.Equals("audio", StringComparison.OrdinalIgnoreCase))
+                        contentUri = MediaStore.Audio.Media.ExternalContentUri;
+
+                    if (contentUri != null && GetDataFilePath(contentUri, "_id=?", new[] { uriPath }) is string filePath)
+                        return filePath;
+                }
+            }
+
+            Debug.WriteLine($"Unable to resolve document URI: '{uri}'");
+
+            return null;
+        }
+
+        static string ResolveContentPath(AndroidUri uri)
+        {
+            Debug.WriteLine($"Trying to resolve content URI: '{uri}'");
+
+            if (GetDataFilePath(uri) is string filePath)
+                return filePath;
+
+            // TODO: support some additional things, like Google Photos if that is possible
+
+            Debug.WriteLine($"Unable to resolve content URI: '{uri}'");
+
+            return null;
+        }
+
+        static string CacheContentFile(AndroidUri uri)
+        {
+            if (!uri.Scheme.Equals("content", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            Debug.WriteLine($"Copying content URI to local cache: '{uri}'");
+
+            // open the source stream
+            using var srcStream = OpenContentStream(uri, out var extension);
+            if (srcStream == null)
+                return null;
+
+            // resolve or generate a valid destination path
+            var filename = GetColumnValue(uri, MediaStore.Files.FileColumns.DisplayName) ?? Guid.NewGuid().ToString("N");
+            if (!Path.HasExtension(filename) && !string.IsNullOrEmpty(extension))
+                filename = Path.ChangeExtension(filename, extension);
+
+            // create a temporary file
+            var tmpFile = GetEssentialsTemporaryFile(Platform.AppContext.CacheDir, filename);
+
+            // copy to the destination
+            using var dstStream = File.Create(tmpFile.CanonicalPath);
+            srcStream.CopyTo(dstStream);
+
+            return tmpFile.CanonicalPath;
+        }
+
+        static Stream OpenContentStream(AndroidUri uri, out string extension)
+        {
+            var isVirtual = IsVirtualFile(uri);
+            if (isVirtual)
+            {
+                Debug.WriteLine($"Content URI was virtual: '{uri}'");
+                return GetVirtualFileStream(uri, out extension);
+            }
+
+            extension = GetFileExtension(uri);
+            return Platform.ContentResolver.OpenInputStream(uri);
+        }
+
+        static bool IsVirtualFile(AndroidUri uri)
+        {
+            if (!DocumentsContract.IsDocumentUri(Platform.AppContext, uri))
+                return false;
+
+            var value = GetColumnValue(uri, DocumentsContract.Document.ColumnFlags);
+            if (!string.IsNullOrEmpty(value) && int.TryParse(value, out var flagsInt))
+            {
+                var flags = (DocumentContractFlags)flagsInt;
+                return flags.HasFlag(DocumentContractFlags.VirtualDocument);
+            }
+
+            return false;
+        }
+
+        static Stream GetVirtualFileStream(AndroidUri uri, out string extension)
+        {
+            var mimeTypes = Platform.ContentResolver.GetStreamTypes(uri, "*/*");
+            if (mimeTypes?.Length >= 1)
+            {
+                var mimeType = mimeTypes[0];
+
+                var stream = Platform.ContentResolver
+                    .OpenTypedAssetFileDescriptor(uri, mimeType, null)
+                    .CreateInputStream();
+
+                extension = MimeTypeMap.Singleton.GetExtensionFromMimeType(mimeType);
+
+                return stream;
+            }
+
+            extension = null;
+            return null;
+        }
+
+        static string GetColumnValue(AndroidUri contentUri, string column, string selection = null, string[] selectionArgs = null)
+        {
+            try
+            {
+                var value = QueryContentResolverColumn(contentUri, column, selection, selectionArgs);
+                if (!string.IsNullOrEmpty(value))
+                    return value;
+            }
+            catch
+            {
+                // Ignore all exceptions and use null for the error indicator
+            }
+
+            return null;
+        }
+
+        static string GetDataFilePath(AndroidUri contentUri, string selection = null, string[] selectionArgs = null)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            const string column = MediaStore.Files.FileColumns.Data;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // ask the content provider for the data column, which may contain the actual file path
+            var path = GetColumnValue(contentUri, column, selection, selectionArgs);
             if (!string.IsNullOrEmpty(path) && Path.IsPathRooted(path))
                 return path;
 
-            // fallback: use content URI
-            return contentUri.ToString();
+            return null;
         }
 
-        static string GetFileName(global::Android.Net.Uri contentUri)
+        static string GetFileExtension(AndroidUri uri)
         {
-            // resolve file name by querying content provider for display name
-            var filename = QueryContentResolverColumn(contentUri, MediaStore.MediaColumns.DisplayName);
+            var mimeType = Platform.ContentResolver.GetType(uri);
 
-            if (string.IsNullOrWhiteSpace(filename))
-            {
-                filename = Path.GetFileName(WebUtility.UrlDecode(contentUri.ToString()));
-            }
-
-            if (!Path.HasExtension(filename))
-                filename = filename.TrimEnd('.') + '.' + GetFileExtensionFromUri(contentUri);
-
-            return filename;
+            return mimeType != null
+                ? MimeTypeMap.Singleton.GetExtensionFromMimeType(mimeType)
+                : null;
         }
 
-        static string QueryContentResolverColumn(global::Android.Net.Uri contentUri, string columnName)
+        static string QueryContentResolverColumn(AndroidUri contentUri, string columnName, string selection = null, string[] selectionArgs = null)
         {
             string text = null;
 
             var projection = new[] { columnName };
-            using var cursor = Application.Context.ContentResolver.Query(contentUri, projection, null, null, null);
+            using var cursor = Platform.ContentResolver.Query(contentUri, projection, selection, selectionArgs, null);
             if (cursor?.MoveToFirst() == true)
             {
                 var columnIndex = cursor.GetColumnIndex(columnName);
@@ -101,12 +333,17 @@ namespace Xamarin.Essentials
 
             return text;
         }
+    }
 
-        static string GetFileExtensionFromUri(global::Android.Net.Uri uri)
+    public partial class FileBase
+    {
+        internal FileBase(Java.IO.File file)
+            : this(file?.Path)
         {
-            var mimeType = Application.Context.ContentResolver.GetType(uri);
-            return mimeType != null ? global::Android.Webkit.MimeTypeMap.Singleton.GetExtensionFromMimeType(mimeType) : string.Empty;
         }
+
+        internal static string PlatformGetContentType(string extension) =>
+            MimeTypeMap.Singleton.GetMimeTypeFromExtension(extension.TrimStart('.'));
 
         internal void PlatformInit(FileBase file)
         {
@@ -114,22 +351,8 @@ namespace Xamarin.Essentials
 
         internal virtual Task<Stream> PlatformOpenReadAsync()
         {
-            if (contentUri?.Scheme == "content")
-            {
-                var content = Application.Context.ContentResolver.OpenInputStream(contentUri);
-                return Task.FromResult(content);
-            }
-
             var stream = File.OpenRead(FullPath);
             return Task.FromResult<Stream>(stream);
-        }
-    }
-
-    public partial class FileResult
-    {
-        internal FileResult(global::Android.Net.Uri contentUri)
-            : base(contentUri)
-        {
         }
     }
 }

--- a/Xamarin.Essentials/FileSystem/FileSystem.ios.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.ios.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Essentials
         {
             uiImage = image;
 
-            FullPath = Guid.NewGuid().ToString() + ".png";
+            FullPath = Guid.NewGuid().ToString() + FileSystem.Extensions.Png;
             FileName = FullPath;
         }
 

--- a/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
@@ -14,11 +14,77 @@ namespace Xamarin.Essentials
 
         public static Task<Stream> OpenAppPackageFileAsync(string filename)
             => PlatformOpenAppPackageFileAsync(filename);
+
+        internal static class MimeTypes
+        {
+            internal const string All = "*/*";
+
+            internal const string ImageAll = "image/*";
+            internal const string ImagePng = "image/png";
+            internal const string ImageJpg = "image/jpeg";
+
+            internal const string VideoAll = "video/*";
+
+            internal const string EmailMessage = "message/rfc822";
+
+            internal const string Pdf = "application/pdf";
+
+            internal const string TextPlain = "text/plain";
+
+            internal const string OctetStream = "application/octet-stream";
+        }
+
+        internal static class Extensions
+        {
+            internal const string Png = ".png";
+            internal const string Jpg = ".jpg";
+            internal const string Jpeg = ".jpeg";
+            internal const string Gif = ".gif";
+            internal const string Bmp = ".bmp";
+
+            internal const string Avi = ".avi";
+            internal const string Flv = ".flv";
+            internal const string Gifv = ".gifv";
+            internal const string Mp4 = ".mp4";
+            internal const string M4v = ".m4v";
+            internal const string Mpg = ".mpg";
+            internal const string Mpeg = ".mpeg";
+            internal const string Mp2 = ".mp2";
+            internal const string Mkv = ".mkv";
+            internal const string Mov = ".mov";
+            internal const string Qt = ".qt";
+            internal const string Wmv = ".wmv";
+
+            internal const string Pdf = ".pdf";
+
+            internal static string[] AllImage =>
+                new[] { Png, Jpg, Jpeg, Gif, Bmp };
+
+            internal static string[] AllJpeg =>
+                new[] { Jpg, Jpeg };
+
+            internal static string[] AllVideo =>
+                new[] { Mp4, Mov, Avi, Wmv, M4v, Mpg, Mpeg, Mp2, Mkv, Flv, Gifv, Qt };
+
+            internal static string Clean(string extension, bool trimLeadingPeriod = false)
+            {
+                if (string.IsNullOrWhiteSpace(extension))
+                    return string.Empty;
+
+                extension = extension.TrimStart('*');
+                extension = extension.TrimStart('.');
+
+                if (!trimLeadingPeriod)
+                    extension = "." + extension;
+
+                return extension;
+            }
+        }
     }
 
     public abstract partial class FileBase
     {
-        internal const string DefaultContentType = "application/octet-stream";
+        internal const string DefaultContentType = FileSystem.MimeTypes.OctetStream;
 
         string contentType;
 
@@ -76,7 +142,8 @@ namespace Xamarin.Essentials
                 if (!string.IsNullOrWhiteSpace(content))
                     return content;
             }
-            return "application/octet-stream";
+
+            return DefaultContentType;
         }
 
         string fileName;

--- a/Xamarin.Essentials/Launcher/Launcher.tizen.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.tizen.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Essentials
             var appControl = new AppControl
             {
                 Operation = AppControlOperations.View,
-                Mime = "*/*",
+                Mime = FileSystem.MimeTypes.All,
                 Uri = "file://" + request.File.FullPath,
             };
 

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Android.App;
 using Android.Content;
 using Android.Content.PM;
 using Android.Provider;
+using AndroidUri = Android.Net.Uri;
 
 namespace Xamarin.Essentials
 {
@@ -24,7 +20,7 @@ namespace Xamarin.Essentials
 
         static async Task<FileResult> PlatformPickAsync(MediaPickerOptions options, bool photo)
         {
-            // we only need the permission when accessing the file, but it's more natural
+            // We only need the permission when accessing the file, but it's more natural
             // to ask the user first, then show the picker.
             await Permissions.RequestAsync<Permissions.StorageRead>();
 
@@ -35,9 +31,19 @@ namespace Xamarin.Essentials
 
             try
             {
-                var result = await IntermediateActivity.StartAsync(pickerIntent, Platform.requestCodeMediaPicker);
+                string path = null;
+                void OnResult(Intent intent)
+                {
+                    // The uri returned is only temporary and only lives as long as the Activity that requested it,
+                    // so this means that it will always be cleaned up by the time we need it because we are using
+                    // an intermediate activity.
 
-                return new FileResult(result.Data);
+                    path = FileSystem.EnsurePhysicalPath(intent.Data);
+                }
+
+                await IntermediateActivity.StartAsync(pickerIntent, Platform.requestCodeMediaPicker, onResult: OnResult);
+
+                return new FileResult(path);
             }
             catch (OperationCanceledException)
             {
@@ -57,32 +63,45 @@ namespace Xamarin.Essentials
             await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
 
             var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);
-            if (capturePhotoIntent.ResolveActivity(Platform.AppContext.PackageManager) != null)
+
+            if (!Platform.IsIntentSupported(capturePhotoIntent))
+                throw new FeatureNotSupportedException($"Either there was no camera on the device or '{capturePhotoIntent.Action}' was not added to the <queries> element in the app's manifest file. See more: https://developer.android.com/about/versions/11/privacy/package-visibility");
+
+            capturePhotoIntent.AddFlags(ActivityFlags.GrantReadUriPermission);
+            capturePhotoIntent.AddFlags(ActivityFlags.GrantWriteUriPermission);
+
+            try
             {
-                try
+                var activity = Platform.GetCurrentActivity(true);
+
+                // Create the temporary file
+                var ext = photo ? ".jpg" : ".mp4";
+                var fileName = Guid.NewGuid().ToString("N") + ext;
+                var tmpFile = FileSystem.GetEssentialsTemporaryFile(Platform.AppContext.CacheDir, fileName);
+
+                // Set up the content:// uri
+                AndroidUri outputUri = null;
+                void OnCreate(Intent intent)
                 {
-                    var activity = Platform.GetCurrentActivity(true);
+                    // Android requires that using a file provider to get a content:// uri for a file to be called
+                    // from within the context of the actual activity which may share that uri with another intent
+                    // it launches.
 
-                    var storageDir = Platform.AppContext.ExternalCacheDir;
-                    var tmpFile = Java.IO.File.CreateTempFile(Guid.NewGuid().ToString(), photo ? ".jpg" : ".mp4", storageDir);
-                    tmpFile.DeleteOnExit();
+                    outputUri ??= FileProvider.GetUriForFile(tmpFile);
 
-                    capturePhotoIntent.AddFlags(ActivityFlags.GrantReadUriPermission);
-                    capturePhotoIntent.AddFlags(ActivityFlags.GrantWriteUriPermission);
-
-                    var result = await IntermediateActivity.StartAsync(capturePhotoIntent, Platform.requestCodeMediaCapture, tmpFile);
-
-                    var outputUri = result.GetParcelableExtra(IntermediateActivity.OutputUriExtra) as global::Android.Net.Uri;
-
-                    return new FileResult(outputUri);
+                    intent.PutExtra(MediaStore.ExtraOutput, outputUri);
                 }
-                catch (OperationCanceledException)
-                {
-                    return null;
-                }
+
+                // Start the capture process
+                await IntermediateActivity.StartAsync(capturePhotoIntent, Platform.requestCodeMediaCapture, OnCreate);
+
+                // Return the file that we just captured
+                return new FileResult(tmpFile.AbsolutePath);
             }
-
-            return null;
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
         }
     }
 }

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Essentials
             await Permissions.RequestAsync<Permissions.StorageRead>();
 
             var intent = new Intent(Intent.ActionGetContent);
-            intent.SetType(photo ? "image/*" : "video/*");
+            intent.SetType(photo ? FileSystem.MimeTypes.ImageAll : FileSystem.MimeTypes.VideoAll);
 
             var pickerIntent = Intent.CreateChooser(intent, options?.Title);
 
@@ -75,7 +75,9 @@ namespace Xamarin.Essentials
                 var activity = Platform.GetCurrentActivity(true);
 
                 // Create the temporary file
-                var ext = photo ? ".jpg" : ".mp4";
+                var ext = photo
+                    ? FileSystem.Extensions.Jpg
+                    : FileSystem.Extensions.Mp4;
                 var fileName = Guid.NewGuid().ToString("N") + ext;
                 var tmpFile = FileSystem.GetEssentialsTemporaryFile(Platform.AppContext.CacheDir, fileName);
 

--- a/Xamarin.Essentials/PhoneDialer/PhoneDialer.android.cs
+++ b/Xamarin.Essentials/PhoneDialer/PhoneDialer.android.cs
@@ -16,9 +16,8 @@ namespace Xamarin.Essentials
         {
             get
             {
-                var packageManager = Platform.AppContext.PackageManager;
                 var dialIntent = ResolveDialIntent(intentCheck);
-                return dialIntent.ResolveActivity(packageManager) != null;
+                return Platform.IsIntentSupported(dialIntent);
             }
         }
 

--- a/Xamarin.Essentials/Share/Share.android.cs
+++ b/Xamarin.Essentials/Share/Share.android.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Essentials
             }
 
             var intent = new Intent(Intent.ActionSend);
-            intent.SetType("text/plain");
+            intent.SetType(FileSystem.MimeTypes.TextPlain);
             intent.PutExtra(Intent.ExtraText, string.Join(System.Environment.NewLine, items));
 
             if (!string.IsNullOrWhiteSpace(request.Subject))
@@ -46,7 +46,10 @@ namespace Xamarin.Essentials
             foreach (var file in request.Files)
                 contentUris.Add(Platform.GetShareableFileUri(file));
 
-            intent.SetType(request.Files.Count() > 1 ? "*/*" : request.Files.FirstOrDefault().ContentType);
+            var type = request.Files.Count > 1
+                ? FileSystem.MimeTypes.All
+                : request.Files.FirstOrDefault().ContentType;
+            intent.SetType(type);
 
             intent.SetFlags(ActivityFlags.GrantReadUriPermission);
             intent.PutParcelableArrayListExtra(Intent.ExtraStream, contentUris);

--- a/Xamarin.Essentials/Share/Share.shared.cs
+++ b/Xamarin.Essentials/Share/Share.shared.cs
@@ -116,7 +116,8 @@ namespace Xamarin.Essentials
         {
         }
 
-        public ShareMultipleFilesRequest(IEnumerable<ShareFile> files) => Files = files;
+        public ShareMultipleFilesRequest(IEnumerable<ShareFile> files) =>
+            Files = files.ToList();
 
         public ShareMultipleFilesRequest(IEnumerable<FileBase> files)
             : this(ConvertList(files))
@@ -131,7 +132,7 @@ namespace Xamarin.Essentials
         {
         }
 
-        public IEnumerable<ShareFile> Files { get; set; }
+        public List<ShareFile> Files { get; set; }
 
         public static explicit operator ShareMultipleFilesRequest(ShareFileRequest request)
         {

--- a/Xamarin.Essentials/Sms/Sms.android.cs
+++ b/Xamarin.Essentials/Sms/Sms.android.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Essentials
                 if (!string.IsNullOrWhiteSpace(packageName))
                 {
                     intent = new Intent(Intent.ActionSend);
-                    intent.SetType("text/plain");
+                    intent.SetType(FileSystem.MimeTypes.TextPlain);
                     intent.PutExtra(Intent.ExtraText, body);
                     intent.SetPackage(packageName);
 

--- a/Xamarin.Essentials/Types/FileProvider.android.cs
+++ b/Xamarin.Essentials/Types/FileProvider.android.cs
@@ -4,6 +4,7 @@ using Android.App;
 using Android.Content;
 using Android.OS;
 using AndroidEnvironment = Android.OS.Environment;
+using AndroidUri = Android.Net.Uri;
 #if __ANDROID_29__
 using ContentFileProvider = AndroidX.Core.Content.FileProvider;
 #else
@@ -29,15 +30,6 @@ namespace Xamarin.Essentials
         public static FileProviderLocation TemporaryLocation { get; set; } = FileProviderLocation.PreferExternal;
 
         internal static string Authority => Platform.AppContext.PackageName + ".fileProvider";
-
-        internal static Java.IO.File GetTemporaryDirectory()
-        {
-            var root = GetTemporaryRootDirectory();
-            var dir = new Java.IO.File(root, "2203693cc04e0be7f4f024d5f9499e13");
-            dir.Mkdirs();
-            dir.DeleteOnExit();
-            return dir;
-        }
 
         internal static Java.IO.File GetTemporaryRootDirectory()
         {
@@ -124,6 +116,9 @@ namespace Xamarin.Essentials
 
             return false;
         }
+
+        internal static AndroidUri GetUriForFile(Java.IO.File file) =>
+            FileProvider.GetUriForFile(Platform.AppContext, Authority, file);
     }
 
     public enum FileProviderLocation

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.android.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.android.cs
@@ -59,9 +59,7 @@ namespace Xamarin.Essentials
             intent.SetData(global::Android.Net.Uri.Parse(callbackUrl.OriginalString));
 
             // Try to find the activity for the callback intent
-            var c = intent.ResolveActivity(Platform.AppContext.PackageManager);
-
-            if (c == null || c.PackageName != packageName)
+            if (!Platform.IsIntentSupported(intent, packageName))
                 throw new InvalidOperationException($"You must subclass the `{nameof(WebAuthenticatorCallbackActivity)}` and create an IntentFilter for it which matches your `{nameof(callbackUrl)}`.");
 
             // Cancel any previous task that's still pending


### PR DESCRIPTION
### Description of Change ###

This PR solves a few issues.

* The URI to the picked file is **only valid as long as the calling Activity is alive**.  
   Because we use an intermediate activity, this means that the URI almost immediately becomes invalid.  
   To solve for this, we have to resolve the physical path of the picked file. Many providers have a way to retrieve the physical path, or the path is known based on the type of content URI.
* Some picked files **cannot be resolve to a physical path**.  
   This might be because there are no permissions, or the file only exists as a stream from a file provider.  
   In this case, we need to copy the file to a local location.
* Some picked **files are virtual*.   
   This might be a Google docs spreadsheet which is not a real file format.
   To solve this, we detect the virtual and then ask the provider what formats are supported. We then use that format and open the stream.

This PR also changes a few things in the code that overlap with the fixes.

* Removed the usage of magic strings to a static list of mime types and extensions.
* Made use of the `IsIntentSupported` method on Android.
* Switched to `List<T>` for `ShareMultipleFilesRequest.Files` for consistency.


### Bugs Fixed ###

- Fixes #1538
- Fixes #1477
- Fixes #1483
- Fixes #1537
- Fixes #1481

### API Changes ###

None visible.

### Behavioral Changes ###

This PR will make sure all the `FileResult` instances point to a physical file location after a picker operation.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
