### PR TITLE
Fix crash when using WebAuthenticator.AuthenticateAsync #1586

### DIFF
--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
@@ -21,15 +21,15 @@ namespace Xamarin.Essentials
             var extras = savedInstanceState ?? Intent.Extras;
 
             // read the values
-            launched = extras.GetBoolean(launchedExtra, false);
-            actualIntent = extras.GetParcelable(actualIntentExtra) as Intent;
+            launched = extras?.GetBoolean(launchedExtra, false) ?? false;
+            actualIntent = extras?.GetParcelable(actualIntentExtra) as Intent;
         }
 
         protected override void OnResume()
         {
             base.OnResume();
 
-            if (!launched)
+            if (actualIntent != null && !launched)
             {
                 // if this is the first time, start the authentication flow
                 StartActivity(actualIntent);


### PR DESCRIPTION
### Description of Change ###

Fix crash when using WebAuthenticator.AuthenticateAsync in latest version. While this might not be the best way to fix it, it fixes the issue (at least on our app). If a different fix is required, can this at least be given some priority? Thanks

No tests are added because I have no idea how I'd even write a test for this case

### Bugs Fixed ###

- Fixes #1586


### API Changes ###

None

### Behavioral Changes ###

None

