### PR TITLE
Target windows EO compliant agent pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ resources:
     - repository: components
       type: github
       name: xamarin/XamarinComponents
-      ref: refs/heads/dev/bond/eo-pools         # UNDONE: DO NOT MERGE TO MAIN
+      ref: refs/heads/main
       endpoint: xamarin
 
 stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ stages:
       - template: .ci/build.yml@components
         parameters:
           windowsAgentPoolName: AzurePipelines-EO
+          windowsImage: ''  # Override the 'windows-latest' default setting
           windowsImageOverride: AzurePipelinesWindows2019compliant
           areaPath: 'DevDiv\Xamarin SDK'
           masterBranchName: 'main'
@@ -96,12 +97,12 @@ stages:
       - template: .ci/build.yml@components
         parameters:
           windowsAgentPoolName: AzurePipelines-EO
+          windowsImage: ''  # Override the 'windows-latest' default setting
           windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_ios
           runChecks: false
           displayName: iOS
           publishOutputSuffix: '-ios'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -111,12 +112,12 @@ stages:
       - template: .ci/build.yml@components
         parameters:
           windowsAgentPoolName: AzurePipelines-EO
+          windowsImage: ''  # Override the 'windows-latest' default setting
           windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_21
           runChecks: false
           displayName: Android API 21
           publishOutputSuffix: '-android21'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -129,12 +130,12 @@ stages:
       - template: .ci/build.yml@components
         parameters:
           windowsAgentPoolName: AzurePipelines-EO
+          windowsImage: ''  # Override the 'windows-latest' default setting
           windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_22
           runChecks: false
           displayName: Android API 22
           publishOutputSuffix: '-android22'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -147,13 +148,13 @@ stages:
 #       - template: .ci/build.yml@components
 #         parameters:
 #           windowsAgentPoolName: AzurePipelines-EO
+#           windowsImage: ''  # Override the 'windows-latest' default setting
 #           windowsImageOverride: AzurePipelinesWindows2019compliant
 #           name: devicetests_android_api_23
 #           runChecks: false
 #           continueOnError: true
 #           displayName: Android API 23
 #           publishOutputSuffix: '-android23'
-#           windowsImage: ''
 #           areaPath: $(AREA_PATH)
 #           verbosity: diagnostic
 #           cakeFile: DeviceTests/build.cake
@@ -166,12 +167,12 @@ stages:
       - template: .ci/build.yml@components
         parameters:
           windowsAgentPoolName: AzurePipelines-EO
+          windowsImage: ''  # Override the 'windows-latest' default setting
           windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_24
           runChecks: false
           displayName: Android API 24
           publishOutputSuffix: '-android24'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -184,12 +185,12 @@ stages:
       - template: .ci/build.yml@components
         parameters:
           windowsAgentPoolName: AzurePipelines-EO
+          windowsImage: ''  # Override the 'windows-latest' default setting
           windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_26
           runChecks: false
           displayName: Android API 26
           publishOutputSuffix: '-android26'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -202,12 +203,12 @@ stages:
       - template: .ci/build.yml@components
         parameters:
           windowsAgentPoolName: AzurePipelines-EO
+          windowsImage: ''  # Override the 'windows-latest' default setting
           windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_29
           runChecks: false
           displayName: Android API 29
           publishOutputSuffix: '-android29'
-          windowsImage: ''
           areaPath: $(AREA_PATH)
           verbosity: diagnostic
           cakeFile: DeviceTests/build.cake
@@ -220,12 +221,12 @@ stages:
       # - template: .ci/build.yml@components
       #   parameters:
       #     windowsAgentPoolName: AzurePipelines-EO
+      #     windowsImage: ''  # Override the 'windows-latest' default setting
       #     windowsImageOverride: AzurePipelinesWindows2019compliant
       #     name: devicetests_android_api_30
       #     runChecks: false
       #     displayName: Android API 30
       #     publishOutputSuffix: '-android30'
-      #     windowsImage: ''
       #     areaPath: $(AREA_PATH)
       #     verbosity: diagnostic
       #     cakeFile: DeviceTests/build.cake

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,7 @@ resources:
     - repository: components
       type: github
       name: xamarin/XamarinComponents
+      ref: refs/heads/dev/bond/eo-pools         # UNDONE: DO NOT MERGE TO MAIN
       endpoint: xamarin
 
 stages:
@@ -33,6 +34,8 @@ stages:
     jobs:
       - template: .ci/build.yml@components
         parameters:
+          windowsAgentPoolName: AzurePipelines-EO
+          windowsImageOverride: AzurePipelinesWindows2019compliant
           areaPath: 'DevDiv\Xamarin SDK'
           masterBranchName: 'main'
           preBuildSteps:
@@ -73,7 +76,9 @@ stages:
         # skip for now
         condition: false
         pool:
-          vmImage: windows-2019
+          name: AzurePipelines-EO
+          demands:
+          - ImageOverride -equals AzurePipelinesWindows2019compliant
         steps:
           - script: 'certutil -importpfx $(Build.SourcesDirectory)\DeviceTests\DeviceTests.UWP\DeviceTests.UWP_TemporaryKey.pfx'
             displayName: 'Run certutil'
@@ -90,6 +95,8 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsAgentPoolName: AzurePipelines-EO
+          windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_ios
           runChecks: false
           displayName: iOS
@@ -103,6 +110,8 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsAgentPoolName: AzurePipelines-EO
+          windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_21
           runChecks: false
           displayName: Android API 21
@@ -119,6 +128,8 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsAgentPoolName: AzurePipelines-EO
+          windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_22
           runChecks: false
           displayName: Android API 22
@@ -135,6 +146,8 @@ stages:
 
 #       - template: .ci/build.yml@components
 #         parameters:
+#           windowsAgentPoolName: AzurePipelines-EO
+#           windowsImageOverride: AzurePipelinesWindows2019compliant
 #           name: devicetests_android_api_23
 #           runChecks: false
 #           continueOnError: true
@@ -152,6 +165,8 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsAgentPoolName: AzurePipelines-EO
+          windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_24
           runChecks: false
           displayName: Android API 24
@@ -168,6 +183,8 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsAgentPoolName: AzurePipelines-EO
+          windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_26
           runChecks: false
           displayName: Android API 26
@@ -184,6 +201,8 @@ stages:
 
       - template: .ci/build.yml@components
         parameters:
+          windowsAgentPoolName: AzurePipelines-EO
+          windowsImageOverride: AzurePipelinesWindows2019compliant
           name: devicetests_android_api_29
           runChecks: false
           displayName: Android API 29
@@ -200,6 +219,8 @@ stages:
 
       # - template: .ci/build.yml@components
       #   parameters:
+      #     windowsAgentPoolName: AzurePipelines-EO
+      #     windowsImageOverride: AzurePipelinesWindows2019compliant
       #     name: devicetests_android_api_30
       #     runChecks: false
       #     displayName: Android API 30


### PR DESCRIPTION
### Description of Change ###

Per Executive Order (EO) migrate all jobs that currently use a Windows hosted pool to instead use the `AzurePipelines-EO` agent pool instead.

Executive Order
https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/buildinfraops

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
