### PR TITLE
[BUGFIX] Changed default MediaPicker image file format to JPEG on iOS

### DIFF
--- a/Xamarin.Essentials/FileSystem/FileSystem.ios.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.ios.cs
@@ -186,13 +186,13 @@ namespace Xamarin.Essentials
         {
             uiImage = image;
 
-            FullPath = Guid.NewGuid().ToString() + FileSystem.Extensions.Png;
+            FullPath = Guid.NewGuid().ToString() + FileSystem.Extensions.Jpg;
             FileName = FullPath;
         }
 
         internal override Task<Stream> PlatformOpenReadAsync()
         {
-            data ??= uiImage.AsPNG();
+            data ??= uiImage.AsJPEG();
 
             return Task.FromResult(data.AsStream());
         }


### PR DESCRIPTION
### Description of Change ###

In Xamarin.Essentials on iOS, whenever the MediaPicker returns an image not represented by a file (mainly camera captures) it defaults to a PNG format in the result. 

This is a very inefficient file format for camera images and inconsistent with Xamarin.Essential image capture behaviour on Android, UWP and Tizen, which all return JPEG formatted images by default.

This PR changes the result type for camera captures to JPEG for efficiency and to be consistent with the other platforms supported in Xamarin.Essentials.

### Bugs Fixed ###

- Fixes issue #1697

### API Changes ###

Added: 
 
None

Changed:

None

### Behavioral Changes ###

On iOS the FileResult returned by `CapturePhotoAsync` is now a JPEG formatted image.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of `main` at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
