### PR TITLE
better UIColor conversion

### DIFF
--- a/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.ios.tvos.watchos.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Essentials
                 throw new ArgumentNullException(nameof(color));
 
             color.GetRGBA(out var red, out var green, out var blue, out var alpha);
-            return Color.FromArgb((int)(alpha * 255), (int)(red * 255), (int)(green * 255), (int)(blue * 255));
+            return Color.FromArgb((int)Math.Round(alpha * 255), (int)Math.Round(red * 255), (int)Math.Round(green * 255), (int)Math.Round(blue * 255));
         }
 
         public static UIColor ToPlatformColor(this Color color) =>

--- a/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.macos.cs
+++ b/Xamarin.Essentials/Types/PlatformExtensions/ColorExtensions.macos.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Essentials
             color = color.UsingColorSpace(NSColorSpace.SRGBColorSpace);
 
             color.GetRgba(out var red, out var green, out var blue, out var alpha);
-            return Color.FromArgb((int)(alpha * 255), (int)(red * 255), (int)(green * 255), (int)(blue * 255));
+            return Color.FromArgb((int)Math.Round(alpha * 255), (int)Math.Round(red * 255), (int)Math.Round(green * 255), (int)Math.Round(blue * 255));
         }
 
         public static NSColor ToPlatformColor(this Color color) =>


### PR DESCRIPTION
### Description of Change ###
Better UIColor conversion uses rounding instead of cutting off decimals

### Bugs Fixed ###
fixes #1572

### API Changes ###
none

### Behavioral Changes ###
none

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
