### PR TITLE
Correctly handle version downgrades (e.g. via TestFlight)

### DIFF
--- a/DeviceTests/DeviceTests.Shared/VersionTracking_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/VersionTracking_Tests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Diagnostics;
+using Xamarin.Essentials;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DeviceTests
+{
+    public class VersionTracking_Tests
+    {
+        /// <summary>
+        /// We cannot mock the app version but it should be constant value
+        /// </summary>
+        const string currentVersion = "1.0.1.0";
+        const string currentBuild = "1";
+
+        const string versionTrailKey = "VersionTracking.Trail";
+        const string versionsKey = "VersionTracking.Versions";
+        const string buildsKey = "VersionTracking.Builds";
+        static readonly string sharedName = Preferences.GetPrivatePreferencesSharedName("versiontracking");
+
+        readonly ITestOutputHelper output;
+
+        public VersionTracking_Tests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void First_Launch_Ever()
+        {
+            VersionTracking.Track();
+            Preferences.Clear(sharedName);
+
+            VersionTracking.InitVersionTracking();
+
+            Assert.Equal(currentVersion, VersionTracking.CurrentVersion);
+            Assert.True(VersionTracking.IsFirstLaunchEver);
+            Assert.True(VersionTracking.IsFirstLaunchForCurrentVersion);
+            Assert.True(VersionTracking.IsFirstLaunchForCurrentBuild);
+        }
+
+        [Fact]
+        public void First_Launch_For_Version()
+        {
+            VersionTracking.Track();
+            Preferences.Set(versionsKey, string.Join("|", new string[] { "0.8.0", "0.9.0", "1.0.0" }), sharedName);
+            Preferences.Set(buildsKey, string.Join("|", new string[] { currentBuild }), sharedName);
+
+            VersionTracking.InitVersionTracking();
+
+            Assert.Equal(currentVersion, VersionTracking.CurrentVersion);
+            Assert.Equal("1.0.0", VersionTracking.PreviousVersion);
+            Assert.Equal("0.8.0", VersionTracking.FirstInstalledVersion);
+            Assert.False(VersionTracking.IsFirstLaunchEver);
+            Assert.True(VersionTracking.IsFirstLaunchForCurrentVersion);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentBuild);
+
+            VersionTracking.InitVersionTracking();
+
+            Assert.Equal(currentVersion, VersionTracking.CurrentVersion);
+            Assert.Equal("1.0.0", VersionTracking.PreviousVersion);
+            Assert.Equal("0.8.0", VersionTracking.FirstInstalledVersion);
+            Assert.False(VersionTracking.IsFirstLaunchEver);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentVersion);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentBuild);
+        }
+
+        [Fact]
+        public void First_Launch_For_Build()
+        {
+            VersionTracking.Track();
+            Preferences.Set(versionsKey, string.Join("|", new string[] { currentVersion }), sharedName);
+            Preferences.Set(buildsKey, string.Join("|", new string[] { "10", "20" }), sharedName);
+
+            VersionTracking.InitVersionTracking();
+
+            Assert.Equal(currentVersion, VersionTracking.CurrentVersion);
+            Assert.Equal("20", VersionTracking.PreviousBuild);
+            Assert.Equal("10", VersionTracking.FirstInstalledBuild);
+            Assert.False(VersionTracking.IsFirstLaunchEver);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentVersion);
+            Assert.True(VersionTracking.IsFirstLaunchForCurrentBuild);
+
+            VersionTracking.InitVersionTracking();
+
+            Assert.Equal(currentVersion, VersionTracking.CurrentVersion);
+            Assert.Equal("20", VersionTracking.PreviousBuild);
+            Assert.Equal("10", VersionTracking.FirstInstalledBuild);
+            Assert.False(VersionTracking.IsFirstLaunchEver);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentVersion);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentBuild);
+        }
+
+        [Fact]
+        public void First_Launch_After_Downgrade()
+        {
+            VersionTracking.Track();
+            Preferences.Set(versionsKey, string.Join("|", new string[] { currentVersion, "1.0.2", "1.0.3" }), sharedName);
+
+            VersionTracking.InitVersionTracking();
+            output.WriteLine(VersionTracking.GetStatus());
+
+            Assert.Equal(currentVersion, VersionTracking.CurrentVersion);
+            Assert.Equal("1.0.3", VersionTracking.PreviousVersion);
+            Assert.Equal("1.0.2", VersionTracking.FirstInstalledVersion);
+            Assert.False(VersionTracking.IsFirstLaunchEver);
+            Assert.True(VersionTracking.IsFirstLaunchForCurrentVersion);
+
+            VersionTracking.InitVersionTracking();
+
+            Assert.Equal(currentVersion, VersionTracking.CurrentVersion);
+            Assert.Equal("1.0.3", VersionTracking.PreviousVersion);
+            Assert.Equal("1.0.2", VersionTracking.FirstInstalledVersion);
+            Assert.False(VersionTracking.IsFirstLaunchEver);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentVersion);
+        }
+
+        [Fact]
+        public void First_Launch_After_Build_Downgrade()
+        {
+            VersionTracking.Track();
+            Preferences.Set(versionsKey, string.Join("|", new string[] { currentVersion }), sharedName);
+            Preferences.Set(buildsKey, string.Join("|", new string[] { currentBuild, "10", "20" }), sharedName);
+
+            VersionTracking.InitVersionTracking();
+            output.WriteLine(VersionTracking.GetStatus());
+
+            Assert.Equal(currentBuild, VersionTracking.CurrentBuild);
+            Assert.Equal("20", VersionTracking.PreviousBuild);
+            Assert.Equal("10", VersionTracking.FirstInstalledBuild);
+            Assert.False(VersionTracking.IsFirstLaunchEver);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentVersion);
+            Assert.True(VersionTracking.IsFirstLaunchForCurrentBuild);
+
+            VersionTracking.InitVersionTracking();
+
+            Assert.Equal(currentBuild, VersionTracking.CurrentBuild);
+            Assert.Equal("20", VersionTracking.PreviousBuild);
+            Assert.Equal("10", VersionTracking.FirstInstalledBuild);
+            Assert.False(VersionTracking.IsFirstLaunchEver);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentVersion);
+            Assert.False(VersionTracking.IsFirstLaunchForCurrentBuild);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Version downgrades (e.g. from "1.1.0" to "1.0.1") are possible on certain platforms (e.g. on iOS with TestFlight) and thus should be handled correctly by VersionTracking module - especially if the version was already installed previously.

Since this is a bugfix (not a feature) covered by unit tests no samples are provided (see PR checklist).

### Bugs Fixed ###

- Related to issue #1960 

### API Changes ###

None


### Behavioral Changes ###

Observable behavior/semantics of the following API elements can change but **only in downgrade scenarios** described above:
- ``VersionTracking.IsFirstLaunchForCurrentVersion``
- ``VersionTracking.IsFirstLaunchForCurrentBuild``
- ``VersionTracking.PreviousVersion``
- ``VersionTracking.PreviousBuild``
- ``VersionTracking.FirstInstalledVersion``
- ``VersionTracking.FirstInstalledBuild``
- ``VersionTracking.VersionHistory``
- ``VersionTracking.BuildHistory``
- ``VersionTracking.IsFirstLaunchForVersion()``
- ``VersionTracking.IsFirstLaunchForBuild()``

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
