### PR TITLE
remove read/write storage permissions from filepicker/mediapicker on Android

### DIFF
--- a/DeviceTests/DeviceTests.Android/Properties/AndroidManifest.xml
+++ b/DeviceTests/DeviceTests.Android/Properties/AndroidManifest.xml
@@ -6,11 +6,9 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.BATTERY_STATS" />
 	<uses-permission android:name="android.permission.CAMERA" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.FLASHLIGHT" />
+    <uses-permission android:name="android.permission.FLASHLIGHT" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.VIBRATE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<queries>
 		<!-- Email -->

--- a/Samples/Samples.Android/Properties/AndroidManifest.xml
+++ b/Samples/Samples.Android/Properties/AndroidManifest.xml
@@ -8,8 +8,6 @@
 	<uses-permission android:name="android.permission.CAMERA" />
 	<uses-permission android:name="android.permission.FLASHLIGHT" />
 	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<queries>

--- a/Xamarin.Essentials/FilePicker/FilePicker.android.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.android.cs
@@ -11,10 +11,6 @@ namespace Xamarin.Essentials
     {
         static async Task<IEnumerable<FileResult>> PlatformPickAsync(PickOptions options, bool allowMultiple = false)
         {
-            // we only need the permission when accessing the file, but it's more natural
-            // to ask the user first, then show the picker.
-            await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
-
             // Essentials supports >= API 19 where this action is available
             var action = Intent.ActionOpenDocument;
 

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
@@ -20,10 +20,6 @@ namespace Xamarin.Essentials
 
         static async Task<FileResult> PlatformPickAsync(MediaPickerOptions options, bool photo)
         {
-            // We only need the permission when accessing the file, but it's more natural
-            // to ask the user first, then show the picker.
-            await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
-
             var intent = new Intent(Intent.ActionGetContent);
             intent.SetType(photo ? FileSystem.MimeTypes.ImageAll : FileSystem.MimeTypes.VideoAll);
 


### PR DESCRIPTION
### Description of Change ###

Due to changes in targeting Android 11 the read/write permissions are super blocked. We dont' need them though as the API doesn't require them

### Bugs Fixed ###

- Related to issue #1961

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###
None.

### Behavioral Changes ###

No longer require permissions.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
