### PR TITLE
Workaround Android 11 -> Samsung Attach to GMail weird behaviour

### DIFF
--- a/Xamarin.Essentials/Email/Email.android.cs
+++ b/Xamarin.Essentials/Email/Email.android.cs
@@ -37,7 +37,6 @@ namespace Xamarin.Essentials
             var action = (message?.Attachments?.Count ?? 0) switch
             {
                 0 => Intent.ActionSendto,
-                1 => Intent.ActionSend,
                 _ => Intent.ActionSendMultiple
             };
             var intent = new Intent(action);
@@ -88,10 +87,7 @@ namespace Xamarin.Essentials
                     uris.Add(Platform.GetShareableFileUri(attachment));
                 }
 
-                if (uris.Count > 1)
-                    intent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
-                else
-                    intent.PutExtra(Intent.ExtraStream, uris[0]);
+                intent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
 
                 intent.AddFlags(ActivityFlags.GrantReadUriPermission);
             }


### PR DESCRIPTION

 
### Description of Change ###

There is a really strange behavior especially on Samsung phones when running Android 11. If you try attach just one file and request an email send if you select the GMail application the first time the file it will get attached and the second time and following time it won't work anymore. If you use any other application like Samsung Mail or Google Mail it will work correctly

### Bugs Fixed ###

Removing the if's with the situation where you have only one attachment and using always Multiple even if in the array there is only one file seems to work for every application at least on Android 11

### API Changes ###

Changed:

 Removed the case where there is only one attachment and fall back to multiple attachments
 
If there is an entirely new API, then you can use a more verbose style:


### Behavioral Changes ###

No changes .

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
