### PR TITLE
Add API to retrieve directories and file lists, in a cross-platform way.

### DIFF
--- a/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
+++ b/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
@@ -109,6 +109,16 @@
     <AndroidAsset Include="Assets\AppBundleFile.txt" />
     <AndroidAsset Include="Assets\AppBundleFile_NoExtension" />
     <AndroidAsset Include="Assets\Folder\AppBundleFile_Nested.txt" />
+    <AndroidAsset Include="Assets\AppBundleFile.txt">
+      <Link>Assets\Folder\AppBundleFile.txt</Link>
+    </AndroidAsset>
+    <AndroidAsset Include="Assets\Folder\AppBundleFile_Nested.txt">
+      <Link>Assets\Folder\SubFolder\AppBundleFile_Nested.txt</Link>
+    </AndroidAsset>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Assets\Folder\SubFolder\" />
+    <Folder Include="Assets\Folder\" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/DeviceTests/DeviceTests.Shared/FileSystem_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/FileSystem_Tests.cs
@@ -46,5 +46,21 @@ namespace DeviceTests
         {
             await Assert.ThrowsAsync<FileNotFoundException>(() => FileSystem.OpenAppPackageFileAsync("MissingFile.txt"));
         }
+
+        [Theory]
+        [InlineData("Folder")]
+        public void AppResourceDirectories_Is_Valid(string path)
+        {
+            var directories = FileSystem.GetAppResourceDirectories(path);
+            Assert.True(directories != null);
+        }
+
+        [Theory]
+        [InlineData("Folder")]
+        public void AppResourceFiles_Is_Valid(string path)
+        {
+            var files = FileSystem.GetAppResourceFiles(path);
+            Assert.True(files != null);
+        }
     }
 }

--- a/DeviceTests/DeviceTests.UWP/DeviceTests.UWP.csproj
+++ b/DeviceTests/DeviceTests.UWP/DeviceTests.UWP.csproj
@@ -153,9 +153,6 @@
     </AppxManifest>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="AppBundleFile.txt" />
-    <Content Include="Folder\AppBundleFile_Nested.txt" />
-    <Content Include="AppBundleFile_NoExtension" />
     <Content Include="Properties\Default.rd.xml" />
     <Content Include="Assets\LockScreenLogo.scale-100.png" />
     <Content Include="Assets\LockScreenLogo.scale-125.png" />
@@ -188,6 +185,21 @@
     <Content Include="Assets\Wide310x150Logo.scale-150.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
     <Content Include="Assets\Wide310x150Logo.scale-400.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="AppBundleFile.txt" />
+    <Content Include="AppBundleFile_NoExtension" />
+    <Content Include="Folder\AppBundleFile_Nested.txt" />
+    <Content Include="AppBundleFile.txt">
+      <Link>Folder\AppBundleFile.txt</Link>
+    </Content>
+    <Content Include="Folder\AppBundleFile_Nested.txt">
+      <Link>Folder\SubFolder\AppBundleFile_Nested.txt</Link>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Folder\SubFolder\" />
+    <Folder Include="Folder\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="DeviceTests.UWP_TemporaryKey.pfx" />

--- a/DeviceTests/DeviceTests.iOS/DeviceTests.iOS.csproj
+++ b/DeviceTests/DeviceTests.iOS/DeviceTests.iOS.csproj
@@ -112,12 +112,26 @@
     <BundleResource Include="Resources\Icon-Small.png" />
     <BundleResource Include="Resources\Icon-Small%402x.png" />
     <BundleResource Include="Resources\Icon-Small%403x.png" />
-    <BundleResource Include="Resources\AppBundleFile.txt" />
     <BundleResource Include="Resources\AppBundleFile_NoExtension" />
     <BundleResource Include="Resources\Folder\AppBundleFile_Nested.txt" />
     <BundleResource Include="Resources\Icon-60.png" />
     <BundleResource Include="Resources\Icon-76%403x.png" />
     <BundleResource Include="tests.cfg" />
+  </ItemGroup>
+  <ItemGroup>
+    <BundleResource Include="Resources\AppBundleFile.txt" />
+    <BundleResource Include="Resources\AppBundleFile_NoExtension" />
+    <BundleResource Include="Resources\Folder\AppBundleFile_Nested.txt" />
+    <BundleResource Include="Resources\AppBundleFile.txt">
+      <Link>Resources\Folder\AppBundleFile.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\Folder\AppBundleFile_Nested.txt">
+      <Link>Resources\Folder\SubFolder\AppBundleFile_Nested.txt</Link>
+    </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\Folder\SubFolder\" />
+    <Folder Include="Resources\Folder\" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />

--- a/Samples/Samples.Android/Samples.Android.csproj
+++ b/Samples/Samples.Android/Samples.Android.csproj
@@ -122,6 +122,22 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\FileSystemTemplate.txt" />
+    <AndroidAsset Include="Assets\FileSystemTemplate.txt">
+      <Link>Assets\Folder\FileSystemTemplate.txt</Link>
+    </AndroidAsset>
+    <AndroidAsset Include="Assets\FileSystemTemplate.txt">
+      <Link>Assets\Folder\FileSystemTemplate1.txt</Link>
+    </AndroidAsset>
+    <AndroidAsset Include="Assets\FileSystemTemplate.txt">
+      <Link>Assets\Folder\FileSystemTemplate2.txt</Link>
+    </AndroidAsset>
+    <AndroidAsset Include="Assets\FileSystemTemplate.txt">
+      <Link>Assets\Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </AndroidAsset>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Assets\Folder\" />
+    <Folder Include="Assets\Folder\SubFolder\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Samples/Samples.Mac/Samples.Mac.csproj
+++ b/Samples/Samples.Mac/Samples.Mac.csproj
@@ -102,6 +102,22 @@
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\FileSystemTemplate.txt" />
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate1.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate2.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\Folder\" />
+    <Folder Include="Resources\Folder\SubFolder\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/Samples/Samples.Tizen/Samples.Tizen.csproj
+++ b/Samples/Samples.Tizen/Samples.Tizen.csproj
@@ -15,10 +15,28 @@
     <ProjectReference Include="..\..\Xamarin.Essentials\Xamarin.Essentials.csproj" />
     <ProjectReference Include="..\Samples\Samples.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="res\FileSystemTemplate.txt" />
+    <None Include="res\FileSystemTemplate.txt">
+      <Link>res\Folder\FileSystemTemplate.txt</Link>
+    </None>
+    <None Include="res\FileSystemTemplate.txt">
+      <Link>res\Folder\FileSystemTemplate1.txt</Link>
+    </None>
+    <None Include="res\FileSystemTemplate.txt">
+      <Link>res\Folder\FileSystemTemplate2.txt</Link>
+    </None>
+    <None Include="res\FileSystemTemplate.txt">
+      <Link>res\Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="lib\" />
     <Folder Include="res\" />
+    <Folder Include="res\Folder\" />
+    <Folder Include="res\Folder\SubFolder\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Samples.UWP/Samples.UWP.csproj
+++ b/Samples/Samples.UWP/Samples.UWP.csproj
@@ -161,7 +161,6 @@
   <ItemGroup>
     <Content Include="Assets\app_info_action_icon.png" />
     <Content Include="Assets\battery_action_icon.png" />
-    <Content Include="FileSystemTemplate.txt" />
     <Content Include="Properties\Default.rd.xml" />
     <Content Include="Assets\LockScreenLogo.scale-100.png" />
     <Content Include="Assets\LockScreenLogo.scale-125.png" />
@@ -195,6 +194,25 @@
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
     <Content Include="Assets\Wide310x150Logo.scale-400.png" />
     <Content Include="Properties\Default.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="FileSystemTemplate.txt" />
+    <Content Include="FileSystemTemplate.txt">
+      <Link>Folder\FileSystemTemplate.txt</Link>
+    </Content>
+    <Content Include="FileSystemTemplate.txt">
+      <Link>Folder\FileSystemTemplate1.txt</Link>
+    </Content>
+    <Content Include="FileSystemTemplate.txt">
+      <Link>Folder\FileSystemTemplate2.txt</Link>
+    </Content>
+    <Content Include="FileSystemTemplate.txt">
+      <Link>Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\Folder\" />
+    <Folder Include="Resources\Folder\SubFolder\" />
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="WindowsMobile, Version=10.0.18362.0">

--- a/Samples/Samples.UWP/Samples.UWP.csproj
+++ b/Samples/Samples.UWP/Samples.UWP.csproj
@@ -211,8 +211,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Resources\Folder\" />
-    <Folder Include="Resources\Folder\SubFolder\" />
+    <Folder Include="Folder\" />
+    <Folder Include="Folder\SubFolder\" />
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="WindowsMobile, Version=10.0.18362.0">

--- a/Samples/Samples.iOS/Samples.iOS.csproj
+++ b/Samples/Samples.iOS/Samples.iOS.csproj
@@ -104,6 +104,22 @@
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\FileSystemTemplate.txt" />
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate1.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\FileSystemTemplate2.txt</Link>
+    </BundleResource>
+    <BundleResource Include="Resources\FileSystemTemplate.txt">
+      <Link>Resources\Folder\SubFolder\FileSystemTemplate.txt</Link>
+    </BundleResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\Folder\" />
+    <Folder Include="Resources\Folder\SubFolder\" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />

--- a/Samples/Samples/View/FileSystemPage.xaml
+++ b/Samples/Samples/View/FileSystemPage.xaml
@@ -15,6 +15,12 @@
         <Label Text="{Binding CacheDirectory, StringFormat='Cache: {0}'}" />
         <Label Text="{Binding AppDataDirectory, StringFormat='App Data: {0}'}" />
 
+        <Label Text="Resource Directories:" FontAttributes="Bold" Margin="0,6,0,0" />
+        <ListView ItemsSource="{Binding AppResourceDirectories}"/>
+
+        <Label Text="Resource Files:" FontAttributes="Bold" Margin="0,6,0,0" />
+        <ListView ItemsSource="{Binding AppResourceFiles}"/>
+
         <Label Text="Operations:" FontAttributes="Bold" Margin="0,6,0,0" />
         <StackLayout Orientation="Horizontal" Spacing="6">
             <Button Text="Load" Command="{Binding LoadFileCommand}" HorizontalOptions="FillAndExpand" />

--- a/Samples/Samples/ViewModel/FileSystemViewModel.cs
+++ b/Samples/Samples/ViewModel/FileSystemViewModel.cs
@@ -33,6 +33,10 @@ namespace Samples.ViewModel
 
         public string CacheDirectory => FileSystem.CacheDirectory;
 
+        public string[] AppResourceDirectories => FileSystem.GetAppResourceDirectories("Folder");
+
+        public string[] AppResourceFiles => FileSystem.GetAppResourceFiles("Folder");
+
         public string CurrentContents
         {
             get => currentContents;

--- a/Xamarin.Essentials/FileSystem/FileSystem.android.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Android.Provider;
 using Android.Webkit;
@@ -52,6 +53,17 @@ namespace Xamarin.Essentials
                 throw new FileNotFoundException(ex.Message, filename, ex);
             }
         }
+
+        // Android does't have the concept for returning Directories (AFICT).
+        // As such, we only return string with no . in them. Not ideal but
+        // should work in most cases as Folders rarely contain dots
+        static string[] PlatformGetAppResourceDirectories(string path)
+            => Platform.AppContext.Assets.List(path).Where(file => !file.Contains(".")).Select(x => Path.Combine(path, x)).ToArray();
+
+        // This may also return Directories, but we can't restrict the list,
+        // as some files may not have an extention. So user is on their own from here.
+        static string[] PlatformGetAppResourceFiles(string path)
+            => Platform.AppContext.Assets.List(path).Select(x => Path.Combine(path, x)).ToArray();
 
         internal static Java.IO.File GetEssentialsTemporaryFile(Java.IO.File root, string fileName)
         {

--- a/Xamarin.Essentials/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
@@ -38,6 +38,22 @@ namespace Xamarin.Essentials
             }
             return dirs[0];
         }
+
+        static string[] PlatformGetAppResourceDirectories(string path)
+        {
+            if (Directory.Exists(path))
+                return Directory.GetDirectories(path);
+            else
+                return null;
+        }
+
+        static string[] PlatformGetAppResourceFiles(string path)
+        {
+            if (Directory.Exists(path))
+                return Directory.GetFiles(path);
+            else
+                return null;
+        }
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.netstandard.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.netstandard.cs
@@ -13,6 +13,12 @@ namespace Xamarin.Essentials
 
         static Task<Stream> PlatformOpenAppPackageFileAsync(string filename)
              => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+        static string[] PlatformGetAppResourceDirectories(string path)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+        static string[] PlatformGetAppResourceFiles(string path)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
@@ -15,6 +15,12 @@ namespace Xamarin.Essentials
         public static Task<Stream> OpenAppPackageFileAsync(string filename)
             => PlatformOpenAppPackageFileAsync(filename);
 
+        public static string[] GetAppResourceDirectories(string path)
+            => PlatformGetAppResourceDirectories(path);
+
+        public static string[] GetAppResourceFiles(string path)
+            => PlatformGetAppResourceFiles(path);
+
         internal static class MimeTypes
         {
             internal const string All = "*/*";

--- a/Xamarin.Essentials/FileSystem/FileSystem.tizen.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.tizen.cs
@@ -22,6 +22,22 @@ namespace Xamarin.Essentials
             Stream fs = File.OpenRead(Path.Combine(Application.Current.DirectoryInfo.Resource, filename));
             return Task.FromResult(fs);
         }
+
+        static string[] PlatformGetAppResourceDirectories(string path)
+        {
+            if (Directory.Exists(Path.Combine(Application.Current.DirectoryInfo.Resource, path)))
+                return Directory.GetDirectories(Path.Combine(Application.Current.DirectoryInfo.Resource, path));
+            else
+                return null;
+        }
+
+        static string[] PlatformGetAppResourceFiles(string path)
+        {
+            if (Directory.Exists(Path.Combine(Application.Current.DirectoryInfo.Resource, path)))
+                return Directory.GetFiles(Path.Combine(Application.Current.DirectoryInfo.Resource, path));
+            else
+                return null;
+        }
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
@@ -26,10 +26,10 @@ namespace Xamarin.Essentials
             => path.Replace('/', Path.DirectorySeparatorChar);
 
         static string[] PlatformGetAppResourceDirectories(string path)
-            => Directory.GetDirectories(Path.Combine(Application.Current.InstalledLocation, NormalizePath(path)));
+            => Directory.GetDirectories(Path.Combine(Package.Current.InstalledLocation.DisplayName, NormalizePath(path)));
 
         static string[] PlatformGetAppResourceFiles(string path)
-            => Directory.GetFiles(Path.Combine(Application.Current.InstalledLocation, NormalizePath(path)));
+            => Directory.GetFiles(Path.Combine(Package.Current.InstalledLocation.DisplayName, NormalizePath(path)));
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
@@ -26,10 +26,20 @@ namespace Xamarin.Essentials
             => path.Replace('/', Path.DirectorySeparatorChar);
 
         static string[] PlatformGetAppResourceDirectories(string path)
-            => Directory.GetDirectories(Path.Combine(Package.Current.InstalledLocation.Path, NormalizePath(path)));
+        {
+            if (Directory.Exists(path))
+                return Directory.GetDirectories(NormalizePath(path));
+            else
+                return null;
+        }
 
         static string[] PlatformGetAppResourceFiles(string path)
-            => Directory.GetFiles(Path.Combine(Package.Current.InstalledLocation.Path, NormalizePath(path)));
+        {
+            if (Directory.Exists(path))
+                return Directory.GetFiles(NormalizePath(path));
+            else
+                return null;
+        }
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Essentials
             => Directory.GetDirectories(Path.Combine(Application.Current.InstalledLocation, NormalizePath(path)));
 
         static string[] PlatformGetAppResourceFiles(string path)
-            => Directory.GetFiles(Path.Combine(Application.Current.InstalledLocation, NormalizePath(path)))
+            => Directory.GetFiles(Path.Combine(Application.Current.InstalledLocation, NormalizePath(path)));
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
@@ -26,10 +26,10 @@ namespace Xamarin.Essentials
             => path.Replace('/', Path.DirectorySeparatorChar);
 
         static string[] PlatformGetAppResourceDirectories(string path)
-            => Directory.GetDirectories(Path.Combine(Package.Current.InstalledLocation.DisplayName, NormalizePath(path)));
+            => Directory.GetDirectories(Path.Combine(Package.Current.InstalledLocation.Path, NormalizePath(path)));
 
         static string[] PlatformGetAppResourceFiles(string path)
-            => Directory.GetFiles(Path.Combine(Package.Current.InstalledLocation.DisplayName, NormalizePath(path)));
+            => Directory.GetFiles(Path.Combine(Package.Current.InstalledLocation.Path, NormalizePath(path)));
     }
 
     public partial class FileBase

--- a/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.uwp.cs
@@ -24,6 +24,12 @@ namespace Xamarin.Essentials
 
         internal static string NormalizePath(string path)
             => path.Replace('/', Path.DirectorySeparatorChar);
+
+        static string[] PlatformGetAppResourceDirectories(string path)
+            => Directory.GetDirectories(Path.Combine(Application.Current.InstalledLocation, NormalizePath(path)));
+
+        static string[] PlatformGetAppResourceFiles(string path)
+            => Directory.GetFiles(Path.Combine(Application.Current.InstalledLocation, NormalizePath(path)))
     }
 
     public partial class FileBase


### PR DESCRIPTION
### Description of Change ###

Given a Directory name,  respectively return either the sub-directories or files within that directory

### Bugs Fixed ###

- Related to issue https://github.com/xamarin/Essentials/issues/1551

### API Changes ###

Added: 

```csharp
public static partial class FileSystem {
    .
    .
    public string[] FileSystem.GetAppResourceDirectories(string path);
    public string[] FileSystem.GetAppResourceFiles(string path);
}
```

And associated cross-platform code.

### Behavioural Changes ###

None. New functionality.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))

### Sample UI Changes ###
**Android:**
![Screenshot_1606994851](https://user-images.githubusercontent.com/271363/101014895-78834980-355e-11eb-8d03-e156475b7701.png)

**iOS:**
<img width="390" alt="Screenshot 2020-12-03 at 11 22 29" src="https://user-images.githubusercontent.com/271363/101014928-8638cf00-355e-11eb-92a3-25db30d56d3d.png">

**Mac:**
<img width="493" alt="Screenshot 2020-12-03 at 11 20 23" src="https://user-images.githubusercontent.com/271363/101014957-8e910a00-355e-11eb-9859-10582f525bcd.png">

**Tizen:**
![Tizen](https://user-images.githubusercontent.com/271363/100910912-753c7f00-34c6-11eb-8afc-080ea9710bce.png)

**Windows.UWP:**
![Windows](https://user-images.githubusercontent.com/271363/101179393-0dab3e80-3642-11eb-88b6-4edde55588c5.png)

