### PR TITLE
Use NSSpeechSynthesizer.AttributesForVoice to correctly populate the X.E Locale on Mac. 

### DIFF
--- a/Samples/Samples/ViewModel/TextToSpeechViewModel.cs
+++ b/Samples/Samples/ViewModel/TextToSpeechViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -87,13 +88,27 @@ namespace Samples.ViewModel
 
         async Task OnPickLocale()
         {
-            var locales = await TextToSpeech.GetLocalesAsync();
-            var languages = locales.Select(i => i.Language).ToArray();
+            var allLocales = await TextToSpeech.GetLocalesAsync();
+            var locales = allLocales
+                .OrderBy(i => i.Language.ToLowerInvariant())
+                .ToArray();
+
+            var languages = locales
+                .Select(i => string.IsNullOrEmpty(i.Country) ? i.Language : $"{i.Language} ({i.Country})")
+                .ToArray();
 
             var result = await Application.Current.MainPage.DisplayActionSheet("Pick", "OK", null, languages);
 
-            selectedLocale = locales.FirstOrDefault(i => i.Language == result);
-            Locale = (result == "OK" || string.IsNullOrEmpty(result)) ? "Default" : result;
+            if (!string.IsNullOrEmpty(result) && Array.IndexOf(languages, result) is int idx && idx != -1)
+            {
+                selectedLocale = locales[idx];
+                Locale = result;
+            }
+            else
+            {
+                selectedLocale = null;
+                Locale = "Default";
+            }
         }
 
         public ICommand CancelCommand { get; }

--- a/Samples/Samples/ViewModel/TextToSpeechViewModel.cs
+++ b/Samples/Samples/ViewModel/TextToSpeechViewModel.cs
@@ -88,11 +88,11 @@ namespace Samples.ViewModel
         async Task OnPickLocale()
         {
             var locales = await TextToSpeech.GetLocalesAsync();
-            var names = locales.Select(i => i.Name).ToArray();
+            var languages = locales.Select(i => i.Language).ToArray();
 
-            var result = await Application.Current.MainPage.DisplayActionSheet("Pick", "OK", null, names);
+            var result = await Application.Current.MainPage.DisplayActionSheet("Pick", "OK", null, languages);
 
-            selectedLocale = locales.FirstOrDefault(i => i.Name == result);
+            selectedLocale = locales.FirstOrDefault(i => i.Language == result);
             Locale = (result == "OK" || string.IsNullOrEmpty(result)) ? "Default" : result;
         }
 

--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Essentials
 
         internal static Task<IEnumerable<Locale>> PlatformGetLocalesAsync() =>
             Task.FromResult(AVSpeechSynthesisVoice.GetSpeechVoices()
-                .Select(v => new Locale(v.Language, null, v.Language, v.Identifier)));
+                .Select(v => new Locale(v.Language, null, v.Name, v.Identifier)));
 
         internal static async Task PlatformSpeakAsync(string text, SpeechOptions options, CancellationToken cancelToken = default)
         {

--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Essentials
         internal static Task<IEnumerable<Locale>> PlatformGetLocalesAsync() =>
             Task.FromResult(NSSpeechSynthesizer.AvailableVoices
                 .Select(voice => NSSpeechSynthesizer.AttributesForVoice(voice))
-                .Select(attribute => new Locale(attribute["VoiceLanguage"].ToString(), null, attribute["VoiceName"].ToString(), attribute["VoiceIdentifier"].ToString())));
+                .Select(attribute => new Locale(attribute["VoiceLanguage"]?.ToString(), null, attribute["VoiceName"]?.ToString(), attribute["VoiceIdentifier"]?.ToString())));
 
         internal static async Task PlatformSpeakAsync(string text, SpeechOptions options, CancellationToken cancelToken = default)
         {

--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs
@@ -14,7 +14,8 @@ namespace Xamarin.Essentials
 
         internal static Task<IEnumerable<Locale>> PlatformGetLocalesAsync() =>
             Task.FromResult(NSSpeechSynthesizer.AvailableVoices
-                .Select(v => new Locale(v, null, null, null)));
+                .Select(voice => NSSpeechSynthesizer.AttributesForVoice(voice))
+                .Select(attribute => new Locale(attribute["VoiceLanguage"].ToString(), null, attribute["VoiceName"].ToString(), attribute["VoiceIdentifier"].ToString())));
 
         internal static async Task PlatformSpeakAsync(string text, SpeechOptions options, CancellationToken cancelToken = default)
         {
@@ -30,7 +31,7 @@ namespace Xamarin.Essentials
                         ss.Volume = NormalizeVolume(options.Volume);
 
                     if (options.Locale != null)
-                        ss.Voice = options.Locale.Language;
+                        ss.Voice = options.Locale.Id;
                 }
 
                 ssd.FinishedSpeaking += OnFinishedSpeaking;


### PR DESCRIPTION
### Description of Change ###

Use NSSynthesiser Attributes to correctly populate the X.E Locale properties on Mac.  
Fix Locale Name on iOS as it was incorrectly populating it with Language
Tweaked TTS demo, to list Languages, so that voices are changed correctly on all platforms.

### Bugs Fixed ###

 - Fixes #1622 - Populate Mac Locale correctly
 - Fixes #1624 - Make TTS demo behave consistently across platforms

### API Changes ###

None

Added: 
 
None

Changed:

[Mac] Pass each voice to the NSSpeechSynthesizer.AttributesForVoice(), so we can then popolate the Locale object correctly.
https://github.com/CartBlanche/Essentials/blob/dominique-FixTTSLocaleOnMac/Xamarin.Essentials/TextToSpeech/TextToSpeech.macos.cs#L15-L18

[iOS] Populate Name property correctly.
https://github.com/CartBlanche/Essentials/blob/dominique-FixTTSLocaleOnMac/Xamarin.Essentials/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs#L15-L16

[Sample] Use language to populate Action sheet, so languages can be changes across platforms.
https://github.com/CartBlanche/Essentials/blob/dominique-FixTTSLocaleOnMac/Samples/Samples/ViewModel/TextToSpeechViewModel.cs#L91-L95

### Behavioural Changes ###

Tweaked how the Locale on Mac is populated as per changes above.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Fixed samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
