### PR TITLE
set result after cleanup of locationmanager #1489

### DIFF
--- a/Xamarin.Essentials/Permissions/Permissions.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.ios.tvos.watchos.cs
@@ -186,9 +186,9 @@ namespace Xamarin.Essentials
                         }
 
                         del.AuthorizationStatusChanged -= LocationAuthCallback;
-                        tcs.TrySetResult(GetLocationStatus(whenInUse));
                         locationManager?.Dispose();
                         locationManager = null;
+                        tcs.TrySetResult(GetLocationStatus(whenInUse));
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION



 
### Description of Change ###

On IOS if you like to request LocationAlways you have to request locationWhenInUse first. This means in an average implementation one would have 2 consecutive calls
await Permissions.RequestAsync<Permissions.LocationWhenInUse>();  
await Permissions.RequestAsync<Permissions.LocationAlways>();  
Both use the static LocationManager instance.
Since RequestAsync<Permissions.LocationWhenInUse>() sets the result of the task completition source before cleaning up its locationManager there is a race condition where RequestAsync<Permission.LocationAlways>() already runs and thus this cleanup disposes the locationManager used by the second call. This will not always be the case but in my test around 50% of the time. Workaround wait 3-10 seconds in between the calls


### Bugs Fixed ###

- Related to issue #1489 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

None


### Behavioral Changes ###


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
