### PR TITLE
Initial attempt at adding cross-platform directory and file lists.

### DIFF
--- a/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
+++ b/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
@@ -109,9 +109,15 @@
     <AndroidAsset Include="Assets\AppBundleFile.txt" />
     <AndroidAsset Include="Assets\AppBundleFile_NoExtension" />
     <AndroidAsset Include="Assets\Folder\AppBundleFile_Nested.txt" />
+    <AndroidAsset Include="Assets\Folder\AppBundleFile_Nested.txt">
+      <Link>Assets\Folder\SubFolder\AppBundleFile_Nested.txt</Link>
+    </AndroidAsset>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Assets\Folder\SubFolder\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/DeviceTests/DeviceTests.Shared/FileSystem_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/FileSystem_Tests.cs
@@ -46,5 +46,21 @@ namespace DeviceTests
         {
             await Assert.ThrowsAsync<FileNotFoundException>(() => FileSystem.OpenAppPackageFileAsync("MissingFile.txt"));
         }
+
+        [Theory]
+        [InlineData("Folder")]
+        public void AppResourceDirectories_Is_Valid(string path)
+        {
+            var directories = FileSystem.GetAppResourceDirectories(path);
+            Assert.True(directories != null);
+        }
+
+        [Theory]
+        [InlineData("Folder")]
+        public void AppResourceFiles_Is_Valid(string path)
+        {
+            var files = FileSystem.GetAppResourceFiles(path);
+            Assert.True(files != null);
+        }
     }
 }

--- a/Samples/Samples.Android/Properties/AndroidManifest.xml
+++ b/Samples/Samples.Android/Properties/AndroidManifest.xml
@@ -13,25 +13,34 @@
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<queries>
+		<!-- Email -->
 		<intent>
 			<action android:name="android.intent.action.SENDTO" />
 			<data android:scheme="mailto" />
 		</intent>
+		<!-- Browser -->
 		<intent>
 			<action android:name="android.intent.action.VIEW" />
 			<data android:scheme="http" />
 		</intent>
+		<!-- Browser -->
 		<intent>
 			<action android:name="android.intent.action.VIEW" />
 			<data android:scheme="https" />
 		</intent>
+		<!-- Sms -->
 		<intent>
 			<action android:name="android.intent.action.VIEW" />
 			<data android:scheme="smsto" />
 		</intent>
+		<!-- PhoneDialer -->
 		<intent>
 			<action android:name="android.intent.action.DIAL" />
 			<data android:scheme="tel" />
+		</intent>
+		<!-- MediaPicker -->
+		<intent>
+			<action android:name="android.media.action.IMAGE_CAPTURE" />
 		</intent>
 	</queries>
 	<uses-feature android:name="android.hardware.location" android:required="false" />

--- a/Samples/Samples.Android/Samples.Android.csproj
+++ b/Samples/Samples.Android/Samples.Android.csproj
@@ -122,6 +122,16 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\FileSystemTemplate.txt" />
+    <AndroidAsset Include="Assets\FileSystemTemplate.txt">
+      <Link>Assets\Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </AndroidAsset>
+    <AndroidAsset Include="Assets\FileSystemTemplate.txt">
+      <Link>Assets\Folder\FileSystemTemplate.txt</Link>
+    </AndroidAsset>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Assets\Folder\" />
+    <Folder Include="Assets\Folder\SubFolder\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Samples/Samples.Mac/Samples.Mac.csproj
+++ b/Samples/Samples.Mac/Samples.Mac.csproj
@@ -102,6 +102,16 @@
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\FileSystemTemplate.txt" />
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\Folder\" />
+    <Folder Include="Resources\Folder\SubFolder\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/Samples/Samples.Mac/Samples.Mac.csproj
+++ b/Samples/Samples.Mac/Samples.Mac.csproj
@@ -106,6 +106,12 @@
       <Link>Resources\Folder\FileSystemTemplate.txt</Link>
     </BundleResource>
     <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate1.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate2.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
       <Link>Resources\Folder\SubFolder\FileSystemTemplate.txt</Link>
     </BundleResource>
   </ItemGroup>

--- a/Samples/Samples.Tizen/Samples.Tizen.csproj
+++ b/Samples/Samples.Tizen/Samples.Tizen.csproj
@@ -19,6 +19,8 @@
   <ItemGroup>
     <Folder Include="lib\" />
     <Folder Include="res\" />
+    <Folder Include="res\Folder" />
+    <Folder Include="res\Folder\SubFolder" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,4 +29,13 @@
     <PackageReference Include="Tizen.NET.MaterialComponents" Version="0.9.9-pre2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="res\FileSystemTemplate.txt" />
+    <None Include="res\FileSystemTemplate.txt">
+      <Link>res\Folder\FileSystemTemplate.txt</Link>
+    </None>
+    <None Include="res\FileSystemTemplate.txt">
+      <Link>res\Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Samples/Samples.UWP/Samples.UWP.csproj
+++ b/Samples/Samples.UWP/Samples.UWP.csproj
@@ -161,7 +161,6 @@
   <ItemGroup>
     <Content Include="Assets\app_info_action_icon.png" />
     <Content Include="Assets\battery_action_icon.png" />
-    <Content Include="FileSystemTemplate.txt" />
     <Content Include="Properties\Default.rd.xml" />
     <Content Include="Assets\LockScreenLogo.scale-100.png" />
     <Content Include="Assets\LockScreenLogo.scale-125.png" />
@@ -195,6 +194,19 @@
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
     <Content Include="Assets\Wide310x150Logo.scale-400.png" />
     <Content Include="Properties\Default.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="FileSystemTemplate.txt" />
+    <Content Include="FileSystemTemplate.txt">
+      <Link>Folder\FileSystemTemplate.txt</Link>
+    </Content>
+    <Content Include="FileSystemTemplate.txt">
+      <Link>Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Folder\" />
+    <Folder Include="Folder\SubFolder\" />
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="WindowsMobile, Version=10.0.18362.0">

--- a/Samples/Samples.iOS/Samples.iOS.csproj
+++ b/Samples/Samples.iOS/Samples.iOS.csproj
@@ -104,12 +104,22 @@
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\FileSystemTemplate.txt" />
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </BundleResource>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\**\*" Visible="false" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\Folder\" />
+    <Folder Include="Resources\Folder\SubFolder\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ProjectExtensions>

--- a/Samples/Samples/View/FileSystemPage.xaml
+++ b/Samples/Samples/View/FileSystemPage.xaml
@@ -15,10 +15,10 @@
         <Label Text="{Binding CacheDirectory, StringFormat='Cache: {0}'}" />
         <Label Text="{Binding AppDataDirectory, StringFormat='App Data: {0}'}" />
 
-        <Label Text="Directories:" FontAttributes="Bold" Margin="0,6,0,0" />
+        <Label Text="Resource Directories:" FontAttributes="Bold" Margin="0,6,0,0" />
         <ListView ItemsSource="{Binding AppResourceDirectories}"/>
 
-        <Label Text="Files:" FontAttributes="Bold" Margin="0,6,0,0" />
+        <Label Text="Resource Files:" FontAttributes="Bold" Margin="0,6,0,0" />
         <ListView ItemsSource="{Binding AppResourceFiles}"/>
 
         <Label Text="Operations:" FontAttributes="Bold" Margin="0,6,0,0" />

--- a/Samples/Samples/View/FileSystemPage.xaml
+++ b/Samples/Samples/View/FileSystemPage.xaml
@@ -15,6 +15,12 @@
         <Label Text="{Binding CacheDirectory, StringFormat='Cache: {0}'}" />
         <Label Text="{Binding AppDataDirectory, StringFormat='App Data: {0}'}" />
 
+        <Label Text="Directories:" FontAttributes="Bold" Margin="0,6,0,0" />
+        <ListView ItemsSource="{Binding AppResourceDirectories}"/>
+
+        <Label Text="Files:" FontAttributes="Bold" Margin="0,6,0,0" />
+        <ListView ItemsSource="{Binding AppResourceFiles}"/>
+
         <Label Text="Operations:" FontAttributes="Bold" Margin="0,6,0,0" />
         <StackLayout Orientation="Horizontal" Spacing="6">
             <Button Text="Load" Command="{Binding LoadFileCommand}" HorizontalOptions="FillAndExpand" />
@@ -25,5 +31,4 @@
         <Label Text="Edit the contents of the file:" />
         <Editor Text="{Binding CurrentContents}" AutoSize="TextChanges" />
     </StackLayout>
-
 </views:BasePage>

--- a/Samples/Samples/ViewModel/FileSystemViewModel.cs
+++ b/Samples/Samples/ViewModel/FileSystemViewModel.cs
@@ -33,6 +33,10 @@ namespace Samples.ViewModel
 
         public string CacheDirectory => FileSystem.CacheDirectory;
 
+        public string[] AppResourceDirectories => FileSystem.GetAppResourceDirectories("Folder");
+
+        public string[] AppResourceFiles => FileSystem.GetAppResourceFiles("Folder");
+
         public string CurrentContents
         {
             get => currentContents;

--- a/Samples/Samples/ViewModel/ShareViewModel.cs
+++ b/Samples/Samples/ViewModel/ShareViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Windows.Input;
 using Samples.Helpers;
 using Xamarin.Essentials;
@@ -157,7 +158,7 @@ namespace Samples.ViewModel
             await Share.RequestAsync(new ShareMultipleFilesRequest
             {
                 Title = ShareFilesTitle,
-                Files = new ShareFile[] { new ShareFile(file1), new ShareFile(file2) },
+                Files = new List<ShareFile> { new ShareFile(file1), new ShareFile(file2) },
                 PresentationSourceBounds = GetRectangle(element)
             });
         }

--- a/Tests/FileSystem_Tests.cs
+++ b/Tests/FileSystem_Tests.cs
@@ -17,5 +17,26 @@ namespace Tests
         {
             await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => FileSystem.OpenAppPackageFileAsync("filename.txt"));
         }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData(".", ".")]
+        [InlineData(".txt", ".txt")]
+        [InlineData("*.txt", ".txt")]
+        [InlineData("*.*", ".*")]
+        [InlineData("txt", ".txt")]
+        [InlineData("test.txt", ".test.txt")]
+        [InlineData("test.", ".test.")]
+        [InlineData("....txt", ".txt")]
+        [InlineData("******txt", ".txt")]
+        [InlineData("******.txt", ".txt")]
+        [InlineData("******.......txt", ".txt")]
+        public void Extensions_Clean_Correctly_Cleans_Extensions(string input, string output)
+        {
+            var cleaned = FileSystem.Extensions.Clean(input);
+
+            Assert.Equal(output, cleaned);
+        }
     }
 }

--- a/Xamarin.Essentials/Email/Email.android.cs
+++ b/Xamarin.Essentials/Email/Email.android.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Essentials
             if (action == Intent.ActionSendto)
                 intent.SetData(Uri.Parse("mailto:"));
             else
-                intent.SetType("message/rfc822");
+                intent.SetType(FileSystem.MimeTypes.EmailMessage);
 
             if (!string.IsNullOrEmpty(message?.Body))
             {

--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -2,11 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
-using Android.App;
 using Android.Content;
-using Android.Provider;
 
 namespace Xamarin.Essentials
 {
@@ -22,7 +19,7 @@ namespace Xamarin.Essentials
             var action = Intent.ActionOpenDocument;
 
             var intent = new Intent(action);
-            intent.SetType("*/*");
+            intent.SetType(FileSystem.MimeTypes.All);
             intent.PutExtra(Intent.ExtraAllowMultiple, allowMultiple);
 
             var allowedTypes = options?.FileTypes?.Value?.ToArray();
@@ -33,23 +30,30 @@ namespace Xamarin.Essentials
 
             try
             {
-                var result = await IntermediateActivity.StartAsync(pickerIntent, Platform.requestCodeFilePicker);
                 var resultList = new List<FileResult>();
-
-                var clipData = new List<global::Android.Net.Uri>();
-
-                if (result.ClipData == null)
+                void OnResult(Intent intent)
                 {
-                    clipData.Add(result.Data);
-                }
-                else
-                {
-                    for (var i = 0; i < result.ClipData.ItemCount; i++)
-                        clipData.Add(result.ClipData.GetItemAt(i).Uri);
+                    // The uri returned is only temporary and only lives as long as the Activity that requested it,
+                    // so this means that it will always be cleaned up by the time we need it because we are using
+                    // an intermediate activity.
+
+                    if (intent.ClipData == null)
+                    {
+                        var path = FileSystem.EnsurePhysicalPath(intent.Data);
+                        resultList.Add(new FileResult(path));
+                    }
+                    else
+                    {
+                        for (var i = 0; i < intent.ClipData.ItemCount; i++)
+                        {
+                            var uri = intent.ClipData.GetItemAt(i).Uri;
+                            var path = FileSystem.EnsurePhysicalPath(uri);
+                            resultList.Add(new FileResult(path));
+                        }
+                    }
                 }
 
-                foreach (var contentUri in clipData)
-                    resultList.Add(new FileResult(contentUri));
+                await IntermediateActivity.StartAsync(pickerIntent, Platform.requestCodeFilePicker, onResult: OnResult);
 
                 return resultList;
             }
@@ -65,31 +69,31 @@ namespace Xamarin.Essentials
         static FilePickerFileType PlatformImageFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "image/png", "image/jpeg" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.ImagePng, FileSystem.MimeTypes.ImageJpg } }
             });
 
         static FilePickerFileType PlatformPngFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "image/png" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.ImagePng } }
             });
 
         static FilePickerFileType PlatformJpegFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "image/jpeg" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.ImageJpg } }
             });
 
         static FilePickerFileType PlatformVideoFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "video/*" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.VideoAll } }
             });
 
         static FilePickerFileType PlatformPdfFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Android, new[] { "application/pdf" } }
+                { DevicePlatform.Android, new[] { FileSystem.MimeTypes.Pdf } }
             });
     }
 }

--- a/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
@@ -34,7 +34,6 @@ namespace Xamarin.Essentials
                 {
                     try
                     {
-                        // there was a cancellation
                         tcs.TrySetResult(GetFileResults(urls));
                     }
                     catch (Exception ex)
@@ -72,13 +71,10 @@ namespace Xamarin.Essentials
             return tcs.Task;
         }
 
-        static IEnumerable<FileResult> GetFileResults(NSUrl[] urls)
-        {
-            if (urls?.Length > 0)
-                return urls.Select(url => new UIDocumentFileResult(url));
-            else
-                return Enumerable.Empty<FileResult>();
-        }
+        static IEnumerable<FileResult> GetFileResults(NSUrl[] urls) =>
+            urls?.Length > 0
+                ? urls.Select(url => new UIDocumentFileResult(url))
+                : Enumerable.Empty<FileResult>();
 
         class PickerDelegate : UIDocumentPickerDelegate
         {

--- a/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.tizen.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Essentials
             appControl.LaunchMode = AppControlLaunchMode.Single;
 
             var fileType = options?.FileTypes?.Value?.FirstOrDefault();
-            appControl.Mime = fileType ?? "*/*";
+            appControl.Mime = fileType ?? FileSystem.MimeTypes.All;
 
             var fileResults = new List<FileResult>();
 
@@ -51,31 +51,31 @@ namespace Xamarin.Essentials
         static FilePickerFileType PlatformImageFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "image/*" } },
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.ImageAll } },
             });
 
         static FilePickerFileType PlatformPngFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "image/png" } }
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.ImagePng } }
             });
 
         static FilePickerFileType PlatformJpegFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "image/jpeg" } }
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.ImageJpg } }
             });
 
         static FilePickerFileType PlatformVideoFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "video/*" } }
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.VideoAll } }
             });
 
         static FilePickerFileType PlatformPdfFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.Tizen, new[] { "application/pdf" } }
+                { DevicePlatform.Tizen, new[] { FileSystem.MimeTypes.Pdf } }
             });
     }
 }

--- a/Xamarin.Essentials/FilePicker/FilePicker.uwp.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.uwp.cs
@@ -49,9 +49,10 @@ namespace Xamarin.Essentials
             {
                 foreach (var type in options.FileTypes.Value)
                 {
-                    if (type.StartsWith(".") || type.StartsWith("*."))
+                    var ext = FileSystem.Extensions.Clean(type);
+                    if (!string.IsNullOrWhiteSpace(ext))
                     {
-                        picker.FileTypeFilter.Add(type.TrimStart('*'));
+                        picker.FileTypeFilter.Add(ext);
                         hasAtLeastOneType = true;
                     }
                 }
@@ -67,31 +68,31 @@ namespace Xamarin.Essentials
         static FilePickerFileType PlatformImageFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.UWP, new[] { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp" } }
+                { DevicePlatform.UWP, FileSystem.Extensions.AllImage }
             });
 
         static FilePickerFileType PlatformPngFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.UWP, new[] { "*.png" } }
+                { DevicePlatform.UWP, new[] { FileSystem.Extensions.Png } }
             });
 
         static FilePickerFileType PlatformJpegFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.UWP, new[] { "*.jpg", "*.jpeg" } }
+                { DevicePlatform.UWP, FileSystem.Extensions.AllJpeg }
             });
 
         static FilePickerFileType PlatformVideoFileType() =>
            new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
            {
-                { DevicePlatform.UWP, new[] { "*.mp4", "*.mov", "*.avi", "*.wmv", "*.m4v", "*.mpg", "*.mpeg", "*.mp2", "*.mkv", "*.flv", "*.gifv", "*.qt" } }
+                { DevicePlatform.UWP, FileSystem.Extensions.AllVideo }
            });
 
         static FilePickerFileType PlatformPdfFileType() =>
             new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
             {
-                { DevicePlatform.UWP, new[] { "*.pdf" } }
+                { DevicePlatform.UWP, new[] { FileSystem.Extensions.Pdf } }
             });
     }
 }

--- a/Xamarin.Essentials/FileSystem/FileSystem.android.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.android.cs
@@ -1,15 +1,36 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Threading.Tasks;
-using Android.App;
 using Android.Provider;
 using Android.Webkit;
+using AndroidUri = Android.Net.Uri;
 
 namespace Xamarin.Essentials
 {
     public partial class FileSystem
     {
+        internal const string EssentialsFolderHash = "2203693cc04e0be7f4f024d5f9499e13";
+
+        const string storageTypePrimary = "primary";
+        const string storageTypeRaw = "raw";
+        const string storageTypeImage = "image";
+        const string storageTypeVideo = "video";
+        const string storageTypeAudio = "audio";
+        static readonly string[] contentUriPrefixes =
+        {
+            "content://downloads/public_downloads",
+            "content://downloads/my_downloads",
+            "content://downloads/all_downloads",
+        };
+
+        internal const string UriSchemeFile = "file";
+        internal const string UriSchemeContent = "content";
+
+        internal const string UriAuthorityExternalStorage = "com.android.externalstorage.documents";
+        internal const string UriAuthorityDownloads = "com.android.providers.downloads.documents";
+        internal const string UriAuthorityMedia = "com.android.providers.media.documents";
+
         static string PlatformCacheDirectory
             => Platform.AppContext.CacheDir.AbsolutePath;
 
@@ -31,67 +52,292 @@ namespace Xamarin.Essentials
                 throw new FileNotFoundException(ex.Message, filename, ex);
             }
         }
-    }
 
-    public partial class FileBase
-    {
-        internal FileBase(Java.IO.File file)
-            : this(file?.Path)
+        internal static Java.IO.File GetEssentialsTemporaryFile(Java.IO.File root, string fileName)
         {
+            // create the directory for all Essentials files
+            var rootDir = new Java.IO.File(root, EssentialsFolderHash);
+            rootDir.Mkdirs();
+            rootDir.DeleteOnExit();
+
+            // create a unique directory just in case there are multiple file with the same name
+            var tmpDir = new Java.IO.File(rootDir, Guid.NewGuid().ToString("N"));
+            tmpDir.Mkdirs();
+            tmpDir.DeleteOnExit();
+
+            // create the new temporary file
+            var tmpFile = new Java.IO.File(tmpDir, fileName);
+            tmpFile.DeleteOnExit();
+
+            return tmpFile;
         }
 
-        internal FileBase(global::Android.Net.Uri contentUri)
-           : this(GetFullPath(contentUri))
-        {
-            this.contentUri = contentUri;
-            FileName = GetFileName(contentUri);
-        }
-
-        readonly global::Android.Net.Uri contentUri;
-
-        internal static string PlatformGetContentType(string extension) =>
-            MimeTypeMap.Singleton.GetMimeTypeFromExtension(extension.TrimStart('.'));
-
-        static string GetFullPath(global::Android.Net.Uri contentUri)
+        internal static string EnsurePhysicalPath(AndroidUri uri)
         {
             // if this is a file, use that
-            if (contentUri.Scheme == "file")
-                return contentUri.Path;
+            if (uri.Scheme.Equals(UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+                return uri.Path;
 
-            // ask the content provider for the data column, which may contain the actual file path
+            // try resolve using the content provider
+            var absolute = ResolvePhysicalPath(uri);
+            if (!string.IsNullOrWhiteSpace(absolute) && Path.IsPathRooted(absolute))
+                return absolute;
+
+            // fall back to just copying it
+            absolute = CacheContentFile(uri);
+            if (!string.IsNullOrWhiteSpace(absolute) && Path.IsPathRooted(absolute))
+                return absolute;
+
+            throw new FileNotFoundException($"Unable to resolve absolute path or retrieve contents of URI '{uri}'.");
+        }
+
+        static string ResolvePhysicalPath(AndroidUri uri)
+        {
+            if (Platform.HasApiLevelKitKat && DocumentsContract.IsDocumentUri(Platform.AppContext, uri))
+            {
+                var resolved = ResolveDocumentPath(uri);
+                if (File.Exists(resolved))
+                    return resolved;
+            }
+
+            if (uri.Scheme.Equals(UriSchemeContent, StringComparison.OrdinalIgnoreCase))
+            {
+                var resolved = ResolveContentPath(uri);
+                if (File.Exists(resolved))
+                    return resolved;
+            }
+            else if (uri.Scheme.Equals(UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+            {
+                var resolved = uri.Path;
+                if (File.Exists(resolved))
+                    return resolved;
+            }
+
+            return null;
+        }
+
+        static string ResolveDocumentPath(AndroidUri uri)
+        {
+            Debug.WriteLine($"Trying to resolve document URI: '{uri}'");
+
+            var docId = DocumentsContract.GetDocumentId(uri);
+
+            var docIdParts = docId?.Split(':');
+            if (docIdParts == null || docIdParts.Length == 0)
+                return null;
+
+            if (uri.Authority.Equals(UriAuthorityExternalStorage, StringComparison.OrdinalIgnoreCase))
+            {
+                Debug.WriteLine($"Resolving external storage URI: '{uri}'");
+
+                if (docIdParts.Length == 2)
+                {
+                    var storageType = docIdParts[0];
+                    var uriPath = docIdParts[1];
+
+                    // This is the internal "external" memory, NOT the SD Card
+                    if (storageType.Equals(storageTypePrimary, StringComparison.OrdinalIgnoreCase))
+                    {
 #pragma warning disable CS0618 // Type or member is obsolete
-            var path = QueryContentResolverColumn(contentUri, MediaStore.Files.FileColumns.Data);
+                        var root = global::Android.OS.Environment.ExternalStorageDirectory.Path;
 #pragma warning restore CS0618 // Type or member is obsolete
 
+                        return Path.Combine(root, uriPath);
+                    }
+
+                    // TODO: support other types, such as actual SD Cards
+                }
+            }
+            else if (uri.Authority.Equals(UriAuthorityDownloads, StringComparison.OrdinalIgnoreCase))
+            {
+                Debug.WriteLine($"Resolving downloads URI: '{uri}'");
+
+                // NOTE: This only really applies to older Android vesions since the privacy changes
+
+                if (docIdParts.Length == 2)
+                {
+                    var storageType = docIdParts[0];
+                    var uriPath = docIdParts[1];
+
+                    if (storageType.Equals(storageTypeRaw, StringComparison.OrdinalIgnoreCase))
+                        return uriPath;
+                }
+
+                // ID could be "###" or "msf:###"
+                var fileId = docIdParts.Length == 2
+                    ? docIdParts[1]
+                    : docIdParts[0];
+
+                foreach (var prefix in contentUriPrefixes)
+                {
+                    var uriString = prefix + "/" + fileId;
+                    var contentUri = AndroidUri.Parse(uriString);
+
+                    if (GetDataFilePath(contentUri) is string filePath)
+                        return filePath;
+                }
+            }
+            else if (uri.Authority.Equals(UriAuthorityMedia, StringComparison.OrdinalIgnoreCase))
+            {
+                Debug.WriteLine($"Resolving media URI: '{uri}'");
+
+                if (docIdParts.Length == 2)
+                {
+                    var storageType = docIdParts[0];
+                    var uriPath = docIdParts[1];
+
+                    AndroidUri contentUri = null;
+                    if (storageType.Equals(storageTypeImage, StringComparison.OrdinalIgnoreCase))
+                        contentUri = MediaStore.Images.Media.ExternalContentUri;
+                    else if (storageType.Equals(storageTypeVideo, StringComparison.OrdinalIgnoreCase))
+                        contentUri = MediaStore.Video.Media.ExternalContentUri;
+                    else if (storageType.Equals(storageTypeAudio, StringComparison.OrdinalIgnoreCase))
+                        contentUri = MediaStore.Audio.Media.ExternalContentUri;
+
+                    if (contentUri != null && GetDataFilePath(contentUri, $"{MediaStore.MediaColumns.Id}=?", new[] { uriPath }) is string filePath)
+                        return filePath;
+                }
+            }
+
+            Debug.WriteLine($"Unable to resolve document URI: '{uri}'");
+
+            return null;
+        }
+
+        static string ResolveContentPath(AndroidUri uri)
+        {
+            Debug.WriteLine($"Trying to resolve content URI: '{uri}'");
+
+            if (GetDataFilePath(uri) is string filePath)
+                return filePath;
+
+            // TODO: support some additional things, like Google Photos if that is possible
+
+            Debug.WriteLine($"Unable to resolve content URI: '{uri}'");
+
+            return null;
+        }
+
+        static string CacheContentFile(AndroidUri uri)
+        {
+            if (!uri.Scheme.Equals(UriSchemeContent, StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            Debug.WriteLine($"Copying content URI to local cache: '{uri}'");
+
+            // open the source stream
+            using var srcStream = OpenContentStream(uri, out var extension);
+            if (srcStream == null)
+                return null;
+
+            // resolve or generate a valid destination path
+            var filename = GetColumnValue(uri, MediaStore.Files.FileColumns.DisplayName) ?? Guid.NewGuid().ToString("N");
+            if (!Path.HasExtension(filename) && !string.IsNullOrEmpty(extension))
+                filename = Path.ChangeExtension(filename, extension);
+
+            // create a temporary file
+            var tmpFile = GetEssentialsTemporaryFile(Platform.AppContext.CacheDir, filename);
+
+            // copy to the destination
+            using var dstStream = File.Create(tmpFile.CanonicalPath);
+            srcStream.CopyTo(dstStream);
+
+            return tmpFile.CanonicalPath;
+        }
+
+        static Stream OpenContentStream(AndroidUri uri, out string extension)
+        {
+            var isVirtual = IsVirtualFile(uri);
+            if (isVirtual)
+            {
+                Debug.WriteLine($"Content URI was virtual: '{uri}'");
+                return GetVirtualFileStream(uri, out extension);
+            }
+
+            extension = GetFileExtension(uri);
+            return Platform.ContentResolver.OpenInputStream(uri);
+        }
+
+        static bool IsVirtualFile(AndroidUri uri)
+        {
+            if (!DocumentsContract.IsDocumentUri(Platform.AppContext, uri))
+                return false;
+
+            var value = GetColumnValue(uri, DocumentsContract.Document.ColumnFlags);
+            if (!string.IsNullOrEmpty(value) && int.TryParse(value, out var flagsInt))
+            {
+                var flags = (DocumentContractFlags)flagsInt;
+                return flags.HasFlag(DocumentContractFlags.VirtualDocument);
+            }
+
+            return false;
+        }
+
+        static Stream GetVirtualFileStream(AndroidUri uri, out string extension)
+        {
+            var mimeTypes = Platform.ContentResolver.GetStreamTypes(uri, FileSystem.MimeTypes.All);
+            if (mimeTypes?.Length >= 1)
+            {
+                var mimeType = mimeTypes[0];
+
+                var stream = Platform.ContentResolver
+                    .OpenTypedAssetFileDescriptor(uri, mimeType, null)
+                    .CreateInputStream();
+
+                extension = MimeTypeMap.Singleton.GetExtensionFromMimeType(mimeType);
+
+                return stream;
+            }
+
+            extension = null;
+            return null;
+        }
+
+        static string GetColumnValue(AndroidUri contentUri, string column, string selection = null, string[] selectionArgs = null)
+        {
+            try
+            {
+                var value = QueryContentResolverColumn(contentUri, column, selection, selectionArgs);
+                if (!string.IsNullOrEmpty(value))
+                    return value;
+            }
+            catch
+            {
+                // Ignore all exceptions and use null for the error indicator
+            }
+
+            return null;
+        }
+
+        static string GetDataFilePath(AndroidUri contentUri, string selection = null, string[] selectionArgs = null)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            const string column = MediaStore.Files.FileColumns.Data;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // ask the content provider for the data column, which may contain the actual file path
+            var path = GetColumnValue(contentUri, column, selection, selectionArgs);
             if (!string.IsNullOrEmpty(path) && Path.IsPathRooted(path))
                 return path;
 
-            // fallback: use content URI
-            return contentUri.ToString();
+            return null;
         }
 
-        static string GetFileName(global::Android.Net.Uri contentUri)
+        static string GetFileExtension(AndroidUri uri)
         {
-            // resolve file name by querying content provider for display name
-            var filename = QueryContentResolverColumn(contentUri, MediaStore.MediaColumns.DisplayName);
+            var mimeType = Platform.ContentResolver.GetType(uri);
 
-            if (string.IsNullOrWhiteSpace(filename))
-            {
-                filename = Path.GetFileName(WebUtility.UrlDecode(contentUri.ToString()));
-            }
-
-            if (!Path.HasExtension(filename))
-                filename = filename.TrimEnd('.') + '.' + GetFileExtensionFromUri(contentUri);
-
-            return filename;
+            return mimeType != null
+                ? MimeTypeMap.Singleton.GetExtensionFromMimeType(mimeType)
+                : null;
         }
 
-        static string QueryContentResolverColumn(global::Android.Net.Uri contentUri, string columnName)
+        static string QueryContentResolverColumn(AndroidUri contentUri, string columnName, string selection = null, string[] selectionArgs = null)
         {
             string text = null;
 
             var projection = new[] { columnName };
-            using var cursor = Application.Context.ContentResolver.Query(contentUri, projection, null, null, null);
+            using var cursor = Platform.ContentResolver.Query(contentUri, projection, selection, selectionArgs, null);
             if (cursor?.MoveToFirst() == true)
             {
                 var columnIndex = cursor.GetColumnIndex(columnName);
@@ -101,12 +347,17 @@ namespace Xamarin.Essentials
 
             return text;
         }
+    }
 
-        static string GetFileExtensionFromUri(global::Android.Net.Uri uri)
+    public partial class FileBase
+    {
+        internal FileBase(Java.IO.File file)
+            : this(file?.Path)
         {
-            var mimeType = Application.Context.ContentResolver.GetType(uri);
-            return mimeType != null ? global::Android.Webkit.MimeTypeMap.Singleton.GetExtensionFromMimeType(mimeType) : string.Empty;
         }
+
+        internal static string PlatformGetContentType(string extension) =>
+            MimeTypeMap.Singleton.GetMimeTypeFromExtension(extension.TrimStart('.'));
 
         internal void PlatformInit(FileBase file)
         {
@@ -114,22 +365,8 @@ namespace Xamarin.Essentials
 
         internal virtual Task<Stream> PlatformOpenReadAsync()
         {
-            if (contentUri?.Scheme == "content")
-            {
-                var content = Application.Context.ContentResolver.OpenInputStream(contentUri);
-                return Task.FromResult(content);
-            }
-
             var stream = File.OpenRead(FullPath);
             return Task.FromResult<Stream>(stream);
-        }
-    }
-
-    public partial class FileResult
-    {
-        internal FileResult(global::Android.Net.Uri contentUri)
-            : base(contentUri)
-        {
         }
     }
 }

--- a/Xamarin.Essentials/FileSystem/FileSystem.android.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Android.Provider;
 using Android.Webkit;
@@ -52,6 +53,17 @@ namespace Xamarin.Essentials
                 throw new FileNotFoundException(ex.Message, filename, ex);
             }
         }
+
+        // Android does't have the concept for returning Directories (AFICT).
+        // As such, we only return string with no . in them. Not ideal but
+        // should work in most cases as Folders rarely contain dots
+        static string[] PlatformGetAppResourceDirectories(string path)
+            => Platform.AppContext.Assets.List(path).Where(file => !file.Contains(".")).ToArray();
+
+        // This may also return Directories, but we can't restrict the list,
+        // as some files may not have an extention. So user is on their own from here.
+        static string[] PlatformGetAppResourceFiles(string path)
+            => Platform.AppContext.Assets.List(path);
 
         internal static Java.IO.File GetEssentialsTemporaryFile(Java.IO.File root, string fileName)
         {

--- a/Xamarin.Essentials/FileSystem/FileSystem.android.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.android.cs
@@ -58,12 +58,12 @@ namespace Xamarin.Essentials
         // As such, we only return string with no . in them. Not ideal but
         // should work in most cases as Folders rarely contain dots
         static string[] PlatformGetAppResourceDirectories(string path)
-            => Platform.AppContext.Assets.List(path).Where(file => !file.Contains(".")).ToArray();
+            => Platform.AppContext.Assets.List(path).Where(file => !file.Contains(".")).Select(x => Path.Combine(path, x)).ToArray();
 
         // This may also return Directories, but we can't restrict the list,
         // as some files may not have an extention. So user is on their own from here.
         static string[] PlatformGetAppResourceFiles(string path)
-            => Platform.AppContext.Assets.List(path);
+            => Platform.AppContext.Assets.List(path).Select(x => Path.Combine(path, x)).ToArray();
 
         internal static Java.IO.File GetEssentialsTemporaryFile(Java.IO.File root, string fileName)
         {

--- a/Xamarin.Essentials/FileSystem/FileSystem.ios.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.ios.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Essentials
         {
             uiImage = image;
 
-            FullPath = Guid.NewGuid().ToString() + ".png";
+            FullPath = Guid.NewGuid().ToString() + FileSystem.Extensions.Png;
             FileName = FullPath;
         }
 

--- a/Xamarin.Essentials/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
@@ -38,6 +38,22 @@ namespace Xamarin.Essentials
             }
             return dirs[0];
         }
+
+        static string[] PlatformGetAppResourceDirectories(string path)
+        {
+            if (Directory.Exists(path))
+                return Directory.GetDirectories(path);
+            else
+                return null;
+        }
+
+        static string[] PlatformGetAppResourceFiles(string path)
+        {
+            if (Directory.Exists(path))
+                return Directory.GetFiles(path);
+            else
+                return null;
+        }
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.netstandard.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.netstandard.cs
@@ -13,6 +13,12 @@ namespace Xamarin.Essentials
 
         static Task<Stream> PlatformOpenAppPackageFileAsync(string filename)
              => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+        static string[] PlatformGetAppResourceDirectories(string path)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+        static string[] PlatformGetAppResourceFiles(string path)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
@@ -14,11 +14,77 @@ namespace Xamarin.Essentials
 
         public static Task<Stream> OpenAppPackageFileAsync(string filename)
             => PlatformOpenAppPackageFileAsync(filename);
+
+        internal static class MimeTypes
+        {
+            internal const string All = "*/*";
+
+            internal const string ImageAll = "image/*";
+            internal const string ImagePng = "image/png";
+            internal const string ImageJpg = "image/jpeg";
+
+            internal const string VideoAll = "video/*";
+
+            internal const string EmailMessage = "message/rfc822";
+
+            internal const string Pdf = "application/pdf";
+
+            internal const string TextPlain = "text/plain";
+
+            internal const string OctetStream = "application/octet-stream";
+        }
+
+        internal static class Extensions
+        {
+            internal const string Png = ".png";
+            internal const string Jpg = ".jpg";
+            internal const string Jpeg = ".jpeg";
+            internal const string Gif = ".gif";
+            internal const string Bmp = ".bmp";
+
+            internal const string Avi = ".avi";
+            internal const string Flv = ".flv";
+            internal const string Gifv = ".gifv";
+            internal const string Mp4 = ".mp4";
+            internal const string M4v = ".m4v";
+            internal const string Mpg = ".mpg";
+            internal const string Mpeg = ".mpeg";
+            internal const string Mp2 = ".mp2";
+            internal const string Mkv = ".mkv";
+            internal const string Mov = ".mov";
+            internal const string Qt = ".qt";
+            internal const string Wmv = ".wmv";
+
+            internal const string Pdf = ".pdf";
+
+            internal static string[] AllImage =>
+                new[] { Png, Jpg, Jpeg, Gif, Bmp };
+
+            internal static string[] AllJpeg =>
+                new[] { Jpg, Jpeg };
+
+            internal static string[] AllVideo =>
+                new[] { Mp4, Mov, Avi, Wmv, M4v, Mpg, Mpeg, Mp2, Mkv, Flv, Gifv, Qt };
+
+            internal static string Clean(string extension, bool trimLeadingPeriod = false)
+            {
+                if (string.IsNullOrWhiteSpace(extension))
+                    return string.Empty;
+
+                extension = extension.TrimStart('*');
+                extension = extension.TrimStart('.');
+
+                if (!trimLeadingPeriod)
+                    extension = "." + extension;
+
+                return extension;
+            }
+        }
     }
 
     public abstract partial class FileBase
     {
-        internal const string DefaultContentType = "application/octet-stream";
+        internal const string DefaultContentType = FileSystem.MimeTypes.OctetStream;
 
         string contentType;
 
@@ -76,7 +142,8 @@ namespace Xamarin.Essentials
                 if (!string.IsNullOrWhiteSpace(content))
                     return content;
             }
-            return "application/octet-stream";
+
+            return DefaultContentType;
         }
 
         string fileName;

--- a/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
@@ -80,6 +80,12 @@ namespace Xamarin.Essentials
                 return extension;
             }
         }
+
+        public static string[] GetAppResourceDirectories(string path)
+            => PlatformGetAppResourceDirectories(path);
+
+        public static string[] GetAppResourceFiles(string path)
+            => PlatformGetAppResourceFiles(path);
     }
 
     public abstract partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.tizen.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.tizen.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Essentials
 
         static Task<Stream> PlatformOpenAppPackageFileAsync(string filename)
         {
+            Tizen.Log.Info("Xamarin.Essentials", "File" + filename);
             if (string.IsNullOrWhiteSpace(filename))
                 throw new ArgumentNullException(nameof(filename));
 
@@ -25,16 +26,16 @@ namespace Xamarin.Essentials
 
         static string[] PlatformGetAppResourceDirectories(string path)
         {
-            if (Directory.Exists(path))
-                return Directory.GetFiles(path);
+            if (Directory.Exists(Path.Combine(Application.Current.DirectoryInfo.Resource, path)))
+                return Directory.GetDirectories(Path.Combine(Application.Current.DirectoryInfo.Resource, path));
             else
                 return null;
         }
 
         static string[] PlatformGetAppResourceFiles(string path)
         {
-            if (Directory.Exists(path))
-                return Directory.GetFiles(path);
+            if (Directory.Exists(Path.Combine(Application.Current.DirectoryInfo.Resource, path)))
+                return Directory.GetFiles(Path.Combine(Application.Current.DirectoryInfo.Resource, path));
             else
                 return null;
         }

--- a/Xamarin.Essentials/FileSystem/FileSystem.tizen.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.tizen.cs
@@ -22,6 +22,22 @@ namespace Xamarin.Essentials
             Stream fs = File.OpenRead(Path.Combine(Application.Current.DirectoryInfo.Resource, filename));
             return Task.FromResult(fs);
         }
+
+        static string[] PlatformGetAppResourceDirectories(string path)
+        {
+            if (Directory.Exists(path))
+                return Directory.GetFiles(path);
+            else
+                return null;
+        }
+
+        static string[] PlatformGetAppResourceFiles(string path)
+        {
+            if (Directory.Exists(path))
+                return Directory.GetFiles(path);
+            else
+                return null;
+        }
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
@@ -24,6 +24,12 @@ namespace Xamarin.Essentials
 
         internal static string NormalizePath(string path)
             => path.Replace('/', Path.DirectorySeparatorChar);
+
+        static string[] PlatformGetAppResourceDirectories(string path)
+            => Directory.GetDirectories(Path.Combine(Application.Current.InstalledLocation, NormalizePath(path)));
+
+        static string[] PlatformGetAppResourceFiles(string path)
+            => Directory.GetFiles(Path.Combine(Application.Current.InstalledLocation, NormalizePath(path)))
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/Launcher/Launcher.tizen.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.tizen.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Essentials
             var appControl = new AppControl
             {
                 Operation = AppControlOperations.View,
-                Mime = "*/*",
+                Mime = FileSystem.MimeTypes.All,
                 Uri = "file://" + request.File.FullPath,
             };
 

--- a/Xamarin.Essentials/PhoneDialer/PhoneDialer.android.cs
+++ b/Xamarin.Essentials/PhoneDialer/PhoneDialer.android.cs
@@ -16,9 +16,8 @@ namespace Xamarin.Essentials
         {
             get
             {
-                var packageManager = Platform.AppContext.PackageManager;
                 var dialIntent = ResolveDialIntent(intentCheck);
-                return dialIntent.ResolveActivity(packageManager) != null;
+                return Platform.IsIntentSupported(dialIntent);
             }
         }
 

--- a/Xamarin.Essentials/Share/Share.android.cs
+++ b/Xamarin.Essentials/Share/Share.android.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Essentials
             }
 
             var intent = new Intent(Intent.ActionSend);
-            intent.SetType("text/plain");
+            intent.SetType(FileSystem.MimeTypes.TextPlain);
             intent.PutExtra(Intent.ExtraText, string.Join(System.Environment.NewLine, items));
 
             if (!string.IsNullOrWhiteSpace(request.Subject))
@@ -46,7 +46,10 @@ namespace Xamarin.Essentials
             foreach (var file in request.Files)
                 contentUris.Add(Platform.GetShareableFileUri(file));
 
-            intent.SetType(request.Files.Count() > 1 ? "*/*" : request.Files.FirstOrDefault().ContentType);
+            var type = request.Files.Count > 1
+                ? FileSystem.MimeTypes.All
+                : request.Files.FirstOrDefault().ContentType;
+            intent.SetType(type);
 
             intent.SetFlags(ActivityFlags.GrantReadUriPermission);
             intent.PutParcelableArrayListExtra(Intent.ExtraStream, contentUris);

--- a/Xamarin.Essentials/Share/Share.shared.cs
+++ b/Xamarin.Essentials/Share/Share.shared.cs
@@ -116,7 +116,8 @@ namespace Xamarin.Essentials
         {
         }
 
-        public ShareMultipleFilesRequest(IEnumerable<ShareFile> files) => Files = files;
+        public ShareMultipleFilesRequest(IEnumerable<ShareFile> files) =>
+            Files = files.ToList();
 
         public ShareMultipleFilesRequest(IEnumerable<FileBase> files)
             : this(ConvertList(files))
@@ -131,7 +132,7 @@ namespace Xamarin.Essentials
         {
         }
 
-        public IEnumerable<ShareFile> Files { get; set; }
+        public List<ShareFile> Files { get; set; }
 
         public static explicit operator ShareMultipleFilesRequest(ShareFileRequest request)
         {

--- a/Xamarin.Essentials/Sms/Sms.android.cs
+++ b/Xamarin.Essentials/Sms/Sms.android.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Essentials
                 if (!string.IsNullOrWhiteSpace(packageName))
                 {
                     intent = new Intent(Intent.ActionSend);
-                    intent.SetType("text/plain");
+                    intent.SetType(FileSystem.MimeTypes.TextPlain);
                     intent.PutExtra(Intent.ExtraText, body);
                     intent.SetPackage(packageName);
 

--- a/Xamarin.Essentials/Types/FileProvider.android.cs
+++ b/Xamarin.Essentials/Types/FileProvider.android.cs
@@ -4,6 +4,7 @@ using Android.App;
 using Android.Content;
 using Android.OS;
 using AndroidEnvironment = Android.OS.Environment;
+using AndroidUri = Android.Net.Uri;
 #if __ANDROID_29__
 using ContentFileProvider = AndroidX.Core.Content.FileProvider;
 #else
@@ -29,15 +30,6 @@ namespace Xamarin.Essentials
         public static FileProviderLocation TemporaryLocation { get; set; } = FileProviderLocation.PreferExternal;
 
         internal static string Authority => Platform.AppContext.PackageName + ".fileProvider";
-
-        internal static Java.IO.File GetTemporaryDirectory()
-        {
-            var root = GetTemporaryRootDirectory();
-            var dir = new Java.IO.File(root, "2203693cc04e0be7f4f024d5f9499e13");
-            dir.Mkdirs();
-            dir.DeleteOnExit();
-            return dir;
-        }
 
         internal static Java.IO.File GetTemporaryRootDirectory()
         {
@@ -124,6 +116,9 @@ namespace Xamarin.Essentials
 
             return false;
         }
+
+        internal static AndroidUri GetUriForFile(Java.IO.File file) =>
+            FileProvider.GetUriForFile(Platform.AppContext, Authority, file);
     }
 
     public enum FileProviderLocation

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.android.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticator.android.cs
@@ -59,9 +59,7 @@ namespace Xamarin.Essentials
             intent.SetData(global::Android.Net.Uri.Parse(callbackUrl.OriginalString));
 
             // Try to find the activity for the callback intent
-            var c = intent.ResolveActivity(Platform.AppContext.PackageManager);
-
-            if (c == null || c.PackageName != packageName)
+            if (!Platform.IsIntentSupported(intent, packageName))
                 throw new InvalidOperationException($"You must subclass the `{nameof(WebAuthenticatorCallbackActivity)}` and create an IntentFilter for it which matches your `{nameof(callbackUrl)}`.");
 
             // Cancel any previous task that's still pending


### PR DESCRIPTION
### Description of Change ###

Given a Directory name,  respectively return either the sub-directories or files within that directory

### Bugs Fixed ###

- Related to issue https://github.com/xamarin/Essentials/issues/1551

### API Changes ###

Added: 

```csharp
public static partial class FileSystem {
    .
    .
    public string[] FileSystem.GetAppResourceDirectories(string path);
    public string[] FileSystem.GetAppResourceFiles(string path);
}
```

And associated cross-platform code.

### Behavioural Changes ###

None. New functionality.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))

### Sample UI Changes ###
**Android:**
![Screenshot_1606931721](https://user-images.githubusercontent.com/271363/100911786-95207280-34c7-11eb-85db-0aa25348bc6c.png)


**iOS:**
<img width="394" alt="Screenshot 2020-12-02 at 17 51 06" src="https://user-images.githubusercontent.com/271363/100911358-06135a80-34c7-11eb-9ca5-9e35eaabf86a.png">

**Mac:**
<img width="490" alt="Screenshot 2020-12-02 at 17 46 16" src="https://user-images.githubusercontent.com/271363/100910944-7d94ba00-34c6-11eb-99ba-bf0ff7f109d2.png">

**Tizen:**
![Tizen](https://user-images.githubusercontent.com/271363/100910912-753c7f00-34c6-11eb-8afc-080ea9710bce.png)

**Windows.UWP:**
Not tested on here yet.
