### PR TITLE
Fix Secure storage group not shareable between iOS applications

### DIFF
--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.tvos.watchos.macos.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.tvos.watchos.macos.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Essentials
 
         public static Task SetAsync(string key, string value, SecAccessible accessible, string accessGroup)
         {
-            var alias = GetAlias(accessGroup);
+            var alias = string.IsNullOrWhiteSpace(accessGroup) ? Alias : accessGroup;
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
 
@@ -32,7 +32,7 @@ namespace Xamarin.Essentials
 
         static Task<string> PlatformGetAsync(string key, string accessGroup)
         {
-            var alias = GetAlias(accessGroup);
+            var alias = string.IsNullOrWhiteSpace(accessGroup) ? Alias : accessGroup;
             var kc = new KeyChain(DefaultAccessible, accessGroup);
             var value = kc.ValueForKey(key, alias);
 
@@ -44,7 +44,7 @@ namespace Xamarin.Essentials
 
         static bool PlatformRemove(string key, string accessGroup)
         {
-            var alias = GetAlias(accessGroup);
+            var alias = string.IsNullOrWhiteSpace(accessGroup) ? Alias : accessGroup;
             var kc = new KeyChain(DefaultAccessible, accessGroup);
 
             return kc.Remove(key, alias);
@@ -52,7 +52,7 @@ namespace Xamarin.Essentials
 
         static void PlatformRemoveAll(string accessGroup)
         {
-            var alias = GetAlias(accessGroup);
+            var alias = string.IsNullOrWhiteSpace(accessGroup) ? Alias : accessGroup;
             var kc = new KeyChain(DefaultAccessible, accessGroup);
 
             kc.RemoveAll(alias);

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.tvos.watchos.macos.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.tvos.watchos.macos.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Essentials
 
         public static Task SetAsync(string key, string value, SecAccessible accessible, string accessGroup)
         {
-            var alias = string.IsNullOrWhiteSpace(accessGroup) ? Alias : accessGroup;
+            var alias = GetAlias(accessGroup);
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
 
@@ -32,7 +32,7 @@ namespace Xamarin.Essentials
 
         static Task<string> PlatformGetAsync(string key, string accessGroup)
         {
-            var alias = string.IsNullOrWhiteSpace(accessGroup) ? Alias : accessGroup;
+            var alias = GetAlias(accessGroup);
             var kc = new KeyChain(DefaultAccessible, accessGroup);
             var value = kc.ValueForKey(key, alias);
 
@@ -44,7 +44,7 @@ namespace Xamarin.Essentials
 
         static bool PlatformRemove(string key, string accessGroup)
         {
-            var alias = string.IsNullOrWhiteSpace(accessGroup) ? Alias : accessGroup;
+            var alias = GetAlias(accessGroup);
             var kc = new KeyChain(DefaultAccessible, accessGroup);
 
             return kc.Remove(key, alias);
@@ -52,7 +52,7 @@ namespace Xamarin.Essentials
 
         static void PlatformRemoveAll(string accessGroup)
         {
-            var alias = string.IsNullOrWhiteSpace(accessGroup) ? Alias : accessGroup;
+            var alias = GetAlias(accessGroup);
             var kc = new KeyChain(DefaultAccessible, accessGroup);
 
             kc.RemoveAll(alias);

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.ios.tvos.watchos.macos.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.ios.tvos.watchos.macos.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Essentials
 
         public static Task SetAsync(string key, string value, SecAccessible accessible, string accessGroup)
         {
+            var alias = GetAlias(accessGroup);
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
 
@@ -24,15 +25,16 @@ namespace Xamarin.Essentials
                 throw new ArgumentNullException(nameof(value));
 
             var kc = new KeyChain(accessible, accessGroup);
-            kc.SetValueForKey(value, key, Alias);
+            kc.SetValueForKey(value, key, alias);
 
             return Task.CompletedTask;
         }
 
         static Task<string> PlatformGetAsync(string key, string accessGroup)
         {
+            var alias = GetAlias(accessGroup);
             var kc = new KeyChain(DefaultAccessible, accessGroup);
-            var value = kc.ValueForKey(key, Alias);
+            var value = kc.ValueForKey(key, alias);
 
             return Task.FromResult(value);
         }
@@ -42,16 +44,18 @@ namespace Xamarin.Essentials
 
         static bool PlatformRemove(string key, string accessGroup)
         {
+            var alias = GetAlias(accessGroup);
             var kc = new KeyChain(DefaultAccessible, accessGroup);
 
-            return kc.Remove(key, Alias);
+            return kc.Remove(key, alias);
         }
 
         static void PlatformRemoveAll(string accessGroup)
         {
+            var alias = GetAlias(accessGroup);
             var kc = new KeyChain(DefaultAccessible, accessGroup);
 
-            kc.RemoveAll(Alias);
+            kc.RemoveAll(alias);
         }
     }
 

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.shared.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.shared.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Essentials
 
         // Special alias needed to used grouping
         internal static string GetAlias(string accessGroup)
-           => string.IsNullOrWhiteSpace(accessGroup) ? Alias : $"{accessGroup}.{Alias}";
+           => string.IsNullOrWhiteSpace(accessGroup) ? Alias : accessGroup;
 
         public static Task<string> GetAsync(string key, string accessGroup)
         {


### PR DESCRIPTION

### Description of Change ###

Resolves secure storage access groups not working on iOS by ensuring that specified shared access groups are not overridden with a bundle-specific access group.

### Bugs Fixed ###

Implementation of changes discussed in thread below, removing bundle-specific override of access group for iOS:

https://github.com/xamarin/Essentials/pull/1351#discussion_r485128322

### API Changes ###

Changed:

 - When access group is specified, SecureStorage explicitly uses shared access group provided.
 - SecureStorage backwards compatibility if no access group supplied, ie. still uses old XaraminEssentials alias as documented