### PR TITLE
Await on async ios MFMailComposeViewController

### DIFF
--- a/Xamarin.Essentials/Email/Email.ios.cs
+++ b/Xamarin.Essentials/Email/Email.ios.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading.Tasks;
 using Foundation;
 using MessageUI;
@@ -20,7 +20,7 @@ namespace Xamarin.Essentials
                 return ComposeWithUrl(message);
         }
 
-        static Task ComposeWithMailCompose(EmailMessage message)
+        static async Task ComposeWithMailCompose(EmailMessage message)
         {
             // do this first so we can throw as early as possible
             var parentController = Platform.GetCurrentViewController();
@@ -57,9 +57,9 @@ namespace Xamarin.Essentials
                 controller.DismissViewController(true, null);
                 tcs.TrySetResult(e.Result == MFMailComposeResult.Sent);
             };
-            parentController.PresentViewController(controller, true, null);
+            await parentController.PresentViewControllerAsync(controller, true);
 
-            return tcs.Task;
+            await tcs.Task;
         }
 
         static async Task ComposeWithUrl(EmailMessage message)


### PR DESCRIPTION
<!-- 

HOL' UP! JUST A SEC!

After January 31, 2021, feature related pull requests cannot be guaranteed to merge by Xamarin.Essentials.

We are in the process of merging Xamarin.Essentials into the MAUI repository for improved experience.
At this stage, MAUI will depend on Xamarin.Essentials, so we are moving it there so that they can be released together.

This repo can still be used for a time to fix any critical bugs and other issues. All new features will be postponed until the merge is complete.

Thanks for all the PRs in the past, we can't wait to have you contributing features very soon in our new and improved home!

PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!

-->
 
### Description of Change ###

Currently on the new iOS 15.1 the Email ComposeAsync API call does not correctly block when awaited. It returns from the email application as soon as it's open. This changes updates the API so that the email compose screen is awaited until the user sends the email. This issue is related to this one #1899.

### Bugs Fixed ###

- #1917 

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

No API changes

### Behavioral Changes ###

No Behavioral changes
