### PR TITLE
Feature/issue1289 maps try open

### DIFF
--- a/Samples/Samples.Android/Properties/AndroidManifest.xml
+++ b/Samples/Samples.Android/Properties/AndroidManifest.xml
@@ -42,6 +42,11 @@
 		<intent>
 			<action android:name="android.media.action.IMAGE_CAPTURE" />
 		</intent>
+		<!-- Maps -->
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="geo" />
+		</intent>
 	</queries>
 	<uses-feature android:name="android.hardware.location" android:required="false" />
 	<uses-feature android:name="android.hardware.location.gps" android:required="false" />

--- a/Samples/Samples/ViewModel/MapsViewModel.cs
+++ b/Samples/Samples/ViewModel/MapsViewModel.cs
@@ -95,11 +95,16 @@ namespace Samples.ViewModel
 
         async void OpenLocation()
         {
-            await Map.OpenAsync(double.Parse(Latitude), double.Parse(Longitude), new MapLaunchOptions
+            var canOpen = await Map.TryOpenAsync(double.Parse(Latitude), double.Parse(Longitude), new MapLaunchOptions
             {
                 Name = Name,
                 NavigationMode = (NavigationMode)NavigationMode
             });
+
+            if (!canOpen)
+            {
+                await DisplayAlertAsync("Can´t open the maps.");
+            }
         }
 
         async void OpenPlacemark()
@@ -112,11 +117,17 @@ namespace Samples.ViewModel
                 Thoroughfare = Thoroughfare,
                 PostalCode = ZipCode
             };
-            await Map.OpenAsync(placemark, new MapLaunchOptions
+
+            var canOpen = await Map.TryOpenAsync(placemark, new MapLaunchOptions
             {
                 Name = Name,
                 NavigationMode = (NavigationMode)NavigationMode
             });
+
+            if (!canOpen)
+            {
+                await DisplayAlertAsync("Can´t open the maps.");
+            }
         }
     }
 }

--- a/Xamarin.Essentials/Launcher/Launcher.ios.tvos.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.ios.tvos.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Essentials
                 ? UIApplication.SharedApplication.OpenUrlAsync(nativeUrl, new UIApplicationOpenUrlOptions())
                 : Task.FromResult(UIApplication.SharedApplication.OpenUrl(nativeUrl));
 
-        static Task<bool> PlatformTryOpenAsync(Uri uri)
+        internal static Task<bool> PlatformTryOpenAsync(Uri uri)
         {
             var nativeUrl = WebUtils.GetNativeUrl(uri);
 

--- a/Xamarin.Essentials/Launcher/Launcher.macos.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.macos.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Essentials
         internal static Task PlatformOpenAsync(Uri uri) =>
             Task.FromResult(NSWorkspace.SharedWorkspace.OpenUrl(WebUtils.GetNativeUrl(uri)));
 
-        static Task<bool> PlatformTryOpenAsync(Uri uri)
+        internal static Task<bool> PlatformTryOpenAsync(Uri uri)
         {
             var nativeUrl = WebUtils.GetNativeUrl(uri);
             var canOpen = NSWorkspace.SharedWorkspace.UrlForApplication(nativeUrl) != null;

--- a/Xamarin.Essentials/Map/Map.android.cs
+++ b/Xamarin.Essentials/Map/Map.android.cs
@@ -1,6 +1,8 @@
 ﻿using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Android.Content;
+using Android.Content.PM;
 using AndroidUri = Android.Net.Uri;
 
 namespace Xamarin.Essentials
@@ -8,6 +10,34 @@ namespace Xamarin.Essentials
     public static partial class Map
     {
         internal static Task PlatformOpenMapsAsync(double latitude, double longitude, MapLaunchOptions options)
+        {
+            var uri = GetMapsUri(latitude, longitude, options);
+
+            return OpenUri(uri);
+        }
+
+        internal static Task PlatformOpenMapsAsync(Placemark placemark, MapLaunchOptions options)
+        {
+            var uri = GetMapsUri(placemark, options);
+
+            return OpenUri(uri);
+        }
+
+        internal static Task<bool> PlatformTryOpenMapsAsync(double latitude, double longitude, MapLaunchOptions options)
+        {
+            var uri = GetMapsUri(latitude, longitude, options);
+
+            return TryOpenUri(uri);
+        }
+
+        internal static Task<bool> PlatformTryOpenMapsAsync(Placemark placemark, MapLaunchOptions options)
+        {
+            var uri = GetMapsUri(placemark, options);
+
+            return TryOpenUri(uri);
+        }
+
+        internal static string GetMapsUri(double latitude, double longitude, MapLaunchOptions options)
         {
             var uri = string.Empty;
             var lat = latitude.ToString(CultureInfo.InvariantCulture);
@@ -25,22 +55,10 @@ namespace Xamarin.Essentials
                 uri = $"google.navigation:q={lat},{lng}{GetMode(options.NavigationMode)}";
             }
 
-            StartIntent(uri);
-            return Task.CompletedTask;
+            return uri;
         }
 
-        internal static string GetMode(NavigationMode mode)
-        {
-            switch (mode)
-            {
-                case NavigationMode.Bicycling: return "&mode=b";
-                case NavigationMode.Driving: return "&mode=d";
-                case NavigationMode.Walking: return "&mode=w";
-            }
-            return string.Empty;
-        }
-
-        internal static Task PlatformOpenMapsAsync(Placemark placemark, MapLaunchOptions options)
+        internal static string GetMapsUri(Placemark placemark, MapLaunchOptions options)
         {
             var uri = string.Empty;
             if (options.NavigationMode == NavigationMode.None)
@@ -54,11 +72,53 @@ namespace Xamarin.Essentials
                 uri = $"google.navigation:q={placemark.GetEscapedAddress()}{GetMode(options.NavigationMode)}";
             }
 
-            StartIntent(uri);
+            return uri;
+        }
+
+        internal static string GetMode(NavigationMode mode)
+        {
+            switch (mode)
+            {
+                case NavigationMode.Bicycling: return "&mode=b";
+                case NavigationMode.Driving: return "&mode=d";
+                case NavigationMode.Walking: return "&mode=w";
+            }
+            return string.Empty;
+        }
+
+        internal static Task OpenUri(string uri)
+        {
+            var intent = ResolveMapIntent(uri);
+
+            Platform.AppContext.StartActivity(intent);
+
             return Task.CompletedTask;
         }
 
-        static void StartIntent(string uri)
+        internal static Task<bool> TryOpenUri(string uri)
+        {
+            var intent = ResolveMapIntent(uri);
+
+            var canStart = CanStartIntent(intent);
+
+            if (canStart)
+                Platform.AppContext.StartActivity(intent);
+
+            return Task.FromResult(canStart);
+        }
+
+        internal static bool CanStartIntent(Intent intent)
+        {
+            if (Platform.AppContext == null)
+                return false;
+
+            var manager = Platform.AppContext.PackageManager;
+            var supportedResolvedInfos = manager.QueryIntentActivities(intent, PackageInfoFlags.MatchDefaultOnly);
+
+            return supportedResolvedInfos.Any();
+        }
+
+        static Intent ResolveMapIntent(string uri)
         {
             var intent = new Intent(Intent.ActionView, AndroidUri.Parse(uri));
             var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
@@ -66,9 +126,10 @@ namespace Xamarin.Essentials
             if (Platform.HasApiLevelN)
                 flags |= ActivityFlags.LaunchAdjacent;
 #endif
+
             intent.SetFlags(flags);
 
-            Platform.AppContext.StartActivity(intent);
+            return intent;
         }
     }
 }

--- a/Xamarin.Essentials/Map/Map.ios.watchos.macos.cs
+++ b/Xamarin.Essentials/Map/Map.ios.watchos.macos.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Contacts;
@@ -12,6 +12,11 @@ namespace Xamarin.Essentials
     {
         internal static Task PlatformOpenMapsAsync(double latitude, double longitude, MapLaunchOptions options)
         {
+            return PlatformTryOpenMapsAsync(latitude, longitude, options);
+        }
+
+        internal static Task<bool> PlatformTryOpenMapsAsync(double latitude, double longitude, MapLaunchOptions options)
+        {
             if (string.IsNullOrWhiteSpace(options.Name))
                 options.Name = string.Empty;
 
@@ -21,6 +26,11 @@ namespace Xamarin.Essentials
         }
 
         internal static async Task PlatformOpenMapsAsync(Placemark placemark, MapLaunchOptions options)
+        {
+            await PlatformTryOpenMapsAsync(placemark, options);
+        }
+
+        internal static async Task<bool> PlatformTryOpenMapsAsync(Placemark placemark, MapLaunchOptions options)
         {
 #if __IOS__
             var address = new MKPlacemarkAddress
@@ -47,7 +57,7 @@ namespace Xamarin.Essentials
             var resolvedPlacemarks = await GetPlacemarksAsync(address);
             if (resolvedPlacemarks?.Length > 0)
             {
-                await OpenPlacemark(new MKPlacemark(resolvedPlacemarks[0].Location.Coordinate, address), options);
+                return await OpenPlacemark(new MKPlacemark(resolvedPlacemarks[0].Location.Coordinate, address), options);
             }
             else
             {
@@ -56,9 +66,9 @@ namespace Xamarin.Essentials
                 var uri = $"http://maps.apple.com/?q={placemark.GetEscapedAddress()}";
                 var nsurl = NSUrl.FromString(uri);
 
-                await Launcher.PlatformOpenAsync(nsurl);
+                return await Launcher.PlatformTryOpenAsync(nsurl);
 #else
-                await OpenPlacemark(new MKPlacemark(default, address), options);
+                return await OpenPlacemark(new MKPlacemark(default, address), options);
 #endif
             }
         }

--- a/Xamarin.Essentials/Map/Map.netstandard.tvos.cs
+++ b/Xamarin.Essentials/Map/Map.netstandard.tvos.cs
@@ -7,7 +7,13 @@ namespace Xamarin.Essentials
         internal static Task PlatformOpenMapsAsync(double latitude, double longitude, MapLaunchOptions options)
             => throw ExceptionUtils.NotSupportedOrImplementedException;
 
+        internal static Task<bool> PlatformTryOpenMapsAsync(double latitude, double longitude, MapLaunchOptions options)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
+
         internal static Task PlatformOpenMapsAsync(Placemark placemark, MapLaunchOptions options)
+            => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+        internal static Task<bool> PlatformTryOpenMapsAsync(Placemark placemark, MapLaunchOptions options)
             => throw ExceptionUtils.NotSupportedOrImplementedException;
     }
 }

--- a/Xamarin.Essentials/Map/Map.shared.cs
+++ b/Xamarin.Essentials/Map/Map.shared.cs
@@ -43,5 +43,44 @@ namespace Xamarin.Essentials
 
             return PlatformOpenMapsAsync(placemark, options);
         }
+
+        public static Task<bool> TryOpenAsync(Location location) =>
+            TryOpenAsync(location, new MapLaunchOptions());
+
+        public static Task<bool> TryOpenAsync(Location location, MapLaunchOptions options)
+        {
+            if (location == null)
+                throw new ArgumentNullException(nameof(location));
+
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            return PlatformTryOpenMapsAsync(location.Latitude, location.Longitude, options);
+        }
+
+        public static Task<bool> TryOpenAsync(double latitude, double longitude) =>
+            TryOpenAsync(latitude, longitude, new MapLaunchOptions());
+
+        public static Task<bool> TryOpenAsync(double latitude, double longitude, MapLaunchOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            return PlatformTryOpenMapsAsync(latitude, longitude, options);
+        }
+
+        public static Task<bool> TryOpenAsync(Placemark placemark) =>
+            TryOpenAsync(placemark, new MapLaunchOptions());
+
+        public static Task<bool> TryOpenAsync(Placemark placemark, MapLaunchOptions options)
+        {
+            if (placemark == null)
+                throw new ArgumentNullException(nameof(placemark));
+
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            return PlatformTryOpenMapsAsync(placemark, options);
+        }
     }
 }

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -10,10 +10,6 @@
       <Member Id="M:Xamarin.Essentials.Accelerometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Accelerometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
-      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.AccelerometerData" Id="T:Xamarin.Essentials.AccelerometerData">
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -24,6 +20,10 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.op_Inequality(Xamarin.Essentials.AccelerometerData,Xamarin.Essentials.AccelerometerData)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
+    </Type>
+    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
+      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.ActivityState" Id="T:Xamarin.Essentials.ActivityState">
       <Member Id="F:Xamarin.Essentials.ActivityState.Created" />
@@ -89,10 +89,6 @@
       <Member Id="M:Xamarin.Essentials.Barometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Barometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
-      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.BarometerData" Id="T:Xamarin.Essentials.BarometerData">
       <Member Id="M:Xamarin.Essentials.BarometerData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.BarometerData.Equals(System.Object)" />
@@ -103,11 +99,15 @@
       <Member Id="M:Xamarin.Essentials.BarometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.BarometerData.PressureInHectopascals" />
     </Type>
+    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
+      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
+    </Type>
     <Type Name="Xamarin.Essentials.Battery" Id="T:Xamarin.Essentials.Battery">
       <Member Id="E:Xamarin.Essentials.Battery.BatteryInfoChanged" />
       <Member Id="E:Xamarin.Essentials.Battery.EnergySaverStatusChanged" />
-      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.EnergySaverStatus" />
+      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.PowerSource" />
       <Member Id="P:Xamarin.Essentials.Battery.State" />
     </Type>
@@ -126,9 +126,9 @@
       <Member Id="F:Xamarin.Essentials.BatteryPowerSource.Wireless" />
     </Type>
     <Type Name="Xamarin.Essentials.BatteryState" Id="T:Xamarin.Essentials.BatteryState">
-      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Discharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Full" />
+      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotCharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotPresent" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Unknown" />
@@ -197,10 +197,6 @@
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
-      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.CompassData" Id="T:Xamarin.Essentials.CompassData">
       <Member Id="M:Xamarin.Essentials.CompassData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.CompassData.Equals(System.Object)" />
@@ -210,6 +206,10 @@
       <Member Id="M:Xamarin.Essentials.CompassData.op_Inequality(Xamarin.Essentials.CompassData,Xamarin.Essentials.CompassData)" />
       <Member Id="M:Xamarin.Essentials.CompassData.ToString" />
       <Member Id="P:Xamarin.Essentials.CompassData.HeadingMagneticNorth" />
+    </Type>
+    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
+      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.ConnectionProfile" Id="T:Xamarin.Essentials.ConnectionProfile">
       <Member Id="F:Xamarin.Essentials.ConnectionProfile.Bluetooth" />
@@ -477,10 +477,6 @@
       <Member Id="M:Xamarin.Essentials.Gyroscope.Stop" />
       <Member Id="P:Xamarin.Essentials.Gyroscope.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
-      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.GyroscopeData" Id="T:Xamarin.Essentials.GyroscopeData">
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Single,System.Single,System.Single)" />
@@ -491,6 +487,10 @@
       <Member Id="M:Xamarin.Essentials.GyroscopeData.op_Inequality(Xamarin.Essentials.GyroscopeData,Xamarin.Essentials.GyroscopeData)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.ToString" />
       <Member Id="P:Xamarin.Essentials.GyroscopeData.AngularVelocity" />
+    </Type>
+    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
+      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.HapticFeedback" Id="T:Xamarin.Essentials.HapticFeedback">
       <Member Id="M:Xamarin.Essentials.HapticFeedback.Perform(Xamarin.Essentials.HapticFeedbackType)" />
@@ -548,10 +548,6 @@
       <Member Id="M:Xamarin.Essentials.Magnetometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Magnetometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
-      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.MagnetometerData" Id="T:Xamarin.Essentials.MagnetometerData">
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -562,6 +558,10 @@
       <Member Id="M:Xamarin.Essentials.MagnetometerData.op_Inequality(Xamarin.Essentials.MagnetometerData,Xamarin.Essentials.MagnetometerData)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.MagnetometerData.MagneticField" />
+    </Type>
+    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
+      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.MainThread" Id="T:Xamarin.Essentials.MainThread">
       <Member Id="M:Xamarin.Essentials.MainThread.BeginInvokeOnMainThread(System.Action)" />
@@ -579,6 +579,12 @@
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
     </Type>
     <Type Name="Xamarin.Essentials.MapLaunchOptions" Id="T:Xamarin.Essentials.MapLaunchOptions">
       <Member Id="M:Xamarin.Essentials.MapLaunchOptions.#ctor" />
@@ -628,10 +634,6 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensor.Stop" />
       <Member Id="P:Xamarin.Essentials.OrientationSensor.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
-      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.OrientationSensorData" Id="T:Xamarin.Essentials.OrientationSensorData">
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Double,System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Single,System.Single,System.Single,System.Single)" />
@@ -642,6 +644,10 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.op_Inequality(Xamarin.Essentials.OrientationSensorData,Xamarin.Essentials.OrientationSensorData)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.ToString" />
       <Member Id="P:Xamarin.Essentials.OrientationSensorData.Orientation" />
+    </Type>
+    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
+      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.PermissionException" Id="T:Xamarin.Essentials.PermissionException">
       <Member Id="M:Xamarin.Essentials.PermissionException.#ctor(System.String)" />
@@ -654,15 +660,15 @@
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePermission" Id="T:Xamarin.Essentials.Permissions.BasePermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.ShouldShowRationale" />
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePlatformPermission" Id="T:Xamarin.Essentials.Permissions.BasePlatformPermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.ShouldShowRationale" />
       <Member Id="P:Xamarin.Essentials.Permissions.BasePlatformPermission.RequiredPermissions" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -10,10 +10,6 @@
       <Member Id="M:Xamarin.Essentials.Accelerometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Accelerometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
-      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.AccelerometerData" Id="T:Xamarin.Essentials.AccelerometerData">
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -24,6 +20,10 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.op_Inequality(Xamarin.Essentials.AccelerometerData,Xamarin.Essentials.AccelerometerData)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
+    </Type>
+    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
+      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
       <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
@@ -76,10 +76,6 @@
       <Member Id="M:Xamarin.Essentials.Barometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Barometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
-      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.BarometerData" Id="T:Xamarin.Essentials.BarometerData">
       <Member Id="M:Xamarin.Essentials.BarometerData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.BarometerData.Equals(System.Object)" />
@@ -90,11 +86,15 @@
       <Member Id="M:Xamarin.Essentials.BarometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.BarometerData.PressureInHectopascals" />
     </Type>
+    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
+      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
+    </Type>
     <Type Name="Xamarin.Essentials.Battery" Id="T:Xamarin.Essentials.Battery">
       <Member Id="E:Xamarin.Essentials.Battery.BatteryInfoChanged" />
       <Member Id="E:Xamarin.Essentials.Battery.EnergySaverStatusChanged" />
-      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.EnergySaverStatus" />
+      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.PowerSource" />
       <Member Id="P:Xamarin.Essentials.Battery.State" />
     </Type>
@@ -113,9 +113,9 @@
       <Member Id="F:Xamarin.Essentials.BatteryPowerSource.Wireless" />
     </Type>
     <Type Name="Xamarin.Essentials.BatteryState" Id="T:Xamarin.Essentials.BatteryState">
-      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Discharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Full" />
+      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotCharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotPresent" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Unknown" />
@@ -185,10 +185,6 @@
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
       <Member Id="P:Xamarin.Essentials.Compass.ShouldDisplayHeadingCalibration" />
     </Type>
-    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
-      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.CompassData" Id="T:Xamarin.Essentials.CompassData">
       <Member Id="M:Xamarin.Essentials.CompassData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.CompassData.Equals(System.Object)" />
@@ -198,6 +194,10 @@
       <Member Id="M:Xamarin.Essentials.CompassData.op_Inequality(Xamarin.Essentials.CompassData,Xamarin.Essentials.CompassData)" />
       <Member Id="M:Xamarin.Essentials.CompassData.ToString" />
       <Member Id="P:Xamarin.Essentials.CompassData.HeadingMagneticNorth" />
+    </Type>
+    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
+      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.ConnectionProfile" Id="T:Xamarin.Essentials.ConnectionProfile">
       <Member Id="F:Xamarin.Essentials.ConnectionProfile.Bluetooth" />
@@ -456,10 +456,6 @@
       <Member Id="M:Xamarin.Essentials.Gyroscope.Stop" />
       <Member Id="P:Xamarin.Essentials.Gyroscope.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
-      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.GyroscopeData" Id="T:Xamarin.Essentials.GyroscopeData">
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Single,System.Single,System.Single)" />
@@ -470,6 +466,10 @@
       <Member Id="M:Xamarin.Essentials.GyroscopeData.op_Inequality(Xamarin.Essentials.GyroscopeData,Xamarin.Essentials.GyroscopeData)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.ToString" />
       <Member Id="P:Xamarin.Essentials.GyroscopeData.AngularVelocity" />
+    </Type>
+    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
+      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.HapticFeedback" Id="T:Xamarin.Essentials.HapticFeedback">
       <Member Id="M:Xamarin.Essentials.HapticFeedback.Perform(Xamarin.Essentials.HapticFeedbackType)" />
@@ -527,10 +527,6 @@
       <Member Id="M:Xamarin.Essentials.Magnetometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Magnetometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
-      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.MagnetometerData" Id="T:Xamarin.Essentials.MagnetometerData">
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -541,6 +537,10 @@
       <Member Id="M:Xamarin.Essentials.MagnetometerData.op_Inequality(Xamarin.Essentials.MagnetometerData,Xamarin.Essentials.MagnetometerData)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.MagnetometerData.MagneticField" />
+    </Type>
+    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
+      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.MainThread" Id="T:Xamarin.Essentials.MainThread">
       <Member Id="M:Xamarin.Essentials.MainThread.BeginInvokeOnMainThread(System.Action)" />
@@ -558,6 +558,12 @@
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
     </Type>
     <Type Name="Xamarin.Essentials.MapLaunchOptions" Id="T:Xamarin.Essentials.MapLaunchOptions">
       <Member Id="M:Xamarin.Essentials.MapLaunchOptions.#ctor" />
@@ -607,10 +613,6 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensor.Stop" />
       <Member Id="P:Xamarin.Essentials.OrientationSensor.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
-      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.OrientationSensorData" Id="T:Xamarin.Essentials.OrientationSensorData">
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Double,System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Single,System.Single,System.Single,System.Single)" />
@@ -621,6 +623,10 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.op_Inequality(Xamarin.Essentials.OrientationSensorData,Xamarin.Essentials.OrientationSensorData)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.ToString" />
       <Member Id="P:Xamarin.Essentials.OrientationSensorData.Orientation" />
+    </Type>
+    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
+      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.PermissionException" Id="T:Xamarin.Essentials.PermissionException">
       <Member Id="M:Xamarin.Essentials.PermissionException.#ctor(System.String)" />
@@ -634,15 +640,15 @@
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePermission" Id="T:Xamarin.Essentials.Permissions.BasePermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.ShouldShowRationale" />
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePlatformPermission" Id="T:Xamarin.Essentials.Permissions.BasePlatformPermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.ShouldShowRationale" />
       <Member Id="P:Xamarin.Essentials.Permissions.BasePlatformPermission.RequiredInfoPlistKeys" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-macos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-macos.xml
@@ -10,10 +10,6 @@
       <Member Id="M:Xamarin.Essentials.Accelerometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Accelerometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
-      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.AccelerometerData" Id="T:Xamarin.Essentials.AccelerometerData">
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -24,6 +20,10 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.op_Inequality(Xamarin.Essentials.AccelerometerData,Xamarin.Essentials.AccelerometerData)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
+    </Type>
+    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
+      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
       <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
@@ -76,10 +76,6 @@
       <Member Id="M:Xamarin.Essentials.Barometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Barometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
-      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.BarometerData" Id="T:Xamarin.Essentials.BarometerData">
       <Member Id="M:Xamarin.Essentials.BarometerData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.BarometerData.Equals(System.Object)" />
@@ -90,11 +86,15 @@
       <Member Id="M:Xamarin.Essentials.BarometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.BarometerData.PressureInHectopascals" />
     </Type>
+    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
+      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
+    </Type>
     <Type Name="Xamarin.Essentials.Battery" Id="T:Xamarin.Essentials.Battery">
       <Member Id="E:Xamarin.Essentials.Battery.BatteryInfoChanged" />
       <Member Id="E:Xamarin.Essentials.Battery.EnergySaverStatusChanged" />
-      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.EnergySaverStatus" />
+      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.PowerSource" />
       <Member Id="P:Xamarin.Essentials.Battery.State" />
     </Type>
@@ -113,9 +113,9 @@
       <Member Id="F:Xamarin.Essentials.BatteryPowerSource.Wireless" />
     </Type>
     <Type Name="Xamarin.Essentials.BatteryState" Id="T:Xamarin.Essentials.BatteryState">
-      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Discharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Full" />
+      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotCharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotPresent" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Unknown" />
@@ -184,10 +184,6 @@
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
-      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.CompassData" Id="T:Xamarin.Essentials.CompassData">
       <Member Id="M:Xamarin.Essentials.CompassData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.CompassData.Equals(System.Object)" />
@@ -197,6 +193,10 @@
       <Member Id="M:Xamarin.Essentials.CompassData.op_Inequality(Xamarin.Essentials.CompassData,Xamarin.Essentials.CompassData)" />
       <Member Id="M:Xamarin.Essentials.CompassData.ToString" />
       <Member Id="P:Xamarin.Essentials.CompassData.HeadingMagneticNorth" />
+    </Type>
+    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
+      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.ConnectionProfile" Id="T:Xamarin.Essentials.ConnectionProfile">
       <Member Id="F:Xamarin.Essentials.ConnectionProfile.Bluetooth" />
@@ -455,10 +455,6 @@
       <Member Id="M:Xamarin.Essentials.Gyroscope.Stop" />
       <Member Id="P:Xamarin.Essentials.Gyroscope.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
-      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.GyroscopeData" Id="T:Xamarin.Essentials.GyroscopeData">
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Single,System.Single,System.Single)" />
@@ -469,6 +465,10 @@
       <Member Id="M:Xamarin.Essentials.GyroscopeData.op_Inequality(Xamarin.Essentials.GyroscopeData,Xamarin.Essentials.GyroscopeData)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.ToString" />
       <Member Id="P:Xamarin.Essentials.GyroscopeData.AngularVelocity" />
+    </Type>
+    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
+      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.HapticFeedback" Id="T:Xamarin.Essentials.HapticFeedback">
       <Member Id="M:Xamarin.Essentials.HapticFeedback.Perform(Xamarin.Essentials.HapticFeedbackType)" />
@@ -526,10 +526,6 @@
       <Member Id="M:Xamarin.Essentials.Magnetometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Magnetometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
-      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.MagnetometerData" Id="T:Xamarin.Essentials.MagnetometerData">
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -540,6 +536,10 @@
       <Member Id="M:Xamarin.Essentials.MagnetometerData.op_Inequality(Xamarin.Essentials.MagnetometerData,Xamarin.Essentials.MagnetometerData)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.MagnetometerData.MagneticField" />
+    </Type>
+    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
+      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.MainThread" Id="T:Xamarin.Essentials.MainThread">
       <Member Id="M:Xamarin.Essentials.MainThread.BeginInvokeOnMainThread(System.Action)" />
@@ -557,6 +557,12 @@
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
     </Type>
     <Type Name="Xamarin.Essentials.MapLaunchOptions" Id="T:Xamarin.Essentials.MapLaunchOptions">
       <Member Id="M:Xamarin.Essentials.MapLaunchOptions.#ctor" />
@@ -606,10 +612,6 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensor.Stop" />
       <Member Id="P:Xamarin.Essentials.OrientationSensor.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
-      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.OrientationSensorData" Id="T:Xamarin.Essentials.OrientationSensorData">
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Double,System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Single,System.Single,System.Single,System.Single)" />
@@ -620,6 +622,10 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.op_Inequality(Xamarin.Essentials.OrientationSensorData,Xamarin.Essentials.OrientationSensorData)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.ToString" />
       <Member Id="P:Xamarin.Essentials.OrientationSensorData.Orientation" />
+    </Type>
+    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
+      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.PermissionException" Id="T:Xamarin.Essentials.PermissionException">
       <Member Id="M:Xamarin.Essentials.PermissionException.#ctor(System.String)" />
@@ -633,15 +639,15 @@
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePermission" Id="T:Xamarin.Essentials.Permissions.BasePermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.ShouldShowRationale" />
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePlatformPermission" Id="T:Xamarin.Essentials.Permissions.BasePlatformPermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.ShouldShowRationale" />
       <Member Id="P:Xamarin.Essentials.Permissions.BasePlatformPermission.RecommendedInfoPlistKeys" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
@@ -10,10 +10,6 @@
       <Member Id="M:Xamarin.Essentials.Accelerometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Accelerometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
-      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.AccelerometerData" Id="T:Xamarin.Essentials.AccelerometerData">
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -24,6 +20,10 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.op_Inequality(Xamarin.Essentials.AccelerometerData,Xamarin.Essentials.AccelerometerData)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
+    </Type>
+    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
+      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
       <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
@@ -76,10 +76,6 @@
       <Member Id="M:Xamarin.Essentials.Barometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Barometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
-      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.BarometerData" Id="T:Xamarin.Essentials.BarometerData">
       <Member Id="M:Xamarin.Essentials.BarometerData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.BarometerData.Equals(System.Object)" />
@@ -90,11 +86,15 @@
       <Member Id="M:Xamarin.Essentials.BarometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.BarometerData.PressureInHectopascals" />
     </Type>
+    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
+      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
+    </Type>
     <Type Name="Xamarin.Essentials.Battery" Id="T:Xamarin.Essentials.Battery">
       <Member Id="E:Xamarin.Essentials.Battery.BatteryInfoChanged" />
       <Member Id="E:Xamarin.Essentials.Battery.EnergySaverStatusChanged" />
-      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.EnergySaverStatus" />
+      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.PowerSource" />
       <Member Id="P:Xamarin.Essentials.Battery.State" />
     </Type>
@@ -113,9 +113,9 @@
       <Member Id="F:Xamarin.Essentials.BatteryPowerSource.Wireless" />
     </Type>
     <Type Name="Xamarin.Essentials.BatteryState" Id="T:Xamarin.Essentials.BatteryState">
-      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Discharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Full" />
+      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotCharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotPresent" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Unknown" />
@@ -184,10 +184,6 @@
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
-      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.CompassData" Id="T:Xamarin.Essentials.CompassData">
       <Member Id="M:Xamarin.Essentials.CompassData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.CompassData.Equals(System.Object)" />
@@ -197,6 +193,10 @@
       <Member Id="M:Xamarin.Essentials.CompassData.op_Inequality(Xamarin.Essentials.CompassData,Xamarin.Essentials.CompassData)" />
       <Member Id="M:Xamarin.Essentials.CompassData.ToString" />
       <Member Id="P:Xamarin.Essentials.CompassData.HeadingMagneticNorth" />
+    </Type>
+    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
+      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.ConnectionProfile" Id="T:Xamarin.Essentials.ConnectionProfile">
       <Member Id="F:Xamarin.Essentials.ConnectionProfile.Bluetooth" />
@@ -455,10 +455,6 @@
       <Member Id="M:Xamarin.Essentials.Gyroscope.Stop" />
       <Member Id="P:Xamarin.Essentials.Gyroscope.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
-      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.GyroscopeData" Id="T:Xamarin.Essentials.GyroscopeData">
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Single,System.Single,System.Single)" />
@@ -469,6 +465,10 @@
       <Member Id="M:Xamarin.Essentials.GyroscopeData.op_Inequality(Xamarin.Essentials.GyroscopeData,Xamarin.Essentials.GyroscopeData)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.ToString" />
       <Member Id="P:Xamarin.Essentials.GyroscopeData.AngularVelocity" />
+    </Type>
+    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
+      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.HapticFeedback" Id="T:Xamarin.Essentials.HapticFeedback">
       <Member Id="M:Xamarin.Essentials.HapticFeedback.Perform(Xamarin.Essentials.HapticFeedbackType)" />
@@ -526,10 +526,6 @@
       <Member Id="M:Xamarin.Essentials.Magnetometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Magnetometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
-      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.MagnetometerData" Id="T:Xamarin.Essentials.MagnetometerData">
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -540,6 +536,10 @@
       <Member Id="M:Xamarin.Essentials.MagnetometerData.op_Inequality(Xamarin.Essentials.MagnetometerData,Xamarin.Essentials.MagnetometerData)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.MagnetometerData.MagneticField" />
+    </Type>
+    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
+      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.MainThread" Id="T:Xamarin.Essentials.MainThread">
       <Member Id="M:Xamarin.Essentials.MainThread.BeginInvokeOnMainThread(System.Action)" />
@@ -557,6 +557,12 @@
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
     </Type>
     <Type Name="Xamarin.Essentials.MapLaunchOptions" Id="T:Xamarin.Essentials.MapLaunchOptions">
       <Member Id="M:Xamarin.Essentials.MapLaunchOptions.#ctor" />
@@ -606,10 +612,6 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensor.Stop" />
       <Member Id="P:Xamarin.Essentials.OrientationSensor.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
-      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.OrientationSensorData" Id="T:Xamarin.Essentials.OrientationSensorData">
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Double,System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Single,System.Single,System.Single,System.Single)" />
@@ -620,6 +622,10 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.op_Inequality(Xamarin.Essentials.OrientationSensorData,Xamarin.Essentials.OrientationSensorData)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.ToString" />
       <Member Id="P:Xamarin.Essentials.OrientationSensorData.Orientation" />
+    </Type>
+    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
+      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.PermissionException" Id="T:Xamarin.Essentials.PermissionException">
       <Member Id="M:Xamarin.Essentials.PermissionException.#ctor(System.String)" />
@@ -633,15 +639,15 @@
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePermission" Id="T:Xamarin.Essentials.Permissions.BasePermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.ShouldShowRationale" />
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePlatformPermission" Id="T:Xamarin.Essentials.Permissions.BasePlatformPermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.ShouldShowRationale" />
       <Member Id="P:Xamarin.Essentials.Permissions.BasePlatformPermission.RequiredInfoPlistKeys" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -10,10 +10,6 @@
       <Member Id="M:Xamarin.Essentials.Accelerometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Accelerometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
-      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.AccelerometerData" Id="T:Xamarin.Essentials.AccelerometerData">
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -24,6 +20,10 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.op_Inequality(Xamarin.Essentials.AccelerometerData,Xamarin.Essentials.AccelerometerData)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
+    </Type>
+    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
+      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
       <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
@@ -78,10 +78,6 @@
       <Member Id="M:Xamarin.Essentials.Barometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Barometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
-      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.BarometerData" Id="T:Xamarin.Essentials.BarometerData">
       <Member Id="M:Xamarin.Essentials.BarometerData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.BarometerData.Equals(System.Object)" />
@@ -92,11 +88,15 @@
       <Member Id="M:Xamarin.Essentials.BarometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.BarometerData.PressureInHectopascals" />
     </Type>
+    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
+      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
+    </Type>
     <Type Name="Xamarin.Essentials.Battery" Id="T:Xamarin.Essentials.Battery">
       <Member Id="E:Xamarin.Essentials.Battery.BatteryInfoChanged" />
       <Member Id="E:Xamarin.Essentials.Battery.EnergySaverStatusChanged" />
-      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.EnergySaverStatus" />
+      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.PowerSource" />
       <Member Id="P:Xamarin.Essentials.Battery.State" />
     </Type>
@@ -115,9 +115,9 @@
       <Member Id="F:Xamarin.Essentials.BatteryPowerSource.Wireless" />
     </Type>
     <Type Name="Xamarin.Essentials.BatteryState" Id="T:Xamarin.Essentials.BatteryState">
-      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Discharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Full" />
+      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotCharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotPresent" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Unknown" />
@@ -186,10 +186,6 @@
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
-      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.CompassData" Id="T:Xamarin.Essentials.CompassData">
       <Member Id="M:Xamarin.Essentials.CompassData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.CompassData.Equals(System.Object)" />
@@ -199,6 +195,10 @@
       <Member Id="M:Xamarin.Essentials.CompassData.op_Inequality(Xamarin.Essentials.CompassData,Xamarin.Essentials.CompassData)" />
       <Member Id="M:Xamarin.Essentials.CompassData.ToString" />
       <Member Id="P:Xamarin.Essentials.CompassData.HeadingMagneticNorth" />
+    </Type>
+    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
+      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.ConnectionProfile" Id="T:Xamarin.Essentials.ConnectionProfile">
       <Member Id="F:Xamarin.Essentials.ConnectionProfile.Bluetooth" />
@@ -457,10 +457,6 @@
       <Member Id="M:Xamarin.Essentials.Gyroscope.Stop" />
       <Member Id="P:Xamarin.Essentials.Gyroscope.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
-      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.GyroscopeData" Id="T:Xamarin.Essentials.GyroscopeData">
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Single,System.Single,System.Single)" />
@@ -471,6 +467,10 @@
       <Member Id="M:Xamarin.Essentials.GyroscopeData.op_Inequality(Xamarin.Essentials.GyroscopeData,Xamarin.Essentials.GyroscopeData)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.ToString" />
       <Member Id="P:Xamarin.Essentials.GyroscopeData.AngularVelocity" />
+    </Type>
+    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
+      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.HapticFeedback" Id="T:Xamarin.Essentials.HapticFeedback">
       <Member Id="M:Xamarin.Essentials.HapticFeedback.Perform(Xamarin.Essentials.HapticFeedbackType)" />
@@ -528,10 +528,6 @@
       <Member Id="M:Xamarin.Essentials.Magnetometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Magnetometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
-      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.MagnetometerData" Id="T:Xamarin.Essentials.MagnetometerData">
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -542,6 +538,10 @@
       <Member Id="M:Xamarin.Essentials.MagnetometerData.op_Inequality(Xamarin.Essentials.MagnetometerData,Xamarin.Essentials.MagnetometerData)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.MagnetometerData.MagneticField" />
+    </Type>
+    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
+      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.MainThread" Id="T:Xamarin.Essentials.MainThread">
       <Member Id="M:Xamarin.Essentials.MainThread.BeginInvokeOnMainThread(System.Action)" />
@@ -559,6 +559,12 @@
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
     </Type>
     <Type Name="Xamarin.Essentials.MapLaunchOptions" Id="T:Xamarin.Essentials.MapLaunchOptions">
       <Member Id="M:Xamarin.Essentials.MapLaunchOptions.#ctor" />
@@ -608,10 +614,6 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensor.Stop" />
       <Member Id="P:Xamarin.Essentials.OrientationSensor.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
-      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.OrientationSensorData" Id="T:Xamarin.Essentials.OrientationSensorData">
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Double,System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Single,System.Single,System.Single,System.Single)" />
@@ -622,6 +624,10 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.op_Inequality(Xamarin.Essentials.OrientationSensorData,Xamarin.Essentials.OrientationSensorData)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.ToString" />
       <Member Id="P:Xamarin.Essentials.OrientationSensorData.Orientation" />
+    </Type>
+    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
+      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.PermissionException" Id="T:Xamarin.Essentials.PermissionException">
       <Member Id="M:Xamarin.Essentials.PermissionException.#ctor(System.String)" />
@@ -634,15 +640,15 @@
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePermission" Id="T:Xamarin.Essentials.Permissions.BasePermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.ShouldShowRationale" />
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePlatformPermission" Id="T:Xamarin.Essentials.Permissions.BasePlatformPermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.ShouldShowRationale" />
       <Member Id="P:Xamarin.Essentials.Permissions.BasePlatformPermission.RequiredDeclarations" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
@@ -10,10 +10,6 @@
       <Member Id="M:Xamarin.Essentials.Accelerometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Accelerometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
-      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.AccelerometerData" Id="T:Xamarin.Essentials.AccelerometerData">
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -24,6 +20,10 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.op_Inequality(Xamarin.Essentials.AccelerometerData,Xamarin.Essentials.AccelerometerData)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
+    </Type>
+    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
+      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
       <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
@@ -76,10 +76,6 @@
       <Member Id="M:Xamarin.Essentials.Barometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Barometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
-      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.BarometerData" Id="T:Xamarin.Essentials.BarometerData">
       <Member Id="M:Xamarin.Essentials.BarometerData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.BarometerData.Equals(System.Object)" />
@@ -90,11 +86,15 @@
       <Member Id="M:Xamarin.Essentials.BarometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.BarometerData.PressureInHectopascals" />
     </Type>
+    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
+      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
+    </Type>
     <Type Name="Xamarin.Essentials.Battery" Id="T:Xamarin.Essentials.Battery">
       <Member Id="E:Xamarin.Essentials.Battery.BatteryInfoChanged" />
       <Member Id="E:Xamarin.Essentials.Battery.EnergySaverStatusChanged" />
-      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.EnergySaverStatus" />
+      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.PowerSource" />
       <Member Id="P:Xamarin.Essentials.Battery.State" />
     </Type>
@@ -113,9 +113,9 @@
       <Member Id="F:Xamarin.Essentials.BatteryPowerSource.Wireless" />
     </Type>
     <Type Name="Xamarin.Essentials.BatteryState" Id="T:Xamarin.Essentials.BatteryState">
-      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Discharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Full" />
+      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotCharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotPresent" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Unknown" />
@@ -184,10 +184,6 @@
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
-      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.CompassData" Id="T:Xamarin.Essentials.CompassData">
       <Member Id="M:Xamarin.Essentials.CompassData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.CompassData.Equals(System.Object)" />
@@ -197,6 +193,10 @@
       <Member Id="M:Xamarin.Essentials.CompassData.op_Inequality(Xamarin.Essentials.CompassData,Xamarin.Essentials.CompassData)" />
       <Member Id="M:Xamarin.Essentials.CompassData.ToString" />
       <Member Id="P:Xamarin.Essentials.CompassData.HeadingMagneticNorth" />
+    </Type>
+    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
+      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.ConnectionProfile" Id="T:Xamarin.Essentials.ConnectionProfile">
       <Member Id="F:Xamarin.Essentials.ConnectionProfile.Bluetooth" />
@@ -455,10 +455,6 @@
       <Member Id="M:Xamarin.Essentials.Gyroscope.Stop" />
       <Member Id="P:Xamarin.Essentials.Gyroscope.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
-      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.GyroscopeData" Id="T:Xamarin.Essentials.GyroscopeData">
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Single,System.Single,System.Single)" />
@@ -469,6 +465,10 @@
       <Member Id="M:Xamarin.Essentials.GyroscopeData.op_Inequality(Xamarin.Essentials.GyroscopeData,Xamarin.Essentials.GyroscopeData)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.ToString" />
       <Member Id="P:Xamarin.Essentials.GyroscopeData.AngularVelocity" />
+    </Type>
+    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
+      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.HapticFeedback" Id="T:Xamarin.Essentials.HapticFeedback">
       <Member Id="M:Xamarin.Essentials.HapticFeedback.Perform(Xamarin.Essentials.HapticFeedbackType)" />
@@ -526,10 +526,6 @@
       <Member Id="M:Xamarin.Essentials.Magnetometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Magnetometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
-      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.MagnetometerData" Id="T:Xamarin.Essentials.MagnetometerData">
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -540,6 +536,10 @@
       <Member Id="M:Xamarin.Essentials.MagnetometerData.op_Inequality(Xamarin.Essentials.MagnetometerData,Xamarin.Essentials.MagnetometerData)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.MagnetometerData.MagneticField" />
+    </Type>
+    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
+      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.MainThread" Id="T:Xamarin.Essentials.MainThread">
       <Member Id="M:Xamarin.Essentials.MainThread.BeginInvokeOnMainThread(System.Action)" />
@@ -557,6 +557,12 @@
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
     </Type>
     <Type Name="Xamarin.Essentials.MapLaunchOptions" Id="T:Xamarin.Essentials.MapLaunchOptions">
       <Member Id="M:Xamarin.Essentials.MapLaunchOptions.#ctor" />
@@ -606,10 +612,6 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensor.Stop" />
       <Member Id="P:Xamarin.Essentials.OrientationSensor.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
-      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.OrientationSensorData" Id="T:Xamarin.Essentials.OrientationSensorData">
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Double,System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Single,System.Single,System.Single,System.Single)" />
@@ -620,6 +622,10 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.op_Inequality(Xamarin.Essentials.OrientationSensorData,Xamarin.Essentials.OrientationSensorData)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.ToString" />
       <Member Id="P:Xamarin.Essentials.OrientationSensorData.Orientation" />
+    </Type>
+    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
+      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.PermissionException" Id="T:Xamarin.Essentials.PermissionException">
       <Member Id="M:Xamarin.Essentials.PermissionException.#ctor(System.String)" />
@@ -633,15 +639,15 @@
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePermission" Id="T:Xamarin.Essentials.Permissions.BasePermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.ShouldShowRationale" />
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePlatformPermission" Id="T:Xamarin.Essentials.Permissions.BasePlatformPermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.ShouldShowRationale" />
       <Member Id="P:Xamarin.Essentials.Permissions.BasePlatformPermission.RequiredInfoPlistKeys" />

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -10,10 +10,6 @@
       <Member Id="M:Xamarin.Essentials.Accelerometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Accelerometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
-      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.AccelerometerData" Id="T:Xamarin.Essentials.AccelerometerData">
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -24,6 +20,10 @@
       <Member Id="M:Xamarin.Essentials.AccelerometerData.op_Inequality(Xamarin.Essentials.AccelerometerData,Xamarin.Essentials.AccelerometerData)" />
       <Member Id="M:Xamarin.Essentials.AccelerometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.AccelerometerData.Acceleration" />
+    </Type>
+    <Type Name="Xamarin.Essentials.AccelerometerChangedEventArgs" Id="T:Xamarin.Essentials.AccelerometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.AccelerometerChangedEventArgs.#ctor(Xamarin.Essentials.AccelerometerData)" />
+      <Member Id="P:Xamarin.Essentials.AccelerometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.AltitudeReferenceSystem" Id="T:Xamarin.Essentials.AltitudeReferenceSystem">
       <Member Id="F:Xamarin.Essentials.AltitudeReferenceSystem.Ellipsoid" />
@@ -76,10 +76,6 @@
       <Member Id="M:Xamarin.Essentials.Barometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Barometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
-      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.BarometerData" Id="T:Xamarin.Essentials.BarometerData">
       <Member Id="M:Xamarin.Essentials.BarometerData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.BarometerData.Equals(System.Object)" />
@@ -90,11 +86,15 @@
       <Member Id="M:Xamarin.Essentials.BarometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.BarometerData.PressureInHectopascals" />
     </Type>
+    <Type Name="Xamarin.Essentials.BarometerChangedEventArgs" Id="T:Xamarin.Essentials.BarometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.BarometerChangedEventArgs.#ctor(Xamarin.Essentials.BarometerData)" />
+      <Member Id="P:Xamarin.Essentials.BarometerChangedEventArgs.Reading" />
+    </Type>
     <Type Name="Xamarin.Essentials.Battery" Id="T:Xamarin.Essentials.Battery">
       <Member Id="E:Xamarin.Essentials.Battery.BatteryInfoChanged" />
       <Member Id="E:Xamarin.Essentials.Battery.EnergySaverStatusChanged" />
-      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.EnergySaverStatus" />
+      <Member Id="P:Xamarin.Essentials.Battery.ChargeLevel" />
       <Member Id="P:Xamarin.Essentials.Battery.PowerSource" />
       <Member Id="P:Xamarin.Essentials.Battery.State" />
     </Type>
@@ -113,9 +113,9 @@
       <Member Id="F:Xamarin.Essentials.BatteryPowerSource.Wireless" />
     </Type>
     <Type Name="Xamarin.Essentials.BatteryState" Id="T:Xamarin.Essentials.BatteryState">
-      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Discharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Full" />
+      <Member Id="F:Xamarin.Essentials.BatteryState.Charging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotCharging" />
       <Member Id="F:Xamarin.Essentials.BatteryState.NotPresent" />
       <Member Id="F:Xamarin.Essentials.BatteryState.Unknown" />
@@ -183,10 +183,6 @@
       <Member Id="M:Xamarin.Essentials.Compass.Stop" />
       <Member Id="P:Xamarin.Essentials.Compass.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
-      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.CompassData" Id="T:Xamarin.Essentials.CompassData">
       <Member Id="M:Xamarin.Essentials.CompassData.#ctor(System.Double)" />
       <Member Id="M:Xamarin.Essentials.CompassData.Equals(System.Object)" />
@@ -196,6 +192,10 @@
       <Member Id="M:Xamarin.Essentials.CompassData.op_Inequality(Xamarin.Essentials.CompassData,Xamarin.Essentials.CompassData)" />
       <Member Id="M:Xamarin.Essentials.CompassData.ToString" />
       <Member Id="P:Xamarin.Essentials.CompassData.HeadingMagneticNorth" />
+    </Type>
+    <Type Name="Xamarin.Essentials.CompassChangedEventArgs" Id="T:Xamarin.Essentials.CompassChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.CompassChangedEventArgs.#ctor(Xamarin.Essentials.CompassData)" />
+      <Member Id="P:Xamarin.Essentials.CompassChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.ConnectionProfile" Id="T:Xamarin.Essentials.ConnectionProfile">
       <Member Id="F:Xamarin.Essentials.ConnectionProfile.Bluetooth" />
@@ -454,10 +454,6 @@
       <Member Id="M:Xamarin.Essentials.Gyroscope.Stop" />
       <Member Id="P:Xamarin.Essentials.Gyroscope.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
-      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.GyroscopeData" Id="T:Xamarin.Essentials.GyroscopeData">
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.#ctor(System.Single,System.Single,System.Single)" />
@@ -468,6 +464,10 @@
       <Member Id="M:Xamarin.Essentials.GyroscopeData.op_Inequality(Xamarin.Essentials.GyroscopeData,Xamarin.Essentials.GyroscopeData)" />
       <Member Id="M:Xamarin.Essentials.GyroscopeData.ToString" />
       <Member Id="P:Xamarin.Essentials.GyroscopeData.AngularVelocity" />
+    </Type>
+    <Type Name="Xamarin.Essentials.GyroscopeChangedEventArgs" Id="T:Xamarin.Essentials.GyroscopeChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.GyroscopeChangedEventArgs.#ctor(Xamarin.Essentials.GyroscopeData)" />
+      <Member Id="P:Xamarin.Essentials.GyroscopeChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.HapticFeedback" Id="T:Xamarin.Essentials.HapticFeedback">
       <Member Id="M:Xamarin.Essentials.HapticFeedback.Perform(Xamarin.Essentials.HapticFeedbackType)" />
@@ -525,10 +525,6 @@
       <Member Id="M:Xamarin.Essentials.Magnetometer.Stop" />
       <Member Id="P:Xamarin.Essentials.Magnetometer.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
-      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.MagnetometerData" Id="T:Xamarin.Essentials.MagnetometerData">
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.#ctor(System.Single,System.Single,System.Single)" />
@@ -539,6 +535,10 @@
       <Member Id="M:Xamarin.Essentials.MagnetometerData.op_Inequality(Xamarin.Essentials.MagnetometerData,Xamarin.Essentials.MagnetometerData)" />
       <Member Id="M:Xamarin.Essentials.MagnetometerData.ToString" />
       <Member Id="P:Xamarin.Essentials.MagnetometerData.MagneticField" />
+    </Type>
+    <Type Name="Xamarin.Essentials.MagnetometerChangedEventArgs" Id="T:Xamarin.Essentials.MagnetometerChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.MagnetometerChangedEventArgs.#ctor(Xamarin.Essentials.MagnetometerData)" />
+      <Member Id="P:Xamarin.Essentials.MagnetometerChangedEventArgs.Reading" />
     </Type>
     <Type Name="Xamarin.Essentials.MainThread" Id="T:Xamarin.Essentials.MainThread">
       <Member Id="M:Xamarin.Essentials.MainThread.BeginInvokeOnMainThread(System.Action)" />
@@ -556,6 +556,12 @@
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark)" />
       <Member Id="M:Xamarin.Essentials.Map.OpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark)" />
+      <Member Id="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
     </Type>
     <Type Name="Xamarin.Essentials.MapLaunchOptions" Id="T:Xamarin.Essentials.MapLaunchOptions">
       <Member Id="M:Xamarin.Essentials.MapLaunchOptions.#ctor" />
@@ -605,10 +611,6 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensor.Stop" />
       <Member Id="P:Xamarin.Essentials.OrientationSensor.IsMonitoring" />
     </Type>
-    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
-      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
-      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
-    </Type>
     <Type Name="Xamarin.Essentials.OrientationSensorData" Id="T:Xamarin.Essentials.OrientationSensorData">
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Double,System.Double,System.Double,System.Double)" />
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.#ctor(System.Single,System.Single,System.Single,System.Single)" />
@@ -620,6 +622,10 @@
       <Member Id="M:Xamarin.Essentials.OrientationSensorData.ToString" />
       <Member Id="P:Xamarin.Essentials.OrientationSensorData.Orientation" />
     </Type>
+    <Type Name="Xamarin.Essentials.OrientationSensorChangedEventArgs" Id="T:Xamarin.Essentials.OrientationSensorChangedEventArgs">
+      <Member Id="M:Xamarin.Essentials.OrientationSensorChangedEventArgs.#ctor(Xamarin.Essentials.OrientationSensorData)" />
+      <Member Id="P:Xamarin.Essentials.OrientationSensorChangedEventArgs.Reading" />
+    </Type>
     <Type Name="Xamarin.Essentials.PermissionException" Id="T:Xamarin.Essentials.PermissionException">
       <Member Id="M:Xamarin.Essentials.PermissionException.#ctor(System.String)" />
     </Type>
@@ -630,15 +636,15 @@
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePermission" Id="T:Xamarin.Essentials.Permissions.BasePermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePermission.ShouldShowRationale" />
     </Type>
     <Type Name="Xamarin.Essentials.Permissions/BasePlatformPermission" Id="T:Xamarin.Essentials.Permissions.BasePlatformPermission">
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.#ctor" />
-      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.EnsureDeclared" />
+      <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.CheckStatusAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.RequestAsync" />
       <Member Id="M:Xamarin.Essentials.Permissions.BasePlatformPermission.ShouldShowRationale" />
     </Type>

--- a/docs/en/Xamarin.Essentials/Battery.xml
+++ b/docs/en/Xamarin.Essentials/Battery.xml
@@ -37,26 +37,6 @@
         <remarks></remarks>
       </Docs>
     </Member>
-    <Member MemberName="ChargeLevel">
-      <MemberSignature Language="C#" Value="public static double ChargeLevel { get; }" />
-      <MemberSignature Language="ILAsm" Value=".property float64 ChargeLevel" />
-      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.Battery.ChargeLevel" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Double</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>Gets the current charge level of the device from 0.0 to 1.0.</summary>
-        <value>
-          <para>Level of charge. Returns -1 if no battery exists.</para>
-        </value>
-        <remarks></remarks>
-      </Docs>
-    </Member>
     <Member MemberName="EnergySaverStatus">
       <MemberSignature Language="C#" Value="public static Xamarin.Essentials.EnergySaverStatus EnergySaverStatus { get; }" />
       <MemberSignature Language="ILAsm" Value=".property valuetype Xamarin.Essentials.EnergySaverStatus EnergySaverStatus" />
@@ -89,6 +69,26 @@
       </ReturnValue>
       <Docs>
         <summary>Event that is triggered when energy saver status changes.</summary>
+        <remarks></remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ChargeLevel">
+      <MemberSignature Language="C#" Value="public static double ChargeLevel { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property float64 ChargeLevel" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.Battery.ChargeLevel" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the current charge level of the device from 0.0 to 1.0.</summary>
+        <value>
+          <para>Level of charge. Returns -1 if no battery exists.</para>
+        </value>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/docs/en/Xamarin.Essentials/BatteryState.xml
+++ b/docs/en/Xamarin.Essentials/BatteryState.xml
@@ -14,23 +14,6 @@
     <remarks></remarks>
   </Docs>
   <Members>
-    <Member MemberName="Charging">
-      <MemberSignature Language="C#" Value="Charging" />
-      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Essentials.BatteryState Charging = int32(1)" />
-      <MemberSignature Language="DocId" Value="F:Xamarin.Essentials.BatteryState.Charging" />
-      <MemberType>Field</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>Xamarin.Essentials.BatteryState</ReturnType>
-      </ReturnValue>
-      <MemberValue>1</MemberValue>
-      <Docs>
-        <summary>Battery is acively being charged by a power source.</summary>
-      </Docs>
-    </Member>
     <Member MemberName="Discharging">
       <MemberSignature Language="C#" Value="Discharging" />
       <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Essentials.BatteryState Discharging = int32(2)" />
@@ -63,6 +46,23 @@
       <MemberValue>3</MemberValue>
       <Docs>
         <summary>Battery is full.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Charging">
+      <MemberSignature Language="C#" Value="Charging" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Xamarin.Essentials.BatteryState Charging = int32(1)" />
+      <MemberSignature Language="DocId" Value="F:Xamarin.Essentials.BatteryState.Charging" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Xamarin.Essentials.BatteryState</ReturnType>
+      </ReturnValue>
+      <MemberValue>1</MemberValue>
+      <Docs>
+        <summary>Battery is acively being charged by a power source.</summary>
       </Docs>
     </Member>
     <Member MemberName="NotCharging">

--- a/docs/en/Xamarin.Essentials/Map.xml
+++ b/docs/en/Xamarin.Essentials/Map.xml
@@ -157,5 +157,147 @@
         <remarks></remarks>
       </Docs>
     </Member>
+    <Member MemberName="TryOpenAsync">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task&lt;bool&gt; TryOpenAsync (Xamarin.Essentials.Location location);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task`1&lt;bool&gt; TryOpenAsync(class Xamarin.Essentials.Location location) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task&lt;System.Boolean&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="location" Type="Xamarin.Essentials.Location" />
+      </Parameters>
+      <Docs>
+        <param name="location">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TryOpenAsync">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task&lt;bool&gt; TryOpenAsync (Xamarin.Essentials.Placemark placemark);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task`1&lt;bool&gt; TryOpenAsync(class Xamarin.Essentials.Placemark placemark) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task&lt;System.Boolean&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="placemark" Type="Xamarin.Essentials.Placemark" />
+      </Parameters>
+      <Docs>
+        <param name="placemark">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TryOpenAsync">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task&lt;bool&gt; TryOpenAsync (double latitude, double longitude);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task`1&lt;bool&gt; TryOpenAsync(float64 latitude, float64 longitude) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task&lt;System.Boolean&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="latitude" Type="System.Double" />
+        <Parameter Name="longitude" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="latitude">To be added.</param>
+        <param name="longitude">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TryOpenAsync">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task&lt;bool&gt; TryOpenAsync (Xamarin.Essentials.Location location, Xamarin.Essentials.MapLaunchOptions options);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task`1&lt;bool&gt; TryOpenAsync(class Xamarin.Essentials.Location location, class Xamarin.Essentials.MapLaunchOptions options) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Location,Xamarin.Essentials.MapLaunchOptions)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task&lt;System.Boolean&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="location" Type="Xamarin.Essentials.Location" />
+        <Parameter Name="options" Type="Xamarin.Essentials.MapLaunchOptions" />
+      </Parameters>
+      <Docs>
+        <param name="location">To be added.</param>
+        <param name="options">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TryOpenAsync">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task&lt;bool&gt; TryOpenAsync (Xamarin.Essentials.Placemark placemark, Xamarin.Essentials.MapLaunchOptions options);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task`1&lt;bool&gt; TryOpenAsync(class Xamarin.Essentials.Placemark placemark, class Xamarin.Essentials.MapLaunchOptions options) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Map.TryOpenAsync(Xamarin.Essentials.Placemark,Xamarin.Essentials.MapLaunchOptions)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task&lt;System.Boolean&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="placemark" Type="Xamarin.Essentials.Placemark" />
+        <Parameter Name="options" Type="Xamarin.Essentials.MapLaunchOptions" />
+      </Parameters>
+      <Docs>
+        <param name="placemark">To be added.</param>
+        <param name="options">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TryOpenAsync">
+      <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task&lt;bool&gt; TryOpenAsync (double latitude, double longitude, Xamarin.Essentials.MapLaunchOptions options);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task`1&lt;bool&gt; TryOpenAsync(float64 latitude, float64 longitude, class Xamarin.Essentials.MapLaunchOptions options) cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Map.TryOpenAsync(System.Double,System.Double,Xamarin.Essentials.MapLaunchOptions)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Threading.Tasks.Task&lt;System.Boolean&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="latitude" Type="System.Double" />
+        <Parameter Name="longitude" Type="System.Double" />
+        <Parameter Name="options" Type="Xamarin.Essentials.MapLaunchOptions" />
+      </Parameters>
+      <Docs>
+        <param name="latitude">To be added.</param>
+        <param name="longitude">To be added.</param>
+        <param name="options">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>

--- a/docs/en/Xamarin.Essentials/Permissions+BasePermission.xml
+++ b/docs/en/Xamarin.Essentials/Permissions+BasePermission.xml
@@ -30,6 +30,24 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="EnsureDeclared">
+      <MemberSignature Language="C#" Value="public abstract void EnsureDeclared ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void EnsureDeclared() cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Permissions.BasePermission.EnsureDeclared" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>Ensures that all permissions are decalred.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="CheckStatusAsync">
       <MemberSignature Language="C#" Value="public abstract System.Threading.Tasks.Task&lt;Xamarin.Essentials.PermissionStatus&gt; CheckStatusAsync ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class System.Threading.Tasks.Task`1&lt;valuetype Xamarin.Essentials.PermissionStatus&gt; CheckStatusAsync() cil managed" />
@@ -48,24 +66,6 @@
           <para>Checks the status of a specific permission.</para>
         </summary>
         <returns>The current status of the permission.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="EnsureDeclared">
-      <MemberSignature Language="C#" Value="public abstract void EnsureDeclared ();" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void EnsureDeclared() cil managed" />
-      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Permissions.BasePermission.EnsureDeclared" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>Ensures that all permissions are decalred.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/en/Xamarin.Essentials/Permissions+BasePlatformPermission.xml
+++ b/docs/en/Xamarin.Essentials/Permissions+BasePlatformPermission.xml
@@ -32,6 +32,24 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="EnsureDeclared">
+      <MemberSignature Language="C#" Value="public override void EnsureDeclared ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance void EnsureDeclared() cil managed" />
+      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Permissions.BasePlatformPermission.EnsureDeclared" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>Ensures that all permissions are declared.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="CheckStatusAsync">
       <MemberSignature Language="C#" Value="public override System.Threading.Tasks.Task&lt;Xamarin.Essentials.PermissionStatus&gt; CheckStatusAsync ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance class System.Threading.Tasks.Task`1&lt;valuetype Xamarin.Essentials.PermissionStatus&gt; CheckStatusAsync() cil managed" />
@@ -48,24 +66,6 @@
       <Docs>
         <summary>Checks the status of a specific permission.</summary>
         <returns>The current status of the permission.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="EnsureDeclared">
-      <MemberSignature Language="C#" Value="public override void EnsureDeclared ();" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance void EnsureDeclared() cil managed" />
-      <MemberSignature Language="DocId" Value="M:Xamarin.Essentials.Permissions.BasePlatformPermission.EnsureDeclared" />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>Xamarin.Essentials</AssemblyName>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.Void</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>Ensures that all permissions are declared.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/docs/en/index.xml
+++ b/docs/en/index.xml
@@ -99,10 +99,7 @@
           <AttributeName>System.Runtime.Versioning.TargetFramework("Xamarin.Mac,Version=v2.0", FrameworkDisplayName="Xamarin.Mac")</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/xamarin/Essentials")</AttributeName>
-        </Attribute>
-        <Attribute>
-          <AttributeName>System.Reflection.AssemblyInformationalVersion("1.0.0+2fb7c9ee75e244e990677fa4ef85bbfd730a97e7")</AttributeName>
+          <AttributeName>System.Reflection.AssemblyInformationalVersion("1.0.0+6c80e921dfbb590a599bd3e45675ca7510c25f7c")</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
@@ -112,8 +109,8 @@
   <Types>
     <Namespace Name="Xamarin.Essentials">
       <Type Name="Accelerometer" Kind="Class" />
-      <Type Name="AccelerometerChangedEventArgs" Kind="Class" />
       <Type Name="AccelerometerData" Kind="Structure" />
+      <Type Name="AccelerometerChangedEventArgs" Kind="Class" />
       <Type Name="ActivityState" Kind="Enumeration" />
       <Type Name="ActivityStateChangedEventArgs" Kind="Class" />
       <Type Name="AltitudeReferenceSystem" Kind="Enumeration" />
@@ -125,8 +122,8 @@
       <Type Name="AppleSignInAuthenticator+Options" Kind="Class" />
       <Type Name="AppTheme" Kind="Enumeration" />
       <Type Name="Barometer" Kind="Class" />
-      <Type Name="BarometerChangedEventArgs" Kind="Class" />
       <Type Name="BarometerData" Kind="Structure" />
+      <Type Name="BarometerChangedEventArgs" Kind="Class" />
       <Type Name="Battery" Kind="Class" />
       <Type Name="BatteryInfoChangedEventArgs" Kind="Class" />
       <Type Name="BatteryPowerSource" Kind="Enumeration" />
@@ -140,8 +137,8 @@
       <Type Name="ColorConverters" Kind="Class" />
       <Type Name="ColorExtensions" Kind="Class" />
       <Type Name="Compass" Kind="Class" />
-      <Type Name="CompassChangedEventArgs" Kind="Class" />
       <Type Name="CompassData" Kind="Structure" />
+      <Type Name="CompassChangedEventArgs" Kind="Class" />
       <Type Name="ConnectionProfile" Kind="Enumeration" />
       <Type Name="Connectivity" Kind="Class" />
       <Type Name="ConnectivityChangedEventArgs" Kind="Class" />
@@ -181,8 +178,8 @@
       <Type Name="GeolocationAccuracy" Kind="Enumeration" />
       <Type Name="GeolocationRequest" Kind="Class" />
       <Type Name="Gyroscope" Kind="Class" />
-      <Type Name="GyroscopeChangedEventArgs" Kind="Class" />
       <Type Name="GyroscopeData" Kind="Structure" />
+      <Type Name="GyroscopeChangedEventArgs" Kind="Class" />
       <Type Name="HapticFeedback" Kind="Class" />
       <Type Name="HapticFeedbackType" Kind="Enumeration" />
       <Type Name="Launcher" Kind="Class" />
@@ -190,8 +187,8 @@
       <Type Name="Location" Kind="Class" />
       <Type Name="LocationExtensions" Kind="Class" />
       <Type Name="Magnetometer" Kind="Class" />
-      <Type Name="MagnetometerChangedEventArgs" Kind="Class" />
       <Type Name="MagnetometerData" Kind="Structure" />
+      <Type Name="MagnetometerChangedEventArgs" Kind="Class" />
       <Type Name="MainThread" Kind="Class" />
       <Type Name="Map" Kind="Class" />
       <Type Name="MapLaunchOptions" Kind="Class" />
@@ -202,8 +199,8 @@
       <Type Name="NotImplementedInReferenceAssemblyException" Kind="Class" />
       <Type Name="OpenFileRequest" Kind="Class" />
       <Type Name="OrientationSensor" Kind="Class" />
-      <Type Name="OrientationSensorChangedEventArgs" Kind="Class" />
       <Type Name="OrientationSensorData" Kind="Structure" />
+      <Type Name="OrientationSensorChangedEventArgs" Kind="Class" />
       <Type Name="PermissionException" Kind="Class" />
       <Type Name="Permissions" Kind="Class" />
       <Type Name="Permissions+BasePermission" Kind="Class" />


### PR DESCRIPTION
### Description of Change ###

- Added Map.TryOpenAsync method for every Map.OpenAsync.
- I also did some refactoring of this module to remove code duplication.
- I contemplated that I could also add Map.CanOpenAsync. However, I'm not sure how to implement this on iOS.
- I came across weird behavior on Android 11. I could run geo intent, however `PackageManager.QueryIntentActivities()` always returned me empty list for some reason. I did some research, and I think that it's necessary to add this intent to AndroidManifest, like all other intents.
`<intent>
    <action android:name="android.intent.action.VIEW" />
    <data android:scheme="geo" />
</intent>`
- I'm not sure whether I should write some tests for this.


### Bugs Fixed ###

- Related to issue https://github.com/xamarin/Essentials/issues/1289

### API Changes ###

Added: 
- `Task<bool> TryOpenAsync(Location location)`
- `Task<bool> TryOpenAsync(Location location, MapLaunchOptions options)`
- `Task<bool> TryOpenAsync(double latitude, double longitude)`
- `Task<bool> TryOpenAsync(double latitude, double longitude, MapLaunchOptions options)`
- `Task<bool> TryOpenAsync(Placemark placemark)`
- `Task<bool> TryOpenAsync(Placemark placemark, MapLaunchOptions options)`


### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
