### PR TITLE
Let UWP's WebAuthenticator.AuthenticateAsync use the browser

### DIFF
--- a/Samples/Samples.UWP/App.xaml.cs
+++ b/Samples/Samples.UWP/App.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
@@ -31,6 +30,7 @@ namespace Samples.UWP
                 rootFrame.NavigationFailed += OnNavigationFailed;
 
                 Xamarin.Forms.Forms.Init(e);
+                WebAuthenticator.UseBrowser = true;
 
                 if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
                 {
@@ -67,6 +67,17 @@ namespace Samples.UWP
             // TODO: Save application state and stop any background activity
 
             deferral.Complete();
+        }
+
+        protected override void OnActivated(IActivatedEventArgs args)
+        {
+            if (args.Kind == ActivationKind.Protocol && WebAuthenticator.BrowserAuthenticationTaskCompletionSource != null)
+            {
+                var protocolArgs = args as ProtocolActivatedEventArgs;
+                var url = new Uri(protocolArgs.Uri.AbsoluteUri);
+                var authenticationResult = new WebAuthenticatorResult(url);
+                WebAuthenticator.BrowserAuthenticationTaskCompletionSource.SetResult(authenticationResult);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

This pull request is a (draft of a) possible fix for issue #1791. In UWP, WebAuthenticator calls `WebAuthenticationBroker`, which uses a "web view" with an old browser engine, which is unsupported in (some) OAuth flows (like the OAuth flow of Dropbox).
This PR offers developers the option to let UWP's WebAuthenticator.AuthenticateAsync use the browser (that the user has installed as their default browser) by setting `WebAuthenticator.UseBrowser` and overriding `OnActivated` as described below (see "Behavioral Changes").

### API Changes ###

For UWP, the property `bool WebAuthenticator.UseBrowser { get; set; }` is added.

### Behavioral Changes ###

There are no behavioural changes without opting in. If a developer wants to use `WebAuthenticator.AuthenticateAsync` in UWP via the browser instead of via a WebView (of the WebAuthenticationBroker), the developer needs to
- add `WebAuthenticator.UseBrowser = true;` to `App.xaml.cs` (for example in `OnLaunched`)
- override OnActivated (in `App.xaml.cs`) via something like:
```
        protected override void OnActivated(IActivatedEventArgs args)
        {
            if (args.Kind == ActivationKind.Protocol && WebAuthenticator.BrowserAuthenticationTaskCompletionSource != null)
            {
                var protocolArgs = args as ProtocolActivatedEventArgs;
                var url = new Uri(protocolArgs.Uri.AbsoluteUri);
                var authenticationResult = new WebAuthenticatorResult(url);
                WebAuthenticator.BrowserAuthenticationTaskCompletionSource.SetResult(authenticationResult);
            }
        }
```
In the UWP example, those changes are included in this PR.

### PR Checklist ###

- [x] Has samples
- [x] Rebased on top of `main` at time of PR
- Has no tests. This is a draft pull request. I'm not sure whether a change like this is appreciated - I won't invest much time before getting some feedback.
- I did not update documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc)) for the same reason.
