### PR TITLE
[Draft] [MediaPicker] [iOS] Captured file metadata

### DIFF
--- a/Samples/Samples.iOS/Samples.iOS.csproj
+++ b/Samples/Samples.iOS/Samples.iOS.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -54,6 +54,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>None</MtouchLink>
     <MtouchInterpreter>-all</MtouchInterpreter>
+    <MtouchI18n>cjk, mideast, other, west</MtouchI18n>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>

--- a/Samples/Samples/Samples.csproj
+++ b/Samples/Samples/Samples.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MetadataExtractor" Version="2.4.3" />
     <PackageReference Include="Microsoft.AppCenter" Version="3.0.0" />
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="3.0.0" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="3.0.0" />

--- a/Samples/Samples/View/MediaPickerPage.xaml
+++ b/Samples/Samples/View/MediaPickerPage.xaml
@@ -1,10 +1,9 @@
-<views:BasePage
-    x:Class="Samples.View.MediaPickerPage"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:viewmodels="clr-namespace:Samples.ViewModel"
-    xmlns:views="clr-namespace:Samples.View"
-    Title="Media Picker">
+<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms" 
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+                xmlns:viewmodels="clr-namespace:Samples.ViewModel" 
+                xmlns:views="clr-namespace:Samples.View" 
+                x:Class="Samples.View.MediaPickerPage" 
+                Title="Media Picker">
     <views:BasePage.BindingContext>
         <viewmodels:MediaPickerViewModel />
     </views:BasePage.BindingContext>
@@ -23,49 +22,14 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <Button Command="{Binding PickPhotoCommand}" Text="Pick photo" />
-            <Button
-                Grid.Row="1"
-                Command="{Binding CapturePhotoCommand}"
-                Text="Capture photo" />
-            <Button
-                Grid.Column="1"
-                Command="{Binding PickVideoCommand}"
-                Text="Pick video" />
-            <Button
-                Grid.Row="1"
-                Grid.Column="1"
-                Command="{Binding CaptureVideoCommand}"
-                Text="Capture video" />
-
-            <Image
-                Grid.Row="2"
-                Grid.ColumnSpan="2"
-                Aspect="AspectFit"
-                HorizontalOptions="FillAndExpand"
-                IsVisible="{Binding ShowPhoto}"
-                Source="{Binding PhotoPath}"
-                VerticalOptions="FillAndExpand" />
-            <MediaElement
-                Grid.Row="2"
-                Grid.ColumnSpan="2"
-                Aspect="AspectFit"
-                HorizontalOptions="FillAndExpand"
-                IsVisible="{Binding ShowVideo}"
-                ShowsPlaybackControls="True"
-                Source="{Binding VideoPath}"
-                VerticalOptions="FillAndExpand" />
-            <Label
-                Grid.Row="3"
-                Grid.ColumnSpan="2"
-                Margin="0,10"
-                FontAttributes="Bold"
-                Text="Metadata:" />
-            <Label
-                Grid.Row="4"
-                Grid.ColumnSpan="2"
-                LineBreakMode="WordWrap"
-                Text="{Binding Metadata}" />
+            <Button Text="Pick photo" Command="{Binding PickPhotoCommand}" />
+            <Button Text="Capture photo" Grid.Row="1" Command="{Binding CapturePhotoCommand}" />
+            <Button Text="Pick video" Grid.Column="1" Command="{Binding PickVideoCommand}" />
+            <Button Text="Capture video" Grid.Row="1" Grid.Column="1" Command="{Binding CaptureVideoCommand}" />
+            <Image Grid.Row="2" Grid.ColumnSpan="2" Aspect="AspectFit" HorizontalOptions="FillAndExpand" IsVisible="{Binding ShowPhoto}" Source="{Binding PhotoPath}" VerticalOptions="FillAndExpand" />
+            <MediaElement Grid.Row="2" Grid.ColumnSpan="2" Aspect="AspectFit" HorizontalOptions="FillAndExpand" IsVisible="{Binding ShowVideo}" ShowsPlaybackControls="True" Source="{Binding VideoPath}" VerticalOptions="FillAndExpand" />
+            <Label Grid.Row="3" Grid.ColumnSpan="2" Margin="0,10" FontAttributes="Bold" Text="Metadata:" />
+            <Label Grid.Row="4" Grid.ColumnSpan="2" LineBreakMode="WordWrap" Text="{Binding Metadata}" />
         </Grid>
     </ScrollView>
 

--- a/Samples/Samples/View/MediaPickerPage.xaml
+++ b/Samples/Samples/View/MediaPickerPage.xaml
@@ -1,23 +1,72 @@
-﻿<views:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:views="clr-namespace:Samples.View"
-                xmlns:viewmodels="clr-namespace:Samples.ViewModel"
-                x:Class="Samples.View.MediaPickerPage"
-                Title="Media Picker">
+<views:BasePage
+    x:Class="Samples.View.MediaPickerPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:viewmodels="clr-namespace:Samples.ViewModel"
+    xmlns:views="clr-namespace:Samples.View"
+    Title="Media Picker">
     <views:BasePage.BindingContext>
         <viewmodels:MediaPickerViewModel />
     </views:BasePage.BindingContext>
 
     <ScrollView>
-        <StackLayout Padding="10">
-            <Button Text="Pick photo" Command="{Binding PickPhotoCommand}" />
-            <Button Text="Capture photo" Command="{Binding CapturePhotoCommand}" />
-            <Button Text="Pick video" Command="{Binding PickVideoCommand}" />
-            <Button Text="Capture video" Command="{Binding CaptureVideoCommand}" />
+        <Grid Padding="10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="400" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-            <Image VerticalOptions="FillAndExpand" Source="{Binding PhotoPath}" IsVisible="{Binding ShowPhoto}" />
-            <MediaElement VerticalOptions="FillAndExpand" Source="{Binding VideoPath}" IsVisible="{Binding ShowVideo}" />
-        </StackLayout>
+            <Button Command="{Binding PickPhotoCommand}" Text="Pick photo" />
+            <Button
+                Grid.Row="1"
+                Command="{Binding CapturePhotoCommand}"
+                Text="Capture photo" />
+            <Button
+                Grid.Column="1"
+                Command="{Binding PickVideoCommand}"
+                Text="Pick video" />
+            <Button
+                Grid.Row="1"
+                Grid.Column="1"
+                Command="{Binding CaptureVideoCommand}"
+                Text="Capture video" />
+
+            <Image
+                Grid.Row="2"
+                Grid.ColumnSpan="2"
+                Aspect="AspectFit"
+                HorizontalOptions="FillAndExpand"
+                IsVisible="{Binding ShowPhoto}"
+                Source="{Binding PhotoPath}"
+                VerticalOptions="FillAndExpand" />
+            <MediaElement
+                Grid.Row="2"
+                Grid.ColumnSpan="2"
+                Aspect="AspectFit"
+                HorizontalOptions="FillAndExpand"
+                IsVisible="{Binding ShowVideo}"
+                ShowsPlaybackControls="True"
+                Source="{Binding VideoPath}"
+                VerticalOptions="FillAndExpand" />
+            <Label
+                Grid.Row="3"
+                Grid.ColumnSpan="2"
+                Margin="0,10"
+                FontAttributes="Bold"
+                Text="Metadata:" />
+            <Label
+                Grid.Row="4"
+                Grid.ColumnSpan="2"
+                LineBreakMode="WordWrap"
+                Text="{Binding Metadata}" />
+        </Grid>
     </ScrollView>
 
 </views:BasePage>

--- a/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.shared.cs
@@ -212,4 +212,21 @@ namespace Xamarin.Essentials
         {
         }
     }
+
+    public class FileResultCreationException : Exception
+    {
+        public FileResultCreationException()
+        {
+        }
+
+        public FileResultCreationException(string message)
+            : base(message)
+        {
+        }
+
+        public FileResultCreationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
 }

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -136,9 +136,10 @@ namespace Xamarin.Essentials
             if (phAsset == null || assetUrl == null)
             {
                 var img = info.ValueForKey(UIImagePickerController.OriginalImage) as UIImage;
+                var meta = info.ValueForKey(UIImagePickerController.MediaMetadata) as NSDictionary;
 
                 if (img != null)
-                    return new UIImageFileResult(img);
+                    return new UIImageFileResult(img, meta);
             }
 
             if (phAsset == null || assetUrl == null)


### PR DESCRIPTION
### Description of Change ###

1. Preserves metadata of captured image
2. Saves the image into app specific temp location
3. MediaPicker sample updated to show metadata

### Questions ###

1. I think we should add some custom exception for the cases when MediaPicker's capturing fails. Not sure where though.
2. Should we rename UIImageFileResult into ImageFileResult or something? After all, UIImage is used just for input there
3. Should we include new options into this PR (e.g., if image should or should not preserve metadata)? If yes, I feel like current `MediaPickerOptions` are not a best choice because there might be different options for picking and capturing media. 

### Bugs Fixed ###

- Related to issue #1638, #1631, #1514

### API Changes ###

Internal API changed

New:

- `FileResultCreationException`

Changed:

 - `internal UIImageFileResult(UIImage image)` => `internal UIImageFileResult(UIImage image, NSDictionary metadata)`
 

### Behavioral Changes ###

Images are saved as JPEG now instead of PNG

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
