### PR TITLE
Launch the maps app when the placemark can't be found

### DIFF
--- a/Xamarin.Essentials/Launcher/Launcher.macos.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.macos.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Essentials
         static Task<bool> PlatformCanOpenAsync(Uri uri) =>
             Task.FromResult(NSWorkspace.SharedWorkspace.UrlForApplication(WebUtils.GetNativeUrl(uri)) != null);
 
-        static Task PlatformOpenAsync(Uri uri) =>
+        internal static Task PlatformOpenAsync(Uri uri) =>
             Task.FromResult(NSWorkspace.SharedWorkspace.OpenUrl(WebUtils.GetNativeUrl(uri)));
 
         static Task<bool> PlatformTryOpenAsync(Uri uri)

--- a/Xamarin.Essentials/Map/Map.android.cs
+++ b/Xamarin.Essentials/Map/Map.android.cs
@@ -42,17 +42,16 @@ namespace Xamarin.Essentials
 
         internal static Task PlatformOpenMapsAsync(Placemark placemark, MapLaunchOptions options)
         {
-            placemark = placemark.Escape();
             var uri = string.Empty;
             if (options.NavigationMode == NavigationMode.None)
             {
-                uri = $"geo:0,0?q={placemark.Thoroughfare} {placemark.Locality} {placemark.AdminArea} {placemark.PostalCode} {placemark.CountryName}";
+                uri = $"geo:0,0?q={placemark.GetEscapedAddress()}";
                 if (!string.IsNullOrWhiteSpace(options.Name))
                     uri += $"({AndroidUri.Encode(options.Name)})";
             }
             else
             {
-                uri = $"google.navigation:q={placemark.Thoroughfare} {placemark.Locality} {placemark.AdminArea} {placemark.PostalCode} {placemark.CountryName}{GetMode(options.NavigationMode)}";
+                uri = $"google.navigation:q={placemark.GetEscapedAddress()}{GetMode(options.NavigationMode)}";
             }
 
             StartIntent(uri);

--- a/Xamarin.Essentials/Map/Map.tizen.cs
+++ b/Xamarin.Essentials/Map/Map.tizen.cs
@@ -33,8 +33,7 @@ namespace Xamarin.Essentials
                 Uri = "geo:",
             };
 
-            placemark = placemark.Escape();
-            appControl.Uri += $"0,0?q={placemark.Thoroughfare} {placemark.Locality} {placemark.AdminArea} {placemark.PostalCode} {placemark.CountryName}";
+            appControl.Uri += $"0,0?q={placemark.GetEscapedAddress()}";
 
             AppControl.SendLaunchRequest(appControl);
 

--- a/Xamarin.Essentials/Map/Map.uwp.cs
+++ b/Xamarin.Essentials/Map/Map.uwp.cs
@@ -38,27 +38,15 @@ namespace Xamarin.Essentials
 
         internal static Task PlatformOpenMapsAsync(Placemark placemark, MapLaunchOptions options)
         {
-            placemark = placemark.Escape();
             var uri = string.Empty;
 
             if (options.NavigationMode == NavigationMode.None)
             {
-                uri = $"bingmaps:?where=" +
-                    $"{placemark.Thoroughfare}" +
-                    $"%20{placemark.Locality}" +
-                    $"%20{placemark.AdminArea}" +
-                    $"%20{placemark.PostalCode}" +
-                    $"%20{placemark.CountryName}";
+                uri = $"bingmaps:?where={placemark.GetEscapedAddress()}";
             }
             else
             {
-                uri = $"bingmaps:?rtp=~adr." +
-                    $"{placemark.Thoroughfare}" +
-                    $"%20{placemark.Locality}" +
-                    $"%20{placemark.AdminArea}" +
-                    $"%20{placemark.PostalCode}" +
-                    $"%20{placemark.CountryName}" +
-                    $"{GetMode(options.NavigationMode)}";
+                uri = $"bingmaps:?rtp=~adr.{placemark.GetEscapedAddress()}{GetMode(options.NavigationMode)}";
             }
 
             return LaunchUri(new Uri(uri));

--- a/Xamarin.Essentials/Types/PlacemarkExtensions.shared.cs
+++ b/Xamarin.Essentials/Types/PlacemarkExtensions.shared.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace Xamarin.Essentials
@@ -12,28 +11,14 @@ namespace Xamarin.Essentials
         public static Task OpenMapsAsync(this Placemark placemark) =>
             Map.OpenAsync(placemark);
 
-        internal static Placemark Escape(this Placemark placemark)
+        internal static string GetEscapedAddress(this Placemark placemark)
         {
             if (placemark == null)
                 throw new ArgumentNullException(nameof(placemark));
-            var escaped = new Placemark();
 
-            if (placemark.Location == null)
-                escaped.Location = new Location();
-            else
-                escaped.Location = new Location(placemark.Location);
+            var address = $"{placemark.Thoroughfare} {placemark.Locality} {placemark.AdminArea} {placemark.PostalCode} {placemark.CountryName}";
 
-            escaped.CountryCode = string.IsNullOrWhiteSpace(placemark.CountryCode) ? string.Empty : WebUtility.UrlEncode(placemark.CountryCode);
-            escaped.CountryName = string.IsNullOrWhiteSpace(placemark.CountryName) ? string.Empty : WebUtility.UrlEncode(placemark.CountryName);
-            escaped.FeatureName = string.IsNullOrWhiteSpace(placemark.FeatureName) ? string.Empty : WebUtility.UrlEncode(placemark.FeatureName);
-            escaped.PostalCode = string.IsNullOrWhiteSpace(placemark.PostalCode) ? string.Empty : WebUtility.UrlEncode(placemark.PostalCode);
-            escaped.Locality = string.IsNullOrWhiteSpace(placemark.Locality) ? string.Empty : WebUtility.UrlEncode(placemark.Locality);
-            escaped.SubLocality = string.IsNullOrWhiteSpace(placemark.SubLocality) ? string.Empty : WebUtility.UrlEncode(placemark.SubLocality);
-            escaped.Thoroughfare = string.IsNullOrWhiteSpace(placemark.Thoroughfare) ? string.Empty : WebUtility.UrlEncode(placemark.Thoroughfare);
-            escaped.SubThoroughfare = string.IsNullOrWhiteSpace(placemark.SubThoroughfare) ? string.Empty : WebUtility.UrlEncode(placemark.SubThoroughfare);
-            escaped.SubAdminArea = string.IsNullOrWhiteSpace(placemark.SubAdminArea) ? string.Empty : WebUtility.UrlEncode(placemark.SubAdminArea);
-            escaped.AdminArea = string.IsNullOrWhiteSpace(placemark.AdminArea) ? string.Empty : WebUtility.UrlEncode(placemark.AdminArea);
-            return escaped;
+            return Uri.EscapeDataString(address);
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

On Apple devices, if the placemark is invalid, then nothing happens. This is inconsistent with all the other platforms.

In this PR, I have launched the maps app according to the Apple guidelines and it seems to work. You will get the app and a message saying that the address could not be found. It will also allow for suggestions and a chance to edit. 

Tested on macOS and iOS. This does not apply to watchOS.

tvOS probably can use this method exclusively to support maps, but that is for another PR.

### Bugs Fixed ###

- Fixes #729

### API Changes ###

None.

### Behavioral Changes ###

On iOS and macOS, invalid addresses will open the maps app to the search page.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
