### PR TITLE
[Bug] [AppAction] [Android] Prevent AppAction double handling on Android

### DIFF
--- a/Xamarin.Essentials/AppActions/AppActions.android.cs
+++ b/Xamarin.Essentials/AppActions/AppActions.android.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Essentials
         const string extraAppActionTitle = "EXTRA_XE_APP_ACTION_TITLE";
         const string extraAppActionSubtitle = "EXTRA_XE_APP_ACTION_SUBTITLE";
         const string extraAppActionIcon = "EXTRA_XE_APP_ACTION_ICON";
+        internal const string extraAppActionHandled = "EXTRA_XE_APP_ACTION_HANDLED";
 
         internal static AppAction ToAppAction(this Intent intent)
             => new AppAction(

--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -108,8 +108,11 @@ namespace Xamarin.Essentials
 
         static void CheckAppActions(AndroidIntent intent)
         {
-            if (intent?.Action == Intent.ActionAppAction)
+            if (intent?.Action == Intent.ActionAppAction && !intent.GetBooleanExtra(AppActions.extraAppActionHandled, false))
             {
+                // prevent launch intent getting handled on activity resume
+                intent.PutExtra(AppActions.extraAppActionHandled, true);
+
                 var appAction = intent.ToAppAction();
 
                 if (!string.IsNullOrEmpty(appAction?.Id))


### PR DESCRIPTION
### Description of Change ###

This prevents the double handling of AppAction Intents on Android by setting an extra in the Intent to ensure that the event is only handled once.

No new test cases or samples. This requires manual testing.

### Bugs Fixed ###

- Related to issue #1922

### API Changes ###

None