### PR TITLE
Software Bill of Materials (SBOM) manifest generation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ stages:
     jobs:
       - template: .ci/build.yml@components
         parameters:
+          windowsImage: windows-2019
           areaPath: 'DevDiv\Xamarin SDK'
           masterBranchName: 'main'
           preBuildSteps:
@@ -103,6 +104,7 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsImage: windows-2019
           name: devicetests_ios
           runChecks: false
           displayName: iOS
@@ -116,6 +118,7 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsImage: windows-2019
           name: devicetests_android_api_21
           runChecks: false
           displayName: Android API 21
@@ -132,6 +135,7 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsImage: windows-2019
           name: devicetests_android_api_22
           runChecks: false
           displayName: Android API 22
@@ -165,6 +169,7 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsImage: windows-2019
           name: devicetests_android_api_24
           runChecks: false
           displayName: Android API 24
@@ -181,6 +186,7 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsImage: windows-2019
           name: devicetests_android_api_26
           runChecks: false
           displayName: Android API 26
@@ -197,6 +203,7 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsImage: windows-2019
           name: devicetests_android_api_29
           runChecks: false
           displayName: Android API 29

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,6 +64,19 @@ stages:
           parameters:
             condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
+  -stage: sbom
+   displayName: 'Software Bill of Materials'
+   ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
+    dependsOn: [ 'build' ]
+   ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+    dependsOn: [ 'signing' ]
+  jobs:
+  - template: compliance/sbom/job.v1.yml@internal-templates
+    parameters:
+      artifactNames: ['nuget']
+      packageName: 'Xamarin Essentials'
+      packageFilter: '*.nupkg'
+
   - stage: devicetests
     displayName: Device Tests
     dependsOn: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ stages:
       ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
         dependsOn: [ 'signing' ]
       jobs:
-      - template: compliance/sbom/job.v1.yml@internal-templates
+      - template: compliance/sbom/job.v1.yml@internal-templates             # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
         parameters:
           artifactNames: ['nuget']
           packageName: 'Xamarin Essentials'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,6 +77,7 @@ stages:
           artifactNames: ['nuget']
           packageName: 'Xamarin Essentials'
           packageFilter: '*.nupkg'
+          packageVersionRegex: '(?i)^Xamarin.Essentials\.(?<version>\d+\.\d+\.\d+)(.*).nupkg$'
 
   - stage: devicetests
     displayName: Device Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,6 @@ stages:
           runChecks: false
           displayName: iOS
           publishOutputSuffix: '-ios'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -123,7 +122,6 @@ stages:
           runChecks: false
           displayName: Android API 21
           publishOutputSuffix: '-android21'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -140,7 +138,6 @@ stages:
           runChecks: false
           displayName: Android API 22
           publishOutputSuffix: '-android22'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -152,12 +149,12 @@ stages:
 
 #       - template: .ci/build.yml@components
 #         parameters:
+#           windowsImage: windows-2019
 #           name: devicetests_android_api_23
 #           runChecks: false
 #           continueOnError: true
 #           displayName: Android API 23
 #           publishOutputSuffix: '-android23'
-#           windowsImage: ''
 #           areaPath: $(AREA_PATH)
 #           verbosity: diagnostic
 #           cakeFile: DeviceTests/build.cake
@@ -174,7 +171,6 @@ stages:
           runChecks: false
           displayName: Android API 24
           publishOutputSuffix: '-android24'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -191,7 +187,6 @@ stages:
           runChecks: false
           displayName: Android API 26
           publishOutputSuffix: '-android26'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -208,7 +203,6 @@ stages:
           runChecks: false
           displayName: Android API 29
           publishOutputSuffix: '-android29'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -220,11 +214,11 @@ stages:
 
       # - template: .ci/build.yml@components
       #   parameters:
+      #     windowsImage: windows-2019
       #     name: devicetests_android_api_30
       #     runChecks: false
       #     displayName: Android API 30
       #     publishOutputSuffix: '-android30'
-      #     windowsImage: ''
       #     areaPath: $(AREA_PATH)
       #     verbosity: diagnostic
       #     cakeFile: DeviceTests/build.cake

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,11 +105,11 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          windowsImage: windows-2019
           name: devicetests_ios
           runChecks: false
           displayName: iOS
           publishOutputSuffix: '-ios'
+          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -118,11 +118,11 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          windowsImage: windows-2019
           name: devicetests_android_api_21
           runChecks: false
           displayName: Android API 21
           publishOutputSuffix: '-android21'
+          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -134,11 +134,11 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          windowsImage: windows-2019
           name: devicetests_android_api_22
           runChecks: false
           displayName: Android API 22
           publishOutputSuffix: '-android22'
+          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -150,12 +150,12 @@ stages:
 
 #       - template: .ci/build.yml@components
 #         parameters:
-#           windowsImage: windows-2019
 #           name: devicetests_android_api_23
 #           runChecks: false
 #           continueOnError: true
 #           displayName: Android API 23
 #           publishOutputSuffix: '-android23'
+#           windowsImage: ''
 #           areaPath: $(AREA_PATH)
 #           verbosity: diagnostic
 #           cakeFile: DeviceTests/build.cake
@@ -167,11 +167,11 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          windowsImage: windows-2019
           name: devicetests_android_api_24
           runChecks: false
           displayName: Android API 24
           publishOutputSuffix: '-android24'
+          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -183,11 +183,11 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          windowsImage: windows-2019
           name: devicetests_android_api_26
           runChecks: false
           displayName: Android API 26
           publishOutputSuffix: '-android26'
+          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -199,11 +199,11 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
-          windowsImage: windows-2019
           name: devicetests_android_api_29
           runChecks: false
           displayName: Android API 29
           publishOutputSuffix: '-android29'
+          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -215,11 +215,11 @@ stages:
 
       # - template: .ci/build.yml@components
       #   parameters:
-      #     windowsImage: windows-2019
       #     name: devicetests_android_api_30
       #     runChecks: false
       #     displayName: Android API 30
       #     publishOutputSuffix: '-android30'
+      #     windowsImage: ''
       #     areaPath: $(AREA_PATH)
       #     verbosity: diagnostic
       #     cakeFile: DeviceTests/build.cake

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,18 +64,18 @@ stages:
           parameters:
             condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
-  -stage: sbom
-   displayName: 'Software Bill of Materials'
-   ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
-    dependsOn: [ 'build' ]
-   ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-    dependsOn: [ 'signing' ]
-  jobs:
-  - template: compliance/sbom/job.v1.yml@internal-templates
-    parameters:
-      artifactNames: ['nuget']
-      packageName: 'Xamarin Essentials'
-      packageFilter: '*.nupkg'
+  - stage: sbom
+    displayName: 'Software Bill of Materials'
+    ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
+      dependsOn: [ 'build' ]
+    ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+      dependsOn: [ 'signing' ]
+    jobs:
+    - template: compliance/sbom/job.v1.yml@internal-templates
+      parameters:
+        artifactNames: ['nuget']
+        packageName: 'Xamarin Essentials'
+        packageFilter: '*.nupkg'
 
   - stage: devicetests
     displayName: Device Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,18 +64,18 @@ stages:
           parameters:
             condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
-  - stage: sbom
-    displayName: 'Software Bill of Materials'
-    ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
-      dependsOn: [ 'build' ]
-    ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-      dependsOn: [ 'signing' ]
-    jobs:
-    - template: compliance/sbom/job.v1.yml@internal-templates
-      parameters:
-        artifactNames: ['nuget']
-        packageName: 'Xamarin Essentials'
-        packageFilter: '*.nupkg'
+    - stage: sbom
+      displayName: 'Software Bill of Materials'
+      ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
+        dependsOn: [ 'build' ]
+      ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
+        dependsOn: [ 'signing' ]
+      jobs:
+      - template: compliance/sbom/job.v1.yml@internal-templates
+        parameters:
+          artifactNames: ['nuget']
+          packageName: 'Xamarin Essentials'
+          packageFilter: '*.nupkg'
 
   - stage: devicetests
     displayName: Device Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ stages:
   - stage: build
     displayName: Build Library
     jobs:
-      - template: .ci/build.yml@components
+      - template: .ci/build.v1.yml@components
         parameters:
           windowsImage: windows-2019
           areaPath: 'DevDiv\Xamarin SDK'
@@ -103,7 +103,7 @@ stages:
               testResultsFiles: '**/xunit-*.xml'
               testRunTitle: 'Device Tests - UWP'
 
-      - template: .ci/build.yml@components
+      - template: .ci/build.v1.yml@components
         parameters:
           name: devicetests_ios
           runChecks: false
@@ -116,7 +116,7 @@ stages:
           cakeTarget: test-ios-emu
           xharness: '1.0.0-prerelease.21620.1'
 
-      - template: .ci/build.yml@components
+      - template: .ci/build.v1.yml@components
         parameters:
           name: devicetests_android_api_21
           runChecks: false
@@ -132,7 +132,7 @@ stages:
             - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-21;google_apis;x86\""
               displayName: Install the Android emulators
 
-      - template: .ci/build.yml@components
+      - template: .ci/build.v1.yml@components
         parameters:
           name: devicetests_android_api_22
           runChecks: false
@@ -148,7 +148,7 @@ stages:
             - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-22;google_apis;x86\""
               displayName: Install the Android emulators
 
-#       - template: .ci/build.yml@components
+#       - template: .ci/build.v1.yml@components
 #         parameters:
 #           name: devicetests_android_api_23
 #           runChecks: false
@@ -165,7 +165,7 @@ stages:
 #             - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-23;google_apis;x86\""
 #               displayName: Install the Android emulators
 
-      - template: .ci/build.yml@components
+      - template: .ci/build.v1.yml@components
         parameters:
           name: devicetests_android_api_24
           runChecks: false
@@ -181,7 +181,7 @@ stages:
             - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-24;google_apis;x86\""
               displayName: Install the Android emulators
 
-      - template: .ci/build.yml@components
+      - template: .ci/build.v1.yml@components
         parameters:
           name: devicetests_android_api_26
           runChecks: false
@@ -197,7 +197,7 @@ stages:
             - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-26;google_apis;x86\""
               displayName: Install the Android emulators
 
-      - template: .ci/build.yml@components
+      - template: .ci/build.v1.yml@components
         parameters:
           name: devicetests_android_api_29
           runChecks: false
@@ -213,7 +213,7 @@ stages:
             - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-29;google_apis;x86\""
               displayName: Install the Android emulators
 
-      # - template: .ci/build.yml@components
+      # - template: .ci/build.v1.yml@components
       #   parameters:
       #     name: devicetests_android_api_30
       #     runChecks: false


### PR DESCRIPTION
 ### Description of Change ###

Per Executive Order (EO) produce a Software Bill of Materials (SBOM) capturing the produced nuget files from a dedicated job
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator

As a result of this change you will find an artifact named `sbom` attached to each build.  Within that artifact is a `manifest.json` file under a `_manifest` directory capturing all of the packages that constitute the `Software Bill of Materials` 

The `sbom` job captures the nuget package files (*.nupkg) published (uploaded) by the build

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
