### PR TITLE
Make sure to use the correct extra when sharing single files

### DIFF
--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -156,11 +156,7 @@ namespace Xamarin.Essentials
             // create the uri, if N use file provider
             if (HasApiLevelN)
             {
-                var providerAuthority = AppContext.PackageName + ".fileProvider";
-                return FileProvider.GetUriForFile(
-                    AppContext.ApplicationContext,
-                    providerAuthority,
-                    sharedFile);
+                return FileProvider.GetUriForFile(sharedFile);
             }
 
             // use the shared file path created

--- a/Xamarin.Essentials/Share/Share.android.cs
+++ b/Xamarin.Essentials/Share/Share.android.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Android.Content;
 using Android.OS;
@@ -41,21 +39,31 @@ namespace Xamarin.Essentials
 
         static Task PlatformRequestAsync(ShareMultipleFilesRequest request)
         {
-            var contentUris = new List<IParcelable>();
-
-            var intentType = request.Files.Count > 1 ? Intent.ActionSendMultiple : Intent.ActionSend;
-            var intent = new Intent(intentType);
-
+            // load the data we need
+            var contentUris = new List<IParcelable>(request.Files.Count);
+            var contentType = default(string);
             foreach (var file in request.Files)
+            {
                 contentUris.Add(Platform.GetShareableFileUri(file));
 
-            var type = request.Files.Count > 1
-                ? FileSystem.MimeTypes.All
-                : request.Files.FirstOrDefault().ContentType;
-            intent.SetType(type);
+                if (contentType == null)
+                    contentType = file.ContentType;
+                else if (contentType != file.ContentType)
+                    contentType = FileSystem.MimeTypes.All;
+            }
 
+            var intentType = contentUris.Count > 1
+                ? Intent.ActionSendMultiple
+                : Intent.ActionSend;
+            var intent = new Intent(intentType);
+
+            intent.SetType(contentType);
             intent.SetFlags(ActivityFlags.GrantReadUriPermission);
-            intent.PutParcelableArrayListExtra(Intent.ExtraStream, contentUris);
+
+            if (contentUris.Count > 1)
+                intent.PutParcelableArrayListExtra(Intent.ExtraStream, contentUris);
+            else if (contentUris.Count == 1)
+                intent.PutExtra(Intent.ExtraStream, contentUris[0]);
 
             if (!string.IsNullOrEmpty(request.Title))
                 intent.PutExtra(Intent.ExtraTitle, request.Title);

--- a/Xamarin.Essentials/Types/FileProvider.android.cs
+++ b/Xamarin.Essentials/Types/FileProvider.android.cs
@@ -54,11 +54,7 @@ namespace Xamarin.Essentials
             }
 
             // make sure the external storage is available
-            var hasExternalMedia = Platform.HasApiLevel(BuildVersionCodes.Lollipop)
-                ? AndroidEnvironment.GetExternalStorageState(Platform.AppContext.ExternalCacheDir) == AndroidEnvironment.MediaMounted
-#pragma warning disable CS0618 // Type or member is obsolete
-                : AndroidEnvironment.GetStorageState(Platform.AppContext.ExternalCacheDir) == AndroidEnvironment.MediaMounted;
-#pragma warning restore CS0618 // Type or member is obsolete
+            var hasExternalMedia = Platform.AppContext.ExternalCacheDir != null && IsMediaMounted(Platform.AppContext.ExternalCacheDir);
 
             // undo all the work if we have requested a fail (mainly for testing)
             if (AlwaysFailExternalMediaAccess)
@@ -74,6 +70,13 @@ namespace Xamarin.Essentials
                 ? Platform.AppContext.ExternalCacheDir
                 : Platform.AppContext.CacheDir;
         }
+
+        static bool IsMediaMounted(Java.IO.File location) =>
+            Platform.HasApiLevel(BuildVersionCodes.Lollipop)
+                ? AndroidEnvironment.GetExternalStorageState(location) == AndroidEnvironment.MediaMounted
+#pragma warning disable CS0618 // Type or member is obsolete
+                : AndroidEnvironment.GetStorageState(location) == AndroidEnvironment.MediaMounted;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         internal static bool IsFileInPublicLocation(string filename)
         {


### PR DESCRIPTION
### Description of Change ###

Currently, the share will use the `intent.PutParcelableArrayListExtra(Intent.ExtraStream, contentUris);` when the action is set to `Intent.ActionSend` which is an invalid combo.