### PR TITLE
MaximumFramesPerSecond only available in iOS 10.3+, fixes #1818

### DIFF
--- a/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.ios.cs
@@ -18,13 +18,15 @@ namespace Xamarin.Essentials
             var bounds = UIScreen.MainScreen.Bounds;
             var scale = UIScreen.MainScreen.Scale;
 
+            // MaximumFramesPerSecond only available in iOS 10.3+. Fall-back to 60 Hz if not supported
+            var fpsRate = Platform.HasOSVersion(10, 3) ? UIScreen.MainScreen.MaximumFramesPerSecond : 60;
             return new DisplayInfo(
                 width: bounds.Width * scale,
                 height: bounds.Height * scale,
                 density: scale,
                 orientation: CalculateOrientation(),
                 rotation: CalculateRotation(),
-                rate: UIScreen.MainScreen.MaximumFramesPerSecond);
+                rate: fpsRate);
         }
 
         static void StartScreenMetricsListeners()


### PR DESCRIPTION

### Description of Change ###

Only access MaximumFramesPerSecond on iOS 10.3+. Fall-back to 60 Hz for older versions.

Tested manually on iOS 10.2 and 11.0.3.

### Bugs Fixed ###

- Fix #1818 

### API Changes ###

None
### Behavioral Changes ###
None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ x] Rebased on top of `main` at time of PR
- [ x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
