### PR TITLE
Fixed local debugging builds

### DIFF
--- a/Nuget.config
+++ b/Nuget.config
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="azureDotNet" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <clear />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
+    <add key="dotnet6" value="https://aka.ms/dotnet6/nuget/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/Nuget.config
+++ b/Nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="azureDotNet" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+</configuration>

--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -31,11 +31,12 @@
     <MDocDocumentationDirectory>$(MSBuildThisFileDirectory)..\docs\en</MDocDocumentationDirectory>
     <DebugType>portable</DebugType>
     <Configurations>Debug;Release</Configurations>
+		<_IsRelease Condition=" '$(Configuration)'=='Release' And '$(OS)' == 'Windows_NT' ">true</_IsRelease>
  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)'=='Release' And '$(OS)' == 'Windows_NT' ">
+  <PropertyGroup Condition=" '$(_IsRelease)'=='true' ">
     <!-- sourcelink: Declare that the Repository URL can be published to NuSpec -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- sourcelink: Embed source files that are not tracked by the source control manager to the PDB -->
@@ -50,7 +51,6 @@
     <None Include="..\LICENSE" PackagePath="" Pack="true" />
     <None Include="..\Assets\xamarin.essentials_128x128.png" PackagePath="icon.png" Pack="true" />
     <None Include="..\nugetreadme.txt" PackagePath="readme.txt" Pack="true" />
-    <PackageReference Include="mdoc" Version="5.7.4.10" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
     <Compile Include="**\*.shared.cs" />
     <Compile Include="**\*.shared.*.cs" />
@@ -111,8 +111,9 @@
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="OpenTK" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(_IsRelease)'=='true' ">
+    <PackageReference Include="mdoc" Version="5.7.4.10" PrivateAssets="All"/> 
     <None Remove="mdoc.targets" />
   </ItemGroup>
-  <Import Project="$(MSBuildThisFileDirectory)mdoc.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)mdoc.targets" Condition=" '$(_IsRelease)'=='true' " />
 </Project>


### PR DESCRIPTION
After the last changes, the project is not building because of `mdoc` and [`Microsoft.DotNet.XHarness.TestRunners.Xunit`](https://github.com/xamarin/Essentials/blob/2627bf2db0c009392e6558f31b9844fa2d4185fd/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj#L64)