### PR TITLE
Fixes hang waiting for cancelled TextToSpeech

### DIFF
--- a/Xamarin.Essentials/TextToSpeech/TextToSpeech.android.cs
+++ b/Xamarin.Essentials/TextToSpeech/TextToSpeech.android.cs
@@ -109,6 +109,8 @@ namespace Xamarin.Essentials
             if (tcsUtterances?.Task != null)
                 await tcsUtterances.Task;
 
+            tcsUtterances = new TaskCompletionSource<bool>();
+
             if (cancelToken != null)
             {
                 cancelToken.Register(() =>
@@ -150,7 +152,6 @@ namespace Xamarin.Essentials
             var parts = text.SplitSpeak(max);
 
             numExpectedUtterances = parts.Count;
-            tcsUtterances = new TaskCompletionSource<bool>();
 
             var guid = Guid.NewGuid().ToString();
 


### PR DESCRIPTION

### Description of Change ###
There's a bug in Android TTS that if you cancel quickly after starting TTS, `SpeakAsync` will never return. This is because the `CancellationToken` was cancelled before the `TaskCompletionSource` was being assigned, so awaiting the `TaskCompletionSource` would wait forever. To fix, I moved the creation of the `TaskCompletionSource` before we register with the `CancellationToken`

### Bugs Fixed ###

- Fixes #1894

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###
None


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
