### PR TITLE
Improving the operation of PresentationControllers

### DIFF
--- a/Xamarin.Essentials/Contacts/Contacts.ios.macos.cs
+++ b/Xamarin.Essentials/Contacts/Contacts.ios.macos.cs
@@ -39,6 +39,14 @@ namespace Xamarin.Essentials
                 })
             };
 
+            if (picker.PresentationController != null)
+            {
+                picker.PresentationController.Delegate = new Platform.UIPresentationControllerDelegate
+                {
+                    DismissHandler = () => source?.TrySetResult(null)
+                };
+            }
+
             uiView.PresentViewController(picker, true, null);
 
             return source.Task;

--- a/Xamarin.Essentials/Email/Email.ios.cs
+++ b/Xamarin.Essentials/Email/Email.ios.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using Foundation;
 using MessageUI;
@@ -50,13 +51,21 @@ namespace Xamarin.Essentials
                 }
             }
 
-            // show the controller
             var tcs = new TaskCompletionSource<bool>();
             controller.Finished += (sender, e) =>
             {
                 controller.DismissViewController(true, null);
                 tcs.TrySetResult(e.Result == MFMailComposeResult.Sent);
             };
+
+            if (controller.PresentationController != null)
+            {
+                controller.PresentationController.Delegate = new Platform.UIPresentationControllerDelegate
+                {
+                    DismissHandler = () => tcs.TrySetResult(false)
+                };
+            }
+
             parentController.PresentViewController(controller, true, null);
 
             return tcs.Task;

--- a/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.ios.cs
@@ -34,9 +34,9 @@ namespace Xamarin.Essentials
 
             if (documentPicker.PresentationController != null)
             {
-                documentPicker.PresentationController.Delegate = new PickerPresentationControllerDelegate
+                documentPicker.PresentationController.Delegate = new Platform.UIPresentationControllerDelegate
                 {
-                    PickHandler = urls => GetFileResults(urls, tcs)
+                    DismissHandler = () => GetFileResults(null, tcs)
                 };
             }
 
@@ -73,14 +73,6 @@ namespace Xamarin.Essentials
 
             public override void DidPickDocument(UIDocumentPickerViewController controller, NSUrl url)
                 => PickHandler?.Invoke(new NSUrl[] { url });
-        }
-
-        class PickerPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate
-        {
-            public Action<NSUrl[]> PickHandler { get; set; }
-
-            public override void DidDismiss(UIPresentationController presentationController) =>
-                PickHandler?.Invoke(null);
         }
     }
 

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.ios.cs
@@ -75,9 +75,9 @@ namespace Xamarin.Essentials
 
             if (picker.PresentationController != null)
             {
-                picker.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
+                picker.PresentationController.Delegate = new Platform.UIPresentationControllerDelegate
                 {
-                    CompletedHandler = info => GetFileResult(info, tcs)
+                    DismissHandler = () => GetFileResult(null, tcs)
                 };
             }
 
@@ -165,14 +165,6 @@ namespace Xamarin.Essentials
                 CompletedHandler?.Invoke(info);
 
             public override void Canceled(UIImagePickerController picker) =>
-                CompletedHandler?.Invoke(null);
-        }
-
-        class PhotoPickerPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate
-        {
-            public Action<NSDictionary> CompletedHandler { get; set; }
-
-            public override void DidDismiss(UIPresentationController presentationController) =>
                 CompletedHandler?.Invoke(null);
         }
     }

--- a/Xamarin.Essentials/Platform/Platform.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Platform/Platform.ios.tvos.watchos.cs
@@ -152,8 +152,11 @@ namespace Xamarin.Essentials
         {
             public Action DismissHandler { get; set; }
 
-            public override void DidDismiss(UIPresentationController presentationController) =>
+            public override void DidDismiss(UIPresentationController presentationController)
+            {
                 DismissHandler?.Invoke();
+                DismissHandler = null;
+            }
 
             protected override void Dispose(bool disposing)
             {

--- a/Xamarin.Essentials/Sms/Sms.ios.cs
+++ b/Xamarin.Essentials/Sms/Sms.ios.cs
@@ -21,13 +21,21 @@ namespace Xamarin.Essentials
 
             messageController.Recipients = message?.Recipients?.ToArray() ?? new string[] { };
 
-            // show the controller
             var tcs = new TaskCompletionSource<bool>();
             messageController.Finished += (sender, e) =>
             {
                 messageController.DismissViewController(true, null);
                 tcs?.TrySetResult(e.Result == MessageComposeResult.Sent);
             };
+
+            if (controller.PresentationController != null)
+            {
+                controller.PresentationController.Delegate = new Platform.UIPresentationControllerDelegate
+                {
+                    DismissHandler = () => tcs.TrySetResult(false)
+                };
+            }
+
             controller.PresentViewController(messageController, true, null);
 
             return tcs.Task;


### PR DESCRIPTION
### Description of Change ###

Using [`Rg.Plugins.Popup`](https://github.com/rotorgames/Rg.Plugins.Popup) and `Essentials` together, I noticed some problems:
- Closing Popups closes pickers and etc., but the tasks remain not finished.
- We don't have the option to specify a UIViewController before opening pickers

This is due not only to `Rg.Plugins.Popup`, but also to any projects that use custom controllers for rendering pages. 


### API Changes ###
Added: 
 
```csharp
public static partial class Platform
{
    public static void Init(Func<UIViewController> getCurrentUIViewController)
}
```

### Behavioral Changes ###
- All tasks will be finished when the controller is closed
- Ability to change the parent controller for pickers


### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
