### PR TITLE
Make sure to require permissions

### DIFF
--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Essentials
         {
             // we only need the permission when accessing the file, but it's more natural
             // to ask the user first, then show the picker.
-            await Permissions.RequestAsync<Permissions.StorageRead>();
+            await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
 
             // Essentials supports >= API 19 where this action is available
             var action = Intent.ActionOpenDocument;


### PR DESCRIPTION

### Description of Change ###

If the permissions were denied, then throw.


### Bugs Fixed ###

- Fixes  #1649

### API Changes ###

None.

### Behavioral Changes ###

If the permissions are denied, then the picker does not launch.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
