### PR TITLE
Fix iOS Sample/DeviceTests build by removing obsolete call

### DIFF
--- a/DeviceTests/DeviceTests.iOS/Main.cs
+++ b/DeviceTests/DeviceTests.iOS/Main.cs
@@ -7,9 +7,9 @@ namespace DeviceTests.iOS
         static void Main(string[] args)
         {
             if (args?.Length > 0) // usually means this is from xharness
-                UIApplication.Main(args, null, nameof(TestApplicationDelegate));
+                UIApplication.Main(args, null, typeof(TestApplicationDelegate));
             else
-                UIApplication.Main(args, null, nameof(AppDelegate));
+                UIApplication.Main(args, null, typeof(AppDelegate));
         }
     }
 }

--- a/Samples/Samples.iOS/Main.cs
+++ b/Samples/Samples.iOS/Main.cs
@@ -6,7 +6,7 @@ namespace Samples.iOS
     {
         static void Main(string[] args)
         {
-            UIApplication.Main(args, null, nameof(AppDelegate));
+            UIApplication.Main(args, null, typeof(AppDelegate));
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

The iOS sample calls `UIApplication.Main(args, null, nameof(AppDelegate));` which is obsolete now and therefore fails our build. This changes it to `UIApplication.Main(args, null, typeof(AppDelegate));`

### Bugs Fixed ###

N/A

### API Changes ###

N/A

### Behavioral Changes ###

N/A

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
