### PR TITLE
[iOS] Request the file data from file providers

### DIFF
--- a/Samples/Samples/ViewModel/FilePickerViewModel.cs
+++ b/Samples/Samples/ViewModel/FilePickerViewModel.cs
@@ -140,9 +140,8 @@ namespace Samples.ViewModel
 
                     Text = $"File Name: {result.FileName} ({size:0.00} KB)";
 
-                    if (result.FileName.EndsWith("jpg", StringComparison.OrdinalIgnoreCase) ||
-                        result.FileName.EndsWith("jpeg", StringComparison.OrdinalIgnoreCase) ||
-                        result.FileName.EndsWith("png", StringComparison.OrdinalIgnoreCase))
+                    var ext = Path.GetExtension(result.FileName).ToLowerInvariant();
+                    if (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".gif")
                     {
                         var stream = await result.OpenReadAsync();
 

--- a/Samples/Samples/ViewModel/FilePickerViewModel.cs
+++ b/Samples/Samples/ViewModel/FilePickerViewModel.cs
@@ -136,12 +136,16 @@ namespace Samples.ViewModel
 
                 if (result != null)
                 {
-                    Text = $"File Name: {result.FileName}";
+                    var size = await GetStreamSizeAsync(result);
+
+                    Text = $"File Name: {result.FileName} ({size:0.00} KB)";
 
                     if (result.FileName.EndsWith("jpg", StringComparison.OrdinalIgnoreCase) ||
+                        result.FileName.EndsWith("jpeg", StringComparison.OrdinalIgnoreCase) ||
                         result.FileName.EndsWith("png", StringComparison.OrdinalIgnoreCase))
                     {
                         var stream = await result.OpenReadAsync();
+
                         Image = ImageSource.FromStream(() => stream);
                         IsImageVisible = true;
                     }
@@ -162,6 +166,19 @@ namespace Samples.ViewModel
                 Text = ex.ToString();
                 IsImageVisible = false;
                 return null;
+            }
+        }
+
+        async Task<double> GetStreamSizeAsync(FileResult result)
+        {
+            try
+            {
+                using var stream = await result.OpenReadAsync();
+                return stream.Length / 1024.0;
+            }
+            catch
+            {
+                return 0.0;
             }
         }
 
@@ -193,6 +210,7 @@ namespace Samples.ViewModel
                 else
                 {
                     Text = $"Pick cancelled.";
+                    IsImageVisible = false;
                 }
             }
             catch (Exception ex)

--- a/Xamarin.Essentials/FileSystem/FileSystem.ios.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.ios.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Foundation;
 using Photos;
@@ -7,29 +9,168 @@ using UIKit;
 
 namespace Xamarin.Essentials
 {
-    class UIDocumentFileResult : FileResult
+    public partial class FileSystem
     {
-        readonly Stream fileStream;
+        internal static async Task<FileResult[]> EnsurePhysicalFileResultsAsync(params NSUrl[] urls)
+        {
+            if (urls == null || urls.Length == 0)
+                return Array.Empty<FileResult>();
 
-        internal UIDocumentFileResult(NSUrl url)
+            var opts = NSFileCoordinatorReadingOptions.WithoutChanges;
+            var intents = urls.Select(x => NSFileAccessIntent.CreateReadingIntent(x, opts)).ToArray();
+
+            using var coordinator = new NSFileCoordinator();
+
+            var tcs = new TaskCompletionSource<FileResult[]>();
+
+            coordinator.CoordinateAccess(intents, new NSOperationQueue(), error =>
+            {
+                if (error != null)
+                {
+                    tcs.TrySetException(new NSErrorException(error));
+                    return;
+                }
+
+                var bookmarks = new List<FileResult>();
+
+                foreach (var intent in intents)
+                {
+                    var url = intent.Url;
+                    var result = new BookmarkDataFileResult(url);
+                    bookmarks.Add(result);
+                }
+
+                tcs.TrySetResult(bookmarks.ToArray());
+            });
+
+            return await tcs.Task;
+        }
+    }
+
+    class BookmarkDataFileResult : FileResult
+    {
+        NSData bookmark;
+
+        internal BookmarkDataFileResult(NSUrl url)
             : base()
         {
-            url.StartAccessingSecurityScopedResource();
+            try
+            {
+                url.StartAccessingSecurityScopedResource();
+
+                var newBookmark = url.CreateBookmarkData(0, Array.Empty<string>(), null, out var bookmarkError);
+                if (bookmarkError != null)
+                    throw new NSErrorException(bookmarkError);
+
+                UpdateBookmark(url, newBookmark);
+            }
+            finally
+            {
+                url.StopAccessingSecurityScopedResource();
+            }
+        }
+
+        void UpdateBookmark(NSUrl url, NSData newBookmark)
+        {
+            bookmark = newBookmark;
 
             var doc = new UIDocument(url);
             FullPath = doc.FileUrl?.Path;
             FileName = doc.LocalizedName ?? Path.GetFileName(FullPath);
-
-            // immediately open a file stream, in case iOS cleans up the picked file
-            fileStream = File.OpenRead(FullPath);
-
-            url.StopAccessingSecurityScopedResource();
         }
 
         internal override Task<Stream> PlatformOpenReadAsync()
         {
-            // make sure we are at he beginning
-            fileStream.Seek(0, SeekOrigin.Begin);
+            var url = NSUrl.FromBookmarkData(bookmark, 0, null, out var isStale, out var error);
+
+            if (error != null)
+                throw new NSErrorException(error);
+
+            url.StartAccessingSecurityScopedResource();
+
+            if (isStale)
+            {
+                var newBookmark = url.CreateBookmarkData(NSUrlBookmarkCreationOptions.SuitableForBookmarkFile, Array.Empty<string>(), null, out error);
+                if (error != null)
+                    throw new NSErrorException(error);
+
+                UpdateBookmark(url, newBookmark);
+            }
+
+            var fileStream = File.OpenRead(FullPath);
+            Stream stream = new SecurityScopedStream(fileStream, url);
+            return Task.FromResult(stream);
+        }
+
+        class SecurityScopedStream : Stream
+        {
+            FileStream stream;
+            NSUrl url;
+
+            internal SecurityScopedStream(FileStream stream, NSUrl url)
+            {
+                this.stream = stream;
+                this.url = url;
+            }
+
+            public override bool CanRead => stream.CanRead;
+
+            public override bool CanSeek => stream.CanSeek;
+
+            public override bool CanWrite => stream.CanWrite;
+
+            public override long Length => stream.Length;
+
+            public override long Position
+            {
+                get => stream.Position;
+                set => stream.Position = value;
+            }
+
+            public override void Flush() =>
+                stream.Flush();
+
+            public override int Read(byte[] buffer, int offset, int count) =>
+                stream.Read(buffer, offset, count);
+
+            public override long Seek(long offset, SeekOrigin origin) =>
+                stream.Seek(offset, origin);
+
+            public override void SetLength(long value) =>
+                stream.SetLength(value);
+
+            public override void Write(byte[] buffer, int offset, int count) =>
+                stream.Write(buffer, offset, count);
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+
+                if (disposing)
+                {
+                    stream?.Dispose();
+                    stream = null;
+
+                    url?.StopAccessingSecurityScopedResource();
+                    url = null;
+                }
+            }
+        }
+    }
+
+    class UIDocumentFileResult : FileResult
+    {
+        internal UIDocumentFileResult(NSUrl url)
+            : base()
+        {
+            var doc = new UIDocument(url);
+            FullPath = doc.FileUrl?.Path;
+            FileName = doc.LocalizedName ?? Path.GetFileName(FullPath);
+        }
+
+        internal override Task<Stream> PlatformOpenReadAsync()
+        {
+            Stream fileStream = File.OpenRead(FullPath);
 
             return Task.FromResult(fileStream);
         }

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -65,34 +65,14 @@ namespace Xamarin.Essentials
             var tcs = new TaskCompletionSource<FileResult>(picker);
             picker.Delegate = new PhotoPickerDelegate
             {
-                CompletedHandler = info =>
-                {
-                    try
-                    {
-                        tcs.TrySetResult(DictionaryToMediaFile(info));
-                    }
-                    catch (Exception ex)
-                    {
-                        tcs.TrySetException(ex);
-                    }
-                }
+                CompletedHandler = info => GetFileResult(info, tcs)
             };
 
             if (picker.PresentationController != null)
             {
                 picker.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
                 {
-                    CompletedHandler = info =>
-                    {
-                        try
-                        {
-                            tcs.TrySetResult(DictionaryToMediaFile(info));
-                        }
-                        catch (Exception ex)
-                        {
-                            tcs.TrySetException(ex);
-                        }
-                    }
+                    CompletedHandler = info => GetFileResult(info, tcs)
                 };
             }
 
@@ -106,6 +86,18 @@ namespace Xamarin.Essentials
             picker = null;
 
             return result;
+        }
+
+        static void GetFileResult(NSDictionary info, TaskCompletionSource<FileResult> tcs)
+        {
+            try
+            {
+                tcs.TrySetResult(DictionaryToMediaFile(info));
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+            }
         }
 
         static FileResult DictionaryToMediaFile(NSDictionary info)


### PR DESCRIPTION
### Description of Change ###

This PR will make sure that when files are picked, they are read correctly. Typically, external apps can provide file using a file provider, so we need to make sure we use that file provider to read the file data.

This PR also fixes a memory leak. Previously, the file was picked and opened. This also had a limitation that once the stream is closed then it can never be opened. And, multiple opens will cause issues with the single stream.

### Bugs Fixed ###

- Fixes #1549

### API Changes ###
None.

### Behavioral Changes ###

When picking files from third party providers, request the data from the provider.