### PR TITLE
Switch to xharness for much more stable CI tests

### DIFF
--- a/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
+++ b/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
@@ -9,12 +9,16 @@
     <RootNamespace>DeviceTests.Droid</RootNamespace>
     <AssemblyName>XamarinEssentialsDeviceTestsAndroid</AssemblyName>
     <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <AndroidApplication>True</AndroidApplication>
-    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidUseIntermediateDesignerFile>true</AndroidUseIntermediateDesignerFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -25,8 +29,14 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <AndroidSupportedAbis />
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <BundleAssemblies>false</BundleAssemblies>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -69,7 +79,6 @@
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
     <Compile Include="TestInstrumentation.cs" />
-    <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
+++ b/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.devices" Version="2.5.25" />
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20575.2" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20602.1" />
     <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.1.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
+++ b/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.devices" Version="2.5.25" />
-    <PackageReference Include="UnitTests.HeadlessRunner" Version="2.0.0" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20575.2" />
     <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.1.0.1" />
   </ItemGroup>
   <ItemGroup>
@@ -68,6 +68,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
+    <Compile Include="TestInstrumentation.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/DeviceTests/DeviceTests.Android/MainActivity.cs
+++ b/DeviceTests/DeviceTests.Android/MainActivity.cs
@@ -1,64 +1,32 @@
-﻿using System.Collections.Generic;
-using System.Reflection;
-using System.Threading.Tasks;
+﻿using System.Reflection;
 using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using Android.Runtime;
-using UnitTests.HeadlessRunner;
 using Xunit.Runners.UI;
 
 namespace DeviceTests.Droid
 {
-    [Activity(Name="com.xamarin.essentials.devicetests.MainActivity", Label = "@string/app_name", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    [Activity(
+        Name = "com.xamarin.essentials.devicetests.MainActivity",
+        Label = "@string/app_name",
+        Theme = "@style/MainTheme",
+        MainLauncher = true,
+        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : RunnerActivity
     {
         protected override void OnCreate(Bundle bundle)
         {
             Xamarin.Essentials.Platform.Init(this, bundle);
 
-            var hostIp = Intent.Extras?.GetString("HOST_IP", null);
-            var hostPort = Intent.Extras?.GetInt("HOST_PORT", 63559) ?? 63559;
-
-            if (!string.IsNullOrEmpty(hostIp))
-            {
-                // Run the headless test runner for CI
-                Task.Run(() =>
-                {
-                    return Tests.RunAsync(new TestOptions
-                    {
-                        Assemblies = new List<Assembly> { typeof(Battery_Tests).Assembly },
-                        NetworkLogHost = hostIp,
-                        NetworkLogPort = hostPort,
-                        Filters = Traits.GetCommonTraits(),
-                        Format = TestResultsFormat.XunitV2
-                    });
-                });
-            }
-
             // tests can be inside the main assembly
             AddTestAssembly(Assembly.GetExecutingAssembly());
             AddTestAssembly(typeof(Battery_Tests).Assembly);
             AddExecutionAssembly(typeof(Battery_Tests).Assembly);
 
-            // or in any reference assemblies
-            //   AddTestAssembly(typeof(PortableTests).Assembly);
-            // or in any assembly that you load (since JIT is available)
-
-#if false
-            // you can use the default or set your own custom writer (e.g. save to web site and tweet it ;-)
-            Writer = new TcpTextWriter("10.0.1.2", 16384);
-            // start running the test suites as soon as the application is loaded
-            AutoStart = true;
-            // crash the application (to ensure it's ended) and return to springboard
-            TerminateAfterExecution = true;
-#endif
-
-            // you cannot add more assemblies once calling base
             base.OnCreate(bundle);
         }
 
-        public override void OnRequestPermissionsResult(int requestCode, string[] permissions, [GeneratedEnum] Permission[] grantResults)
+        public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
         {
             Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
 

--- a/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
+++ b/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
@@ -73,7 +73,9 @@ namespace DeviceTests.Droid
             public TestsEntryPoint(string resultsFileName)
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                var root = Android.OS.Environment.ExternalStorageDirectory.Path;
+                var root = Platform.HasApiLevel(30)
+                    ? Android.OS.Environment.ExternalStorageDirectory.AbsolutePath
+                    : Application.Context.GetExternalFilesDir(null)?.AbsolutePath ?? FileSystem.AppDataDirectory;
 #pragma warning restore CS0618 // Type or member is obsolete
 
                 var docsDir = Path.Combine(root, "Documents");

--- a/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
+++ b/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using Android.App;
+using Android.OS;
+using Android.Runtime;
+using Microsoft.DotNet.XHarness.TestRunners.Common;
+using Microsoft.DotNet.XHarness.TestRunners.Xunit;
+using Xamarin.Essentials;
+
+namespace DeviceTests.Droid
+{
+    [Instrumentation(Name = "com.xamarin.essentials.devicetests.TestInstrumentation")]
+    public class TestInstrumentation : Instrumentation
+    {
+        string resultsFileName;
+
+        protected TestInstrumentation()
+        {
+        }
+
+        protected TestInstrumentation(IntPtr handle, JniHandleOwnership transfer)
+            : base(handle, transfer)
+        {
+        }
+
+        public override void OnCreate(Bundle arguments)
+        {
+            base.OnCreate(arguments);
+
+            resultsFileName = arguments.GetString("results-file-name", "TestResults.xml");
+
+            Start();
+        }
+
+        public override async void OnStart()
+        {
+            base.OnStart();
+
+            var bundle = new Bundle();
+
+            var runner = new TestRunner(resultsFileName);
+            runner.TestsCompleted += (sender, results) =>
+            {
+                var message =
+                    $"Tests run: {results.ExecutedTests} " +
+                    $"Passed: {results.PassedTests} " +
+                    $"Inconclusive: {results.InconclusiveTests} " +
+                    $"Failed: {results.FailedTests} " +
+                    $"Ignored: {results.SkippedTests}";
+                bundle.PutString("test-execution-summary", message);
+
+                bundle.PutLong("return-code", results.FailedTests == 0 ? 0 : 1);
+            };
+
+            await runner.RunAsync();
+
+            // if (File.Exists(runner.TestsResultsFinalPath))
+            //    bundle.PutString("test-results-path", runner.TestsResultsFinalPath);
+
+            if (bundle.GetLong("return-code", -1) == -1)
+                bundle.PutLong("return-code", 1);
+
+            Finish(Result.Ok, bundle);
+        }
+
+        class TestRunner : AndroidApplicationEntryPoint
+        {
+            readonly string resultsPath;
+
+            public TestRunner(string resultsFileName)
+            {
+                var docsDir = Application.Context.GetExternalFilesDir(null)?.AbsolutePath ?? FileSystem.AppDataDirectory;
+                if (!Directory.Exists(docsDir))
+                    Directory.CreateDirectory(docsDir);
+
+                resultsPath = Path.Combine(docsDir, resultsFileName);
+            }
+
+            public override TextWriter Logger => null;
+
+            public override string TestsResultsFinalPath => resultsPath;
+
+            protected override int? MaxParallelThreads => System.Environment.ProcessorCount;
+
+            protected override IDevice Device { get; } = new TestDevice();
+
+            protected override IEnumerable<TestAssemblyInfo> GetTestAssemblies()
+            {
+                yield return new TestAssemblyInfo(Assembly.GetExecutingAssembly(), Assembly.GetExecutingAssembly().Location);
+                yield return new TestAssemblyInfo(typeof(Battery_Tests).Assembly, typeof(Battery_Tests).Assembly.Location);
+            }
+
+            protected override void TerminateWithSuccess()
+            {
+            }
+        }
+
+        class TestDevice : IDevice
+        {
+            public string BundleIdentifier => AppInfo.PackageName;
+
+            public string UniqueIdentifier => Guid.NewGuid().ToString("N");
+
+            public string Name => DeviceInfo.Name;
+
+            public string Model => DeviceInfo.Model;
+
+            public string SystemName => DeviceInfo.Platform.ToString();
+
+            public string SystemVersion => DeviceInfo.VersionString;
+
+            public string Locale => CultureInfo.CurrentCulture.Name;
+        }
+    }
+}

--- a/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
+++ b/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
@@ -109,7 +109,11 @@ namespace DeviceTests.Droid
             protected override TestRunner GetTestRunner(LogWriter logWriter)
             {
                 var testRunner = base.GetTestRunner(logWriter);
-                testRunner.SkipCategories(Traits.GetSkipTraits());
+                var additional = new List<string>
+                {
+                    $"{Traits.FileProvider}={Traits.FeatureSupport.ToExclude(Platform.HasApiLevel(24))}",
+                };
+                testRunner.SkipCategories(Traits.GetSkipTraits(additional));
                 return testRunner;
             }
         }

--- a/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
+++ b/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
@@ -57,8 +57,8 @@ namespace DeviceTests.Droid
 
             await entryPoint.RunAsync();
 
-            // if (File.Exists(entryPoint.TestsResultsFinalPath))
-            //    bundle.PutString("test-results-path", entryPoint.TestsResultsFinalPath);
+            if (File.Exists(entryPoint.TestsResultsFinalPath))
+                bundle.PutString("test-results-path", entryPoint.TestsResultsFinalPath);
 
             if (bundle.GetLong("return-code", -1) == -1)
                 bundle.PutLong("return-code", 1);
@@ -76,8 +76,10 @@ namespace DeviceTests.Droid
                 if (!Directory.Exists(docsDir))
                     Directory.CreateDirectory(docsDir);
 
-                resultsPath = Path.Combine(docsDir, resultsFileName);
+                resultsPath = Path.Combine(docsDir, "Documents", resultsFileName);
             }
+
+            protected override bool LogExcludedTests => true;
 
             public override TextWriter Logger => null;
 
@@ -100,20 +102,7 @@ namespace DeviceTests.Droid
             protected override TestRunner GetTestRunner(LogWriter logWriter)
             {
                 var testRunner = base.GetTestRunner(logWriter);
-
-                var traits = new[]
-                {
-                    $"{Traits.DeviceType}={Traits.DeviceTypes.ToExclude}",
-                    $"{Traits.Hardware.Accelerometer}={Traits.FeatureSupport.ToExclude(HardwareSupport.HasAccelerometer)}",
-                    $"{Traits.Hardware.Compass}={Traits.FeatureSupport.ToExclude(HardwareSupport.HasCompass)}",
-                    $"{Traits.Hardware.Gyroscope}={Traits.FeatureSupport.ToExclude(HardwareSupport.HasGyroscope)}",
-                    $"{Traits.Hardware.Magnetometer}={Traits.FeatureSupport.ToExclude(HardwareSupport.HasMagnetometer)}",
-                    $"{Traits.Hardware.Battery}={Traits.FeatureSupport.ToExclude(HardwareSupport.HasBattery)}",
-                    $"{Traits.Hardware.Flash}={Traits.FeatureSupport.ToExclude(HardwareSupport.HasFlash)}",
-                };
-
-                testRunner.SkipCategories(traits);
-
+                testRunner.SkipCategories(Traits.GetSkipTraits());
                 return testRunner;
             }
         }

--- a/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
+++ b/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
@@ -73,10 +73,12 @@ namespace DeviceTests.Droid
             public TestsEntryPoint(string resultsFileName)
             {
                 var docsDir = Application.Context.GetExternalFilesDir(null)?.AbsolutePath ?? FileSystem.AppDataDirectory;
+                docsDir = Path.Combine(docsDir, "Documents");
+
                 if (!Directory.Exists(docsDir))
                     Directory.CreateDirectory(docsDir);
 
-                resultsPath = Path.Combine(docsDir, "Documents", resultsFileName);
+                resultsPath = Path.Combine(docsDir, resultsFileName);
             }
 
             protected override bool LogExcludedTests => true;

--- a/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
+++ b/DeviceTests/DeviceTests.Android/TestInstrumentation.cs
@@ -72,8 +72,11 @@ namespace DeviceTests.Droid
 
             public TestsEntryPoint(string resultsFileName)
             {
-                var docsDir = Application.Context.GetExternalFilesDir(null)?.AbsolutePath ?? FileSystem.AppDataDirectory;
-                docsDir = Path.Combine(docsDir, "Documents");
+#pragma warning disable CS0618 // Type or member is obsolete
+                var root = Android.OS.Environment.ExternalStorageDirectory.Path;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                var docsDir = Path.Combine(root, "Documents");
 
                 if (!Directory.Exists(docsDir))
                     Directory.CreateDirectory(docsDir);

--- a/DeviceTests/DeviceTests.Android/Tests/FileProvider_Tests.cs
+++ b/DeviceTests/DeviceTests.Android/Tests/FileProvider_Tests.cs
@@ -39,6 +39,7 @@ namespace DeviceTests.Shared
         [InlineData(true, FileProviderLocation.PreferExternal)]
         [InlineData(false, FileProviderLocation.Internal)]
         [InlineData(false, FileProviderLocation.PreferExternal)]
+        [Trait(Traits.FileProvider, Traits.FeatureSupport.Supported)]
         public void Get_Shareable_Uri(bool failAccess, FileProviderLocation location)
         {
             // Always fail to simulate unmounted media
@@ -84,6 +85,7 @@ namespace DeviceTests.Shared
         }
 
         [Fact]
+        [Trait(Traits.FileProvider, Traits.FeatureSupport.Supported)]
         public void No_Media_Fails_Get_External_Cache_Shareable_Uri()
         {
             // Always fail to simulate unmounted media
@@ -107,6 +109,7 @@ namespace DeviceTests.Shared
         }
 
         [Fact]
+        [Trait(Traits.FileProvider, Traits.FeatureSupport.Supported)]
         public void Get_External_Cache_Shareable_Uri()
         {
             // Save a local cache data directory file
@@ -138,6 +141,7 @@ namespace DeviceTests.Shared
         [InlineData(FileProviderLocation.External)]
         [InlineData(FileProviderLocation.Internal)]
         [InlineData(FileProviderLocation.PreferExternal)]
+        [Trait(Traits.FileProvider, Traits.FeatureSupport.Supported)]
         public void Get_Existing_Internal_Cache_Shareable_Uri(FileProviderLocation location)
         {
             // Save a local cache directory file
@@ -160,6 +164,7 @@ namespace DeviceTests.Shared
         [InlineData(FileProviderLocation.External)]
         [InlineData(FileProviderLocation.Internal)]
         [InlineData(FileProviderLocation.PreferExternal)]
+        [Trait(Traits.FileProvider, Traits.FeatureSupport.Supported)]
         public void Get_Existing_External_Cache_Shareable_Uri(FileProviderLocation location)
         {
             // Save an external cache directory file
@@ -182,14 +187,10 @@ namespace DeviceTests.Shared
         [InlineData(FileProviderLocation.External)]
         [InlineData(FileProviderLocation.Internal)]
         [InlineData(FileProviderLocation.PreferExternal)]
+        [Trait(Traits.FileProvider, Traits.FeatureSupport.Supported)]
         public void Get_Existing_External_Shareable_Uri(FileProviderLocation location)
         {
             // Save an external directory file
-
-            #if !__ANDROID_29__
-            var externalRoot = AndroidEnvironment.ExternalStorageDirectory.AbsolutePath;
-            #endif
-
             var root = Platform.AppContext.GetExternalFilesDir(null).AbsolutePath;
             var file = CreateFile(root);
 
@@ -204,12 +205,17 @@ namespace DeviceTests.Shared
             Assert.Equal("content", shareableUri.Scheme);
             Assert.Equal("com.xamarin.essentials.devicetests.fileProvider", shareableUri.Authority);
 
-            #if !__ANDROID_29__
-            // replace the real root with the providers "root"
-            var segements = Path.Combine(root.Replace(externalRoot, "external_files"), Path.GetFileName(file));
+            if (Platform.HasApiLevel(29))
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                var externalRoot = AndroidEnvironment.ExternalStorageDirectory.AbsolutePath;
+#pragma warning restore CS0618 // Type or member is obsolete
 
-            Assert.Equal(segements.Split(Path.DirectorySeparatorChar), shareableUri.PathSegments);
-            #endif
+                // replace the real root with the providers "root"
+                var segements = Path.Combine(root.Replace(externalRoot, "external_files"), Path.GetFileName(file));
+
+                Assert.Equal(segements.Split(Path.DirectorySeparatorChar), shareableUri.PathSegments);
+            }
         }
 
         static string CreateFile(string root, string name = "the-file.txt")

--- a/DeviceTests/DeviceTests.Shared/AppActions_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/AppActions_Tests.cs
@@ -13,18 +13,15 @@ namespace DeviceTests
         {
             var expectSupported = false;
 
-#if __ANDROID_25__
-            expectSupported = true;
+#if __ANDROID__
+            expectSupported = Platform.SdkInt >= 25;
+#elif __IOS__
+            expectSupported = Platform.HasOSVersion(9, 0);
 #endif
 
-#if __IOS__
-            if (Platform.HasOSVersion(9, 0))
-                expectSupported = true;
-#endif
             Assert.Equal(expectSupported, AppActions.IsSupported);
         }
 
-#if __ANDROID_25__ || __IOS__
         [Fact]
         public async Task GetSetItems()
         {
@@ -43,6 +40,5 @@ namespace DeviceTests
 
             Assert.Contains(get, a => a.Id == "TEST1");
         }
-#endif
     }
 }

--- a/DeviceTests/DeviceTests.Shared/Clipboard_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Clipboard_Tests.cs
@@ -9,6 +9,7 @@ namespace DeviceTests
         [Theory]
         [InlineData("text")]
         [InlineData("some really long test text")]
+        [Trait(Traits.UI, Traits.FeatureSupport.Supported)]
         public Task Set_Clipboard_Values(string text)
         {
             return Utils.OnMainThread(async () =>
@@ -21,6 +22,7 @@ namespace DeviceTests
         [Theory]
         [InlineData("text")]
         [InlineData("some really long test text")]
+        [Trait(Traits.UI, Traits.FeatureSupport.Supported)]
         public Task Get_Clipboard_Values(string text)
         {
             return Utils.OnMainThread(async () =>

--- a/DeviceTests/DeviceTests.Shared/DeviceInfo_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/DeviceInfo_Tests.cs
@@ -115,6 +115,7 @@ namespace DeviceTests
         }
 
         [Fact]
+        [Trait(Traits.UI, Traits.FeatureSupport.Supported)]
         public Task ScreenLock_Locks()
         {
             return Utils.OnMainThread(() =>
@@ -130,6 +131,7 @@ namespace DeviceTests
         }
 
         [Fact]
+        [Trait(Traits.UI, Traits.FeatureSupport.Supported)]
         public Task ScreenLock_Unlocks_Without_Locking()
         {
             return Utils.OnMainThread(() =>
@@ -142,6 +144,7 @@ namespace DeviceTests
         }
 
         [Fact]
+        [Trait(Traits.UI, Traits.FeatureSupport.Supported)]
         public Task ScreenLock_Locks_Only_Once()
         {
             return Utils.OnMainThread(() =>

--- a/DeviceTests/DeviceTests.Shared/DeviceInfo_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/DeviceInfo_Tests.cs
@@ -39,7 +39,9 @@ namespace DeviceTests
 
             if (DeviceInfo.DeviceType == DeviceType.Virtual)
             {
-                var isEmulator = DeviceInfo.Model.Contains("google_sdk") ||
+                var isEmulator =
+                    DeviceInfo.Model.Contains("sdk_gphone_x86") ||
+                    DeviceInfo.Model.Contains("google_sdk") ||
                     DeviceInfo.Model.Contains("Emulator") ||
                     DeviceInfo.Model.Contains("Android SDK built for x86");
 

--- a/DeviceTests/DeviceTests.Shared/Flashlight_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Flashlight_Tests.cs
@@ -16,17 +16,21 @@ namespace DeviceTests
         [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
 #endif
         [Trait(Traits.Hardware.Flash, Traits.FeatureSupport.Supported)]
-        public async Task Turn_On_Off(bool oldCameraApi)
+        public Task Turn_On_Off(bool oldCameraApi)
         {
             // TODO: the test runner app (UI version) should do this, until then...
             if (!HardwareSupport.HasFlash)
-                return;
+                return Task.CompletedTask;
 
 #if __ANDROID__
             Flashlight.AlwaysUseCameraApi = oldCameraApi;
 #endif
-            await Flashlight.TurnOnAsync();
-            await Flashlight.TurnOffAsync();
+
+            return Utils.OnMainThread(async () =>
+            {
+                await Flashlight.TurnOnAsync();
+                await Flashlight.TurnOffAsync();
+            });
         }
     }
 }

--- a/DeviceTests/DeviceTests.Shared/Geocoding_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Geocoding_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Xamarin.Essentials;
 using Xunit;
@@ -25,7 +26,7 @@ namespace DeviceTests
                 Assert.NotNull(placemarks);
                 Assert.True(placemarks.Any());
             }
-            catch (System.Exception ex) when (ex.Message.ToLower().Contains("grpc"))
+            catch (System.Exception ex) when (IsEmulatorFailure(ex))
             {
             }
         }
@@ -41,7 +42,7 @@ namespace DeviceTests
                 Assert.NotNull(placemarks);
                 Assert.True(placemarks.Any());
             }
-            catch (System.Exception ex) when (ex.Message.ToLower().Contains("grpc"))
+            catch (System.Exception ex) when (IsEmulatorFailure(ex))
             {
             }
         }
@@ -57,9 +58,12 @@ namespace DeviceTests
                 Assert.NotNull(locations);
                 Assert.True(locations.Any());
             }
-            catch (System.Exception ex) when (ex.Message.ToLower().Contains("grpc"))
+            catch (System.Exception ex) when (IsEmulatorFailure(ex))
             {
             }
         }
+
+        static bool IsEmulatorFailure(Exception ex) =>
+            ex.Message.ToLower().Contains("grpc") || ex.Message.ToLower().Contains("service not available");
     }
 }

--- a/DeviceTests/DeviceTests.Shared/Permissions_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Permissions_Tests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xamarin.Essentials;
 using Xunit;
 
@@ -66,11 +63,9 @@ namespace DeviceTests
 
             Assert.Equal(expectedStatus, status);
         }
-    }
 
-    public class A_Permissions_Tests
-    {
         [Fact]
+        [Trait(Traits.UI, Traits.FeatureSupport.Supported)]
         public async Task Request_NotMainThread()
         {
             await Task.Run(async () =>

--- a/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/SecureStorage_Tests.cs
@@ -62,6 +62,10 @@ namespace DeviceTests
         [InlineData("test.txt", "data")]
         public async Task Fix_Corrupt_Key(string key, string data)
         {
+            // this operation is only available on API level 23+ devices
+            if (!Platform.HasApiLevel(23))
+                return;
+
             // set a valid key
             SecureStorage.AlwaysUseAsymmetricKeyStorage = true;
             await SecureStorage.SetAsync(key, data);

--- a/DeviceTests/DeviceTests.Shared/Traits.cs
+++ b/DeviceTests/DeviceTests.Shared/Traits.cs
@@ -70,7 +70,7 @@ namespace DeviceTests
             return filters;
         }
 
-        internal static IEnumerable<string> GetSkipTraits(IEnumerable<string> additionalFilters)
+        internal static IEnumerable<string> GetSkipTraits(IEnumerable<string> additionalFilters = null)
         {
             yield return $"{DeviceType}={DeviceTypes.ToExclude}";
             yield return $"{InteractionType}={InteractionTypes.ToExclude}";

--- a/DeviceTests/DeviceTests.Shared/Traits.cs
+++ b/DeviceTests/DeviceTests.Shared/Traits.cs
@@ -11,6 +11,7 @@ namespace DeviceTests
         public const string DeviceType = "DeviceType";
         public const string InteractionType = "InteractionType";
         public const string UI = "UI";
+        public const string FileProvider = "FileProvider";
 
         internal static class Hardware
         {
@@ -69,7 +70,7 @@ namespace DeviceTests
             return filters;
         }
 
-        internal static IEnumerable<string> GetSkipTraits()
+        internal static IEnumerable<string> GetSkipTraits(IEnumerable<string> additionalFilters)
         {
             yield return $"{DeviceType}={DeviceTypes.ToExclude}";
             yield return $"{InteractionType}={InteractionTypes.ToExclude}";
@@ -80,6 +81,14 @@ namespace DeviceTests
             yield return $"{Hardware.Magnetometer}={FeatureSupport.ToExclude(HardwareSupport.HasMagnetometer)}";
             yield return $"{Hardware.Battery}={FeatureSupport.ToExclude(HardwareSupport.HasBattery)}";
             yield return $"{Hardware.Flash}={FeatureSupport.ToExclude(HardwareSupport.HasFlash)}";
+
+            if (additionalFilters != null)
+            {
+                foreach (var filter in additionalFilters)
+                {
+                    yield return filter;
+                }
+            }
         }
     }
 }

--- a/DeviceTests/DeviceTests.Shared/Traits.cs
+++ b/DeviceTests/DeviceTests.Shared/Traits.cs
@@ -10,6 +10,7 @@ namespace DeviceTests
     {
         public const string DeviceType = "DeviceType";
         public const string InteractionType = "InteractionType";
+        public const string UI = "UI";
 
         internal static class Hardware
         {
@@ -44,8 +45,8 @@ namespace DeviceTests
             public const string Supported = "Supported";
             public const string NotSupported = "NotSupported";
 
-            internal static string ToExclude(bool hardware) =>
-                hardware ? NotSupported : Supported;
+            internal static string ToExclude(bool hasFeature) =>
+                hasFeature ? NotSupported : Supported;
         }
 
         internal static List<XUnitFilter> GetCommonTraits(params XUnitFilter[] additionalFilters)
@@ -66,6 +67,19 @@ namespace DeviceTests
                 filters.AddRange(additionalFilters);
 
             return filters;
+        }
+
+        internal static IEnumerable<string> GetSkipTraits()
+        {
+            yield return $"{DeviceType}={DeviceTypes.ToExclude}";
+            yield return $"{InteractionType}={InteractionTypes.ToExclude}";
+            yield return $"{UI}={FeatureSupport.ToExclude(false)}";
+            yield return $"{Hardware.Accelerometer}={FeatureSupport.ToExclude(HardwareSupport.HasAccelerometer)}";
+            yield return $"{Hardware.Compass}={FeatureSupport.ToExclude(HardwareSupport.HasCompass)}";
+            yield return $"{Hardware.Gyroscope}={FeatureSupport.ToExclude(HardwareSupport.HasGyroscope)}";
+            yield return $"{Hardware.Magnetometer}={FeatureSupport.ToExclude(HardwareSupport.HasMagnetometer)}";
+            yield return $"{Hardware.Battery}={FeatureSupport.ToExclude(HardwareSupport.HasBattery)}";
+            yield return $"{Hardware.Flash}={FeatureSupport.ToExclude(HardwareSupport.HasFlash)}";
         }
     }
 }

--- a/DeviceTests/DeviceTests.iOS/AppDelegate.cs
+++ b/DeviceTests/DeviceTests.iOS/AppDelegate.cs
@@ -1,9 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Reflection;
-using System.Threading.Tasks;
+﻿using System.Reflection;
 using Foundation;
 using UIKit;
-using UnitTests.HeadlessRunner;
 
 namespace DeviceTests.iOS
 {
@@ -12,28 +9,6 @@ namespace DeviceTests.iOS
     {
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
-            // Invoke the headless test runner if a config was specified
-            var testCfg = System.IO.File.ReadAllText("tests.cfg")?.Split(':');
-            if (testCfg != null && testCfg.Length > 1)
-            {
-                var ip = testCfg[0];
-                if (int.TryParse(testCfg[1], out var port))
-                {
-                    // Run the headless test runner for CI
-                    Task.Run(() =>
-                    {
-                        return Tests.RunAsync(new TestOptions
-                        {
-                            Assemblies = new List<Assembly> { typeof(Battery_Tests).Assembly },
-                            NetworkLogHost = ip,
-                            NetworkLogPort = port,
-                            Filters = Traits.GetCommonTraits(),
-                            Format = TestResultsFormat.XunitV2
-                        });
-                    });
-                }
-            }
-
             // We need this to ensure the execution assembly is part of the app bundle
             AddExecutionAssembly(typeof(Battery_Tests).Assembly);
 
@@ -42,18 +17,6 @@ namespace DeviceTests.iOS
 
             AddTestAssembly(typeof(Battery_Tests).Assembly);
 
-            // otherwise you need to ensure that the test assemblies will
-            // become part of the app bundle
-            //    AddTestAssembly(typeof(PortableTests).Assembly);
-
-#if false
-            // you can use the default or set your own custom writer (e.g. save to web site and tweet it ;-)
-            Writer = new TcpTextWriter("10.0.1.2", 16384);
-            // start running the test suites as soon as the application is loaded
-            AutoStart = true;
-            // crash the application (to ensure it's ended) and return to springboard
-            TerminateAfterExecution = true;
-#endif
             return base.FinishedLaunching(app, options);
         }
     }

--- a/DeviceTests/DeviceTests.iOS/DeviceTests.iOS.csproj
+++ b/DeviceTests/DeviceTests.iOS/DeviceTests.iOS.csproj
@@ -80,7 +80,7 @@
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.devices" Version="2.5.25" />
-    <PackageReference Include="UnitTests.HeadlessRunner" Version="2.0.0" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20602.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
@@ -100,6 +100,7 @@
     <None Include="Entitlements.plist" />
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestApplicationDelegate.cs" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\Icon-60%402x.png" />
@@ -117,7 +118,6 @@
     <BundleResource Include="Resources\Folder\AppBundleFile_Nested.txt" />
     <BundleResource Include="Resources\Icon-60.png" />
     <BundleResource Include="Resources\Icon-76%403x.png" />
-    <BundleResource Include="tests.cfg" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />

--- a/DeviceTests/DeviceTests.iOS/Main.cs
+++ b/DeviceTests/DeviceTests.iOS/Main.cs
@@ -6,7 +6,10 @@ namespace DeviceTests.iOS
     {
         static void Main(string[] args)
         {
-            UIApplication.Main(args, null, nameof(AppDelegate));
+            if (args?.Length > 0) // usually means this is from xharness
+                UIApplication.Main(args, null, nameof(TestApplicationDelegate));
+            else
+                UIApplication.Main(args, null, nameof(AppDelegate));
         }
     }
 }

--- a/DeviceTests/DeviceTests.iOS/TestApplicationDelegate.cs
+++ b/DeviceTests/DeviceTests.iOS/TestApplicationDelegate.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using Foundation;
+using Microsoft.DotNet.XHarness.TestRunners.Common;
+using Microsoft.DotNet.XHarness.TestRunners.Xunit;
+using UIKit;
+using Xamarin.Essentials;
+
+namespace DeviceTests.iOS
+{
+    [Register(nameof(TestApplicationDelegate))]
+    public class TestApplicationDelegate : UIApplicationDelegate
+    {
+        public override UIWindow Window { get; set; }
+
+        public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+        {
+            Window = new UIWindow(UIScreen.MainScreen.Bounds)
+            {
+                RootViewController = new ViewController()
+            };
+            Window.MakeKeyAndVisible();
+
+            return true;
+        }
+
+        class ViewController : UIViewController
+        {
+            public override async void ViewDidLoad()
+            {
+                base.ViewDidLoad();
+
+                var entryPoint = new TestsEntryPoint();
+
+                await entryPoint.RunAsync();
+            }
+        }
+
+        class TestsEntryPoint : iOSApplicationEntryPoint
+        {
+            protected override bool LogExcludedTests => true;
+
+            protected override int? MaxParallelThreads => Environment.ProcessorCount;
+
+            protected override IDevice Device { get; } = new TestDevice();
+
+            protected override IEnumerable<TestAssemblyInfo> GetTestAssemblies()
+            {
+                yield return new TestAssemblyInfo(Assembly.GetExecutingAssembly(), Assembly.GetExecutingAssembly().Location);
+                yield return new TestAssemblyInfo(typeof(Battery_Tests).Assembly, typeof(Battery_Tests).Assembly.Location);
+            }
+
+            protected override void TerminateWithSuccess()
+            {
+                Console.WriteLine("Exiting test run with success");
+
+                var s = new ObjCRuntime.Selector("terminateWithSuccess");
+                UIApplication.SharedApplication.PerformSelector(s, UIApplication.SharedApplication, 0);
+            }
+
+            protected override TestRunner GetTestRunner(LogWriter logWriter)
+            {
+                var testRunner = base.GetTestRunner(logWriter);
+                testRunner.SkipCategories(Traits.GetSkipTraits());
+                return testRunner;
+            }
+        }
+
+        class TestDevice : IDevice
+        {
+            public string BundleIdentifier => AppInfo.PackageName;
+
+            public string UniqueIdentifier => Guid.NewGuid().ToString("N");
+
+            public string Name => DeviceInfo.Name;
+
+            public string Model => DeviceInfo.Model;
+
+            public string SystemName => DeviceInfo.Platform.ToString();
+
+            public string SystemVersion => DeviceInfo.VersionString;
+
+            public string Locale => CultureInfo.CurrentCulture.Name;
+        }
+    }
+}

--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -93,9 +93,6 @@ Task DownloadTcpTextAsync(int port, FilePath filename, Action waitAction = null)
 Task("build-ios")
     .Does(() =>
 {
-    // Setup the test listener config to be built into the app
-    FileWriteText((new FilePath(IOS_PROJ)).GetDirectory().CombineWithFilePath("tests.cfg"), $"{TCP_LISTEN_HOST}:{TCP_LISTEN_PORT}");
-
     MSBuild(IOS_PROJ, c => {
         c.Configuration = "Release";
         c.Restore = true;

--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -158,6 +158,9 @@ Task("test-ios-emu")
     // Close up simulators
     Information("Closing Simulator");
     ShutdownAllAppleSimulators();
+
+    if (FindTextInFiles(IOS_TEST_RESULTS_PATH.FullPath, "result=\"Fail\"").Length > 0)
+        throw new Exception("Some tests failed.");
 });
 
 

--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -184,6 +184,9 @@ Task("test-android-emu")
     .IsDependentOn("build-android")
     .Does(() =>
 {
+    // Clean up after previous runs
+    CleanDirectories(ANDROID_TEST_RESULTS_PATH.FullPath);
+
     var avdSettings = new AndroidAvdManagerToolSettings { SdkRoot = ANDROID_HOME };
     var adbSettings = new AdbToolSettings { SdkRoot = ANDROID_HOME };
     var emuSettings = new AndroidEmulatorToolSettings { SdkRoot = ANDROID_HOME, ArgumentCustomization = args => args.Append("-no-window") };

--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -6,7 +6,7 @@
 var TARGET = Argument("target", "Default");
 
 var IOS_SIM_NAME = Argument("ios-device", EnvironmentVariable("IOS_SIM_NAME") ?? "iPhone 11");
-var IOS_SIM_RUNTIME = Argument("ios-runtime", EnvironmentVariable("IOS_SIM_RUNTIME") ?? "com.apple.CoreSimulator.SimRuntime.iOS-14-0");
+var IOS_SIM_RUNTIME = Argument("ios-runtime", EnvironmentVariable("IOS_SIM_RUNTIME") ?? "com.apple.CoreSimulator.SimRuntime.iOS-14-2");
 var IOS_PROJ = "./DeviceTests.iOS/DeviceTests.iOS.csproj";
 var IOS_BUNDLE_ID = "com.xamarin.essentials.devicetests";
 var IOS_IPA_PATH = "./DeviceTests.iOS/bin/iPhoneSimulator/Release/XamarinEssentialsDeviceTestsiOS.app";
@@ -200,13 +200,6 @@ Task("test-android-emu")
     // Start the emulator
     Information("Starting Emulator: {0}...", ANDROID_AVD);
     var emulatorProcess = AndroidEmulatorStart(ANDROID_AVD, emuSettings);
-
-    var retries = 60 * 10;
-    while (AdbShell("getprop sys.boot_completed", adbSettings).FirstOrDefault() != "1") {
-        System.Threading.Thread.Sleep(1000);
-        if (retries-- <= 0)
-            break;
-    }
 
     // Run the tests
     var resultCode = StartProcess("xharness", "android test " +

--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -207,9 +207,8 @@ Task("test-android-emu")
     var waited = 0;
     while (AdbShell("getprop sys.boot_completed", adbSettings).FirstOrDefault() != "1") {
         System.Threading.Thread.Sleep(1000);
-        if (retries-- > 60 * 10)
+        if (waited++ > 60 * 10)
             break;
-        waited++;
     }
     Information("Waited {0} seconds for the emulator to boot up.", waited);
 

--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -204,6 +204,13 @@ Task("test-android-emu")
     Information("Starting Emulator: {0}...", ANDROID_AVD);
     var emulatorProcess = AndroidEmulatorStart(ANDROID_AVD, emuSettings);
 
+    var retries = 60 * 10;
+    while (AdbShell("getprop sys.boot_completed", adbSettings).FirstOrDefault() != "1") {
+        System.Threading.Thread.Sleep(1000);
+        if (retries-- <= 0)
+            break;
+    }
+
     // Run the tests
     var resultCode = StartProcess("xharness", "android test " +
         $"--app=\"{ANDROID_APK_PATH}\" " +

--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -204,12 +204,14 @@ Task("test-android-emu")
     Information("Starting Emulator: {0}...", ANDROID_AVD);
     var emulatorProcess = AndroidEmulatorStart(ANDROID_AVD, emuSettings);
 
-    var retries = 60 * 10;
+    var waited = 0;
     while (AdbShell("getprop sys.boot_completed", adbSettings).FirstOrDefault() != "1") {
         System.Threading.Thread.Sleep(1000);
-        if (retries-- <= 0)
+        if (retries-- > 60 * 10)
             break;
+        waited++;
     }
+    Information("Waited {0} seconds for the emulator to boot up.", waited);
 
     // Run the tests
     var resultCode = StartProcess("xharness", "android test " +

--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -13,12 +13,12 @@ var IOS_IPA_PATH = "./DeviceTests.iOS/bin/iPhoneSimulator/Release/XamarinEssenti
 var IOS_TEST_RESULTS_PATH = MakeAbsolute((FilePath)"../output/test-results/ios/TestResults.xml");
 
 var ANDROID_PROJ = "./DeviceTests.Android/DeviceTests.Android.csproj";
-var ANDROID_APK_PATH = "./DeviceTests.Android/bin/Release/com.xamarin.essentials.devicetests-Signed.apk";
-var ANDROID_TEST_RESULTS_PATH = MakeAbsolute((FilePath)"../output/test-results/android/TestResults.xml");
-var ANDROID_SCREENSHOT_PATH = MakeAbsolute((DirectoryPath)"../output/test-results/android");
+var ANDROID_APK_PATH = MakeAbsolute((FilePath)"./DeviceTests.Android/bin/Debug/com.xamarin.essentials.devicetests-Signed.apk");
+var ANDROID_INSTRUMENTATION_NAME = "com.xamarin.essentials.devicetests.TestInstrumentation";
+var ANDROID_TEST_RESULTS_PATH = MakeAbsolute((FilePath)"../output/test-results/android");
 var ANDROID_AVD = EnvironmentVariable("ANDROID_AVD") ?? "CABOODLE";
 var ANDROID_PKG_NAME = "com.xamarin.essentials.devicetests";
-var ANDROID_EMU_TARGET = Argument("avd-target", EnvironmentVariable("ANDROID_EMU_TARGET") ?? "system-images;android-29;google_apis_playstore;x86");
+var ANDROID_EMU_TARGET = Argument("avd-target", EnvironmentVariable("ANDROID_EMU_TARGET") ?? "system-images;android-30;google_apis_playstore;x86");
 var ANDROID_EMU_DEVICE = Argument("avd-device", EnvironmentVariable("ANDROID_EMU_DEVICE") ?? "Nexus 5X");
 
 var UWP_PROJ = "./DeviceTests.UWP/DeviceTests.UWP.csproj";
@@ -85,17 +85,6 @@ Task DownloadTcpTextAsync(int port, FilePath filename, Action waitAction = null)
             throw new Exception("Test results listener failed or timed out.");
         }
     });
-}
-
-void AddPlatformToTestResults(FilePath testResultsFile, string platformName)
-{
-    if (FileExists(testResultsFile)) {
-        var txt = FileReadText(testResultsFile);
-        txt = txt.Replace("<test-case name=\"DeviceTests.", $"<test-case name=\"DeviceTests.{platformName}.");
-        txt = txt.Replace("<test name=\"DeviceTests.", $"<test name=\"DeviceTests.{platformName}.");
-        txt = txt.Replace("name=\"Test collection for DeviceTests.", $"name=\"Test collection for DeviceTests.{platformName}.");
-        FileWriteText(testResultsFile, txt);
-    }
 }
 
 
@@ -166,8 +155,6 @@ Task("test-ios-emu")
     Information("Waiting for tests...");
     tcpListenerTask.Wait();
 
-    AddPlatformToTestResults(IOS_TEST_RESULTS_PATH, "iOS");
-
     // Close up simulators
     Information("Closing Simulator");
     ShutdownAllAppleSimulators();
@@ -179,14 +166,13 @@ Task("test-ios-emu")
 Task("build-android")
     .Does(() =>
 {
-    // Build the app in debug mode
-    // needs to be debug so unit tests get discovered
     MSBuild(ANDROID_PROJ, c => {
-        c.Configuration = "Debug";
+        c.Configuration = "Debug"; // needs to be debug so unit tests get discovered
         c.Restore = true;
         c.Properties["ContinuousIntegrationBuild"]  = new List<string> { "false" };
         c.Targets.Clear();
         c.Targets.Add("Rebuild");
+        c.Targets.Add("SignAndroidPackage");
         c.BinaryLogger = new MSBuildBinaryLogSettings {
             Enabled = true,
             FileName = OUTPUT_PATH.CombineWithFilePath("binlogs/device-tests-android-build.binlog").FullPath,
@@ -199,6 +185,8 @@ Task("test-android-emu")
     .Does(() =>
 {
     var avdSettings = new AndroidAvdManagerToolSettings { SdkRoot = ANDROID_HOME };
+    var adbSettings = new AdbToolSettings { SdkRoot = ANDROID_HOME };
+    var emuSettings = new AndroidEmulatorToolSettings { SdkRoot = ANDROID_HOME, ArgumentCustomization = args => args.Append("-no-window") };
 
     // Delete AVD first, if it exists
     Information("Deleting AVD if exists: {0}...", ANDROID_AVD);
@@ -209,87 +197,37 @@ Task("test-android-emu")
     Information("Creating AVD: {0}...", ANDROID_AVD);
     AndroidAvdCreate(ANDROID_AVD, ANDROID_EMU_TARGET, ANDROID_EMU_DEVICE, force: true, settings: avdSettings);
 
+    // Start the emulator
     Information("Starting Emulator: {0}...", ANDROID_AVD);
-    var emuSettings = new AndroidEmulatorToolSettings { SdkRoot = ANDROID_HOME, ArgumentCustomization = args => args.Append("-no-window") };
     var emulatorProcess = AndroidEmulatorStart(ANDROID_AVD, emuSettings);
 
-    var adbSettings = new AdbToolSettings { SdkRoot = ANDROID_HOME };
-
-    // Keep checking adb for an emulator with an AVD name matching the one we just started
-    var emuSerial = string.Empty;
-    for (int i = 0; i < 100; i++) {
-        foreach (var device in AdbDevices(adbSettings).Where(d => d.Serial.StartsWith("emulator-"))) {
-            if (AdbGetAvdName(device.Serial).Equals(ANDROID_AVD, StringComparison.OrdinalIgnoreCase)) {
-                emuSerial = device.Serial;
-                break;
-            }
-        }
-
-        if (!string.IsNullOrEmpty(emuSerial))
+    var retries = 60 * 10;
+    while (AdbShell("getprop sys.boot_completed", adbSettings).FirstOrDefault() != "1") {
+        System.Threading.Thread.Sleep(1000);
+        if (retries-- <= 0)
             break;
-        else
-            System.Threading.Thread.Sleep(1000);
     }
 
-    Information("Matched ADB Serial: {0}", emuSerial);
-    adbSettings = new AdbToolSettings { SdkRoot = ANDROID_HOME, Serial = emuSerial };
-
-    // Wait for the emulator to enter a 'booted' state
-    AdbWaitForEmulatorToBoot(TimeSpan.FromSeconds(100), adbSettings);
-    Information("Emulator finished booting.");
-
-    // Read the logcat
-    AdbLogcat(new AdbLogcatOptions { Clear = true }, settings: adbSettings);
-    AdbLogcat(settings: adbSettings);
-
-    // Try uninstalling the existing package(if installed)
-    try {
-        AdbUninstall(ANDROID_PKG_NAME, false, adbSettings);
-        Information("Uninstalled old: {0}", ANDROID_PKG_NAME);
-    } catch { }
-
-    // Use the Install target to push the app onto emulator
-    MSBuild(ANDROID_PROJ, c => {
-        c.Configuration = "Debug";
-        c.Properties["ContinuousIntegrationBuild"] = new List<string> { "false" };
-        c.Properties["AdbTarget"] = new List<string> { "-s " + emuSerial };
-        c.Targets.Clear();
-        c.Targets.Add("Install");
-        c.BinaryLogger = new MSBuildBinaryLogSettings {
-            Enabled = true,
-            FileName = OUTPUT_PATH.CombineWithFilePath("binlogs/device-tests-android-install.binlog").FullPath,
-        };
-    });
-
-    // Start the TCP Test results listener
-    Information("Started TCP Test Results Listener on port: {0}:{1}", TCP_LISTEN_HOST, TCP_LISTEN_PORT);
-    // var printed = false;
-    var tcpListenerTask = DownloadTcpTextAsync(TCP_LISTEN_PORT, ANDROID_TEST_RESULTS_PATH, () => {
-        // if (!printed) {
-        //     AdbScreenCapture(ANDROID_SCREENSHOT_PATH.CombineWithFilePath($"screenshot.png"), adbSettings);
-        //     AdbLogcat(settings: adbSettings);
-        //     printed = true;
-        // }
-    });
-
-    // Launch the app on the emulator
-    AdbShell($"am start -n {ANDROID_PKG_NAME}/{ANDROID_PKG_NAME}.MainActivity --es HOST_IP {TCP_LISTEN_HOST} --ei HOST_PORT {TCP_LISTEN_PORT}", adbSettings);
-    AdbLogcat(settings: adbSettings);
-
-    // Wait for the test results to come back
-    Information("Waiting for tests...");
-    tcpListenerTask.Wait();
-
-    AddPlatformToTestResults(ANDROID_TEST_RESULTS_PATH, "Android");
+    // Run the tests
+    var resultCode = StartProcess("xharness", "android test " +
+        $"--app=\"{ANDROID_APK_PATH}\" " +
+        $"--package-name=\"{ANDROID_PKG_NAME}\" " +
+        $"--instrumentation=\"{ANDROID_INSTRUMENTATION_NAME}\" " +
+        $"--device-arch=\"x86\" " +
+        $"--output-directory=\"{ANDROID_TEST_RESULTS_PATH}\" " +
+        $"--verbosity=\"Debug\" ");
 
     // Stop / cleanup the emulator
     AdbEmuKill(adbSettings);
 
     System.Threading.Thread.Sleep(5000);
 
-    // Finally kill the process if it's not exited already
+    // Kill the process if it has not already exited
     try { emulatorProcess.Kill(); }
     catch { }
+
+    if (resultCode != 0)
+        throw new Exception("xharness had an error.");
 
     Information("Done Tests");
 });
@@ -306,6 +244,7 @@ Task("build-uwp")
         c.Properties["ContinuousIntegrationBuild"] = new List<string> { "false" };
         c.Properties["AppxBundlePlatforms"] = new List<string> { "x86" };
         c.Properties["AppxBundle"] = new List<string> { "Always" };
+        c.Properties["AppxPackageSigningEnabled"] = new List<string> { "true" };
         c.Targets.Clear();
         c.Targets.Add("Rebuild");
         c.BinaryLogger = new MSBuildBinaryLogSettings {
@@ -330,13 +269,18 @@ Task("test-uwp-emu")
     // Try to uninstall the app if it exists from before
     uninstallPS();
 
+    var certPath = GetFiles("./**/DeviceTests.UWP_TemporaryKey.pfx").First();
+    Information("Installing certificate: {0}", certPath);
+
+    StartProcess("certutil", "-p Microsoft -importpfx \"" + MakeAbsolute(certPath).FullPath + "\"");
+
     // Install the appx
     var dependencies = GetFiles("./**/AppPackages/**/Dependencies/x86/*.appx");
     foreach (var dep in dependencies) {
         Information("Installing Dependency appx: {0}", dep);
         StartProcess("powershell", "Add-AppxPackage -Path \"" + MakeAbsolute(dep).FullPath + "\"");
     }
-    var appxBundlePath = GetFiles("./**/AppPackages/**/*.appxbundle").First();
+    var appxBundlePath = GetFiles("./**/AppPackages/**/*.msixbundle").First();
     Information("Installing appx: {0}", appxBundlePath);
     StartProcess("powershell", "Add-AppxPackage -Path \"" + MakeAbsolute(appxBundlePath).FullPath + "\"");
 
@@ -347,13 +291,13 @@ Task("test-uwp-emu")
     // Launch the app
     Information("Running appx: {0}", appxBundlePath);
     var ip = TCP_LISTEN_HOST.Replace(".", "-");
-    System.Diagnostics.Process.Start($"xamarin-essentials-device-tests://{ip}_{TCP_LISTEN_PORT}");
+    var executeCommand = $"xamarin-essentials-device-tests://{ip}_{TCP_LISTEN_PORT}";
+    Information("Running appx: {0}", executeCommand);
+    StartProcess("explorer", executeCommand);
 
     // Wait for the test results to come back
     Information("Waiting for tests...");
     tcpListenerTask.Wait();
-
-    AddPlatformToTestResults(UWP_TEST_RESULTS_PATH, "UWP");
 
     // Uninstall the app(this will terminate it too)
     uninstallPS();

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ stages:
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
           cakeTarget: test-ios-emu
-          cakeExtraArgs: --ios-device="`"iPhone 11`"" --ios-runtime="`"com.apple.CoreSimulator.SimRuntime.iOS-14-0`""
+          cakeExtraArgs: --ios-device="`"iPhone 11`"" --ios-runtime="`"com.apple.CoreSimulator.SimRuntime.iOS-14-2`""
 
       - template: .ci/build.yml@components
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,22 +135,6 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          name: devicetests_android_api_23_google
-          runChecks: false
-          displayName: Android API 23
-          publishOutputSuffix: '-android23'
-          windowsImage: ''
-          areaPath: $(AREA_PATH)
-          verbosity: diagnostic
-          cakeFile: DeviceTests/build.cake
-          cakeTarget: test-android-emu
-          cakeExtraArgs: --avd-target="`"system-images;android-23;google_apis_playstore;x86`""
-          preBuildSteps:
-            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-23;google_apis_playstore;x86\""
-              displayName: Install the Android emulators
-
-      - template: .ci/build.yml@components
-        parameters:
           name: devicetests_android_api_24
           runChecks: false
           displayName: Android API 24

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,7 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          name: devicetests_android_api_23
+          name: devicetests_android_api_23_google
           runChecks: false
           displayName: Android API 23
           publishOutputSuffix: '-android23'
@@ -199,7 +199,7 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          name: devicetests_android_api_29
+          name: devicetests_android_api_29_google
           runChecks: false
           displayName: Android API 29
           publishOutputSuffix: '-android29'
@@ -231,7 +231,7 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          name: devicetests_android_api_30
+          name: devicetests_android_api_30_google
           runChecks: false
           displayName: Android API 30
           publishOutputSuffix: '-android30'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,13 @@ variables:
   NUGET_VERSION: $[format('{0}-{1}.{2}', variables['BASE_VERSION'], variables['PREVIEW_LABEL'], variables['BUILD_NUMBER'])]
   GIT_SHA: $(Build.SourceVersion)
   GIT_BRANCH_NAME: $(Build.SourceBranchName)
+  AREA_PATH: 'DevDiv\Xamarin SDK\Build and Tools'
+  ANDROID_API_LEVELS:
+    - 21
+    - 23
+    - 26
+    - 29
+    - 30
 
 resources:
   repositories:
@@ -92,59 +99,27 @@ stages:
           name: devicetests_ios
           runChecks: false
           displayName: iOS
+          publishOutputSuffix: '-ios'
           windowsImage: ''
-          areaPath: 'DevDiv\Xamarin SDK\Build and Tools'
+          areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
           cakeTarget: test-ios-emu
+          cakeExtraArgs: --ios-device="`"iPhone 11`"" --ios-runtime="`"com.apple.CoreSimulator.SimRuntime.iOS-14-0`""
 
-      - template: .ci/build.yml@components
-        parameters:
-          name: devicetests_android_api_23
-          runChecks: false
-          displayName: Android API 23
-          windowsImage: ''
-          macosImage: 'macos-10.14'
-          xcode: '11.3.1'
-          areaPath: 'DevDiv\Xamarin SDK\Build and Tools'
-          verbosity: diagnostic
-          cakeFile: DeviceTests/build.cake
-          cakeTarget: test-android-emu
-          cakeExtraArgs: --avd-target="`"system-images;android-23;google_apis;x86`""
-          preBuildSteps:
-            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-23;google_apis;x86\""
-              displayName: Install the Android emulators
-
-      - template: .ci/build.yml@components
-        parameters:
-          name: devicetests_android_api_26
-          runChecks: false
-          displayName: Android API 26
-          windowsImage: ''
-          macosImage: 'macos-10.14'
-          xcode: '11.3.1'
-          areaPath: 'DevDiv\Xamarin SDK\Build and Tools'
-          verbosity: diagnostic
-          cakeFile: DeviceTests/build.cake
-          cakeTarget: test-android-emu
-          cakeExtraArgs: --avd-target="`"system-images;android-26;google_apis;x86`""
-          preBuildSteps:
-            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-26;google_apis;x86\""
-              displayName: Install the Android emulators
-
-      - template: .ci/build.yml@components
-        parameters:
-          name: devicetests_android_api_29
-          runChecks: false
-          displayName: Android API 29
-          windowsImage: ''
-          macosImage: 'macos-10.14'
-          xcode: '11.3.1'
-          areaPath: 'DevDiv\Xamarin SDK\Build and Tools'
-          verbosity: diagnostic
-          cakeFile: DeviceTests/build.cake
-          cakeTarget: test-android-emu
-          cakeExtraArgs: --avd-target="`"system-images;android-29;google_apis_playstore;x86`""
-          preBuildSteps:
-            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-29;google_apis_playstore;x86\""
-              displayName: Install the Android emulators
+      - ${{ each level in variables['ANDROID_API_LEVELS'] }}:
+        - template: .ci/build.yml@components
+          parameters:
+            name: devicetests_android_api_$(level)
+            runChecks: false
+            displayName: Android API $(level)
+            publishOutputSuffix: '-android$(level)'
+            windowsImage: ''
+            areaPath: $(AREA_PATH)
+            verbosity: diagnostic
+            cakeFile: DeviceTests/build.cake
+            cakeTarget: test-android-emu
+            cakeExtraArgs: --avd-target="`"system-images;android-$(level);google_apis;x86`""
+            preBuildSteps:
+              - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-$(level);google_apis;x86\""
+                displayName: Install the Android emulators

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,6 +135,38 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          name: devicetests_android_api_23
+          runChecks: false
+          displayName: Android API 23
+          publishOutputSuffix: '-android23'
+          windowsImage: ''
+          areaPath: $(AREA_PATH)
+          verbosity: diagnostic
+          cakeFile: DeviceTests/build.cake
+          cakeTarget: test-android-emu
+          cakeExtraArgs: --avd-target="`"system-images;android-23;google_apis_playstore;x86`""
+          preBuildSteps:
+            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-23;google_apis_playstore;x86\""
+              displayName: Install the Android emulators
+
+      - template: .ci/build.yml@components
+        parameters:
+          name: devicetests_android_api_24
+          runChecks: false
+          displayName: Android API 24
+          publishOutputSuffix: '-android24'
+          windowsImage: ''
+          areaPath: $(AREA_PATH)
+          verbosity: diagnostic
+          cakeFile: DeviceTests/build.cake
+          cakeTarget: test-android-emu
+          cakeExtraArgs: --avd-target="`"system-images;android-24;google_apis;x86`""
+          preBuildSteps:
+            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-24;google_apis;x86\""
+              displayName: Install the Android emulators
+
+      - template: .ci/build.yml@components
+        parameters:
           name: devicetests_android_api_26
           runChecks: false
           displayName: Android API 26
@@ -167,6 +199,22 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          name: devicetests_android_api_29
+          runChecks: false
+          displayName: Android API 29
+          publishOutputSuffix: '-android29'
+          windowsImage: ''
+          areaPath: $(AREA_PATH)
+          verbosity: diagnostic
+          cakeFile: DeviceTests/build.cake
+          cakeTarget: test-android-emu
+          cakeExtraArgs: --avd-target="`"system-images;android-29;google_apis_playstore;x86`""
+          preBuildSteps:
+            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-29;google_apis_playstore;x86\""
+              displayName: Install the Android emulators
+
+      - template: .ci/build.yml@components
+        parameters:
           name: devicetests_android_api_30
           runChecks: false
           displayName: Android API 30
@@ -179,4 +227,20 @@ stages:
           cakeExtraArgs: --avd-target="`"system-images;android-30;google_apis;x86`""
           preBuildSteps:
             - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-30;google_apis;x86\""
+              displayName: Install the Android emulators
+
+      - template: .ci/build.yml@components
+        parameters:
+          name: devicetests_android_api_30
+          runChecks: false
+          displayName: Android API 30
+          publishOutputSuffix: '-android30'
+          windowsImage: ''
+          areaPath: $(AREA_PATH)
+          verbosity: diagnostic
+          cakeFile: DeviceTests/build.cake
+          cakeTarget: test-android-emu
+          cakeExtraArgs: --avd-target="`"system-images;android-30;google_apis_playstore;x86`""
+          preBuildSteps:
+            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-30;google_apis_playstore;x86\""
               displayName: Install the Android emulators

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,22 +183,6 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          name: devicetests_android_api_29_google
-          runChecks: false
-          displayName: Android API 29
-          publishOutputSuffix: '-android29'
-          windowsImage: ''
-          areaPath: $(AREA_PATH)
-          verbosity: diagnostic
-          cakeFile: DeviceTests/build.cake
-          cakeTarget: test-android-emu
-          cakeExtraArgs: --avd-target="`"system-images;android-29;google_apis_playstore;x86`""
-          preBuildSteps:
-            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-29;google_apis_playstore;x86\""
-              displayName: Install the Android emulators
-
-      - template: .ci/build.yml@components
-        parameters:
           name: devicetests_android_api_30
           runChecks: false
           displayName: Android API 30
@@ -211,20 +195,4 @@ stages:
           cakeExtraArgs: --avd-target="`"system-images;android-30;google_apis;x86`""
           preBuildSteps:
             - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-30;google_apis;x86\""
-              displayName: Install the Android emulators
-
-      - template: .ci/build.yml@components
-        parameters:
-          name: devicetests_android_api_30_google
-          runChecks: false
-          displayName: Android API 30
-          publishOutputSuffix: '-android30'
-          windowsImage: ''
-          areaPath: $(AREA_PATH)
-          verbosity: diagnostic
-          cakeFile: DeviceTests/build.cake
-          cakeTarget: test-android-emu
-          cakeExtraArgs: --avd-target="`"system-images;android-30;google_apis_playstore;x86`""
-          preBuildSteps:
-            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-30;google_apis_playstore;x86\""
               displayName: Install the Android emulators

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,12 +15,7 @@ variables:
   GIT_SHA: $(Build.SourceVersion)
   GIT_BRANCH_NAME: $(Build.SourceBranchName)
   AREA_PATH: 'DevDiv\Xamarin SDK\Build and Tools'
-  ANDROID_API_LEVELS:
-    - 21
-    - 23
-    - 26
-    - 29
-    - 30
+  ANDROID_API_LEVELS: [ 21, 23, 26, 29, 30 ]
 
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,6 @@ variables:
   GIT_SHA: $(Build.SourceVersion)
   GIT_BRANCH_NAME: $(Build.SourceBranchName)
   AREA_PATH: 'DevDiv\Xamarin SDK\Build and Tools'
-  ANDROID_API_LEVELS: [ 21, 23, 26, 29, 30 ]
 
 resources:
   repositories:
@@ -72,7 +71,7 @@ stages:
       - job: devicetests_uwp
         displayName: UWP
         # skip for now
-        condition: and(succeeded(), not(succeeded()))
+        condition: false
         pool:
           vmImage: windows-2019
         steps:
@@ -102,19 +101,82 @@ stages:
           cakeTarget: test-ios-emu
           cakeExtraArgs: --ios-device="`"iPhone 11`"" --ios-runtime="`"com.apple.CoreSimulator.SimRuntime.iOS-14-0`""
 
-      - ${{ each level in variables['ANDROID_API_LEVELS'] }}:
-        - template: .ci/build.yml@components
-          parameters:
-            name: devicetests_android_api_$(level)
-            runChecks: false
-            displayName: Android API $(level)
-            publishOutputSuffix: '-android$(level)'
-            windowsImage: ''
-            areaPath: $(AREA_PATH)
-            verbosity: diagnostic
-            cakeFile: DeviceTests/build.cake
-            cakeTarget: test-android-emu
-            cakeExtraArgs: --avd-target="`"system-images;android-$(level);google_apis;x86`""
-            preBuildSteps:
-              - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-$(level);google_apis;x86\""
-                displayName: Install the Android emulators
+      - template: .ci/build.yml@components
+        parameters:
+          name: devicetests_android_api_21
+          runChecks: false
+          displayName: Android API 21
+          publishOutputSuffix: '-android21'
+          windowsImage: ''
+          areaPath: $(AREA_PATH)
+          verbosity: diagnostic
+          cakeFile: DeviceTests/build.cake
+          cakeTarget: test-android-emu
+          cakeExtraArgs: --avd-target="`"system-images;android-21;google_apis;x86`""
+          preBuildSteps:
+            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-21;google_apis;x86\""
+              displayName: Install the Android emulators
+
+      - template: .ci/build.yml@components
+        parameters:
+          name: devicetests_android_api_23
+          runChecks: false
+          displayName: Android API 23
+          publishOutputSuffix: '-android23'
+          windowsImage: ''
+          areaPath: $(AREA_PATH)
+          verbosity: diagnostic
+          cakeFile: DeviceTests/build.cake
+          cakeTarget: test-android-emu
+          cakeExtraArgs: --avd-target="`"system-images;android-23;google_apis;x86`""
+          preBuildSteps:
+            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-23;google_apis;x86\""
+              displayName: Install the Android emulators
+
+      - template: .ci/build.yml@components
+        parameters:
+          name: devicetests_android_api_26
+          runChecks: false
+          displayName: Android API 26
+          publishOutputSuffix: '-android26'
+          windowsImage: ''
+          areaPath: $(AREA_PATH)
+          verbosity: diagnostic
+          cakeFile: DeviceTests/build.cake
+          cakeTarget: test-android-emu
+          cakeExtraArgs: --avd-target="`"system-images;android-26;google_apis;x86`""
+          preBuildSteps:
+            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-26;google_apis;x86\""
+              displayName: Install the Android emulators
+
+      - template: .ci/build.yml@components
+        parameters:
+          name: devicetests_android_api_29
+          runChecks: false
+          displayName: Android API 29
+          publishOutputSuffix: '-android29'
+          windowsImage: ''
+          areaPath: $(AREA_PATH)
+          verbosity: diagnostic
+          cakeFile: DeviceTests/build.cake
+          cakeTarget: test-android-emu
+          cakeExtraArgs: --avd-target="`"system-images;android-29;google_apis;x86`""
+          preBuildSteps:
+            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-29;google_apis;x86\""
+              displayName: Install the Android emulators
+
+      - template: .ci/build.yml@components
+        parameters:
+          name: devicetests_android_api_30
+          runChecks: false
+          displayName: Android API 30
+          publishOutputSuffix: '-android30'
+          windowsImage: ''
+          areaPath: $(AREA_PATH)
+          verbosity: diagnostic
+          cakeFile: DeviceTests/build.cake
+          cakeTarget: test-android-emu
+          cakeExtraArgs: --avd-target="`"system-images;android-30;google_apis;x86`""
+          preBuildSteps:
+            - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-30;google_apis;x86\""
+              displayName: Install the Android emulators

--- a/nuget.config
+++ b/nuget.config
@@ -10,6 +10,7 @@
 
     <packageSources>
         <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     </packageSources>
 
 </configuration>


### PR DESCRIPTION

### Description of Change ###

* Generate the Android device test builds
* Switch to xharness

### Bugs Fixed ###

- Related to issue #

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
```


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
