### PR TITLE
Fix #1972 - allow restricted permissions for geolocation on android

### DIFF
--- a/Xamarin.Essentials/Geolocation/Geolocation.android.cs
+++ b/Xamarin.Essentials/Geolocation/Geolocation.android.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Essentials
 
         static async Task<Location> PlatformLastKnownLocationAsync()
         {
-            await Permissions.EnsureGrantedAsync<Permissions.LocationWhenInUse>();
+            await Permissions.EnsureGrantedAsync<Permissions.LocationWhenInUse>(true);
 
             var lm = Platform.LocationManager;
             AndroidLocation bestLocation = null;
@@ -37,7 +37,7 @@ namespace Xamarin.Essentials
 
         static async Task<Location> PlatformLocationAsync(GeolocationRequest request, CancellationToken cancellationToken)
         {
-            await Permissions.EnsureGrantedAsync<Permissions.LocationWhenInUse>();
+            await Permissions.EnsureGrantedAsync<Permissions.LocationWhenInUse>(true);
 
             var locationManager = Platform.LocationManager;
 

--- a/Xamarin.Essentials/Geolocation/Geolocation.android.cs
+++ b/Xamarin.Essentials/Geolocation/Geolocation.android.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Essentials
 
         static async Task<Location> PlatformLastKnownLocationAsync()
         {
-            await Permissions.EnsureGrantedAsync<Permissions.LocationWhenInUse>(true);
+            await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
             var lm = Platform.LocationManager;
             AndroidLocation bestLocation = null;
@@ -37,7 +37,7 @@ namespace Xamarin.Essentials
 
         static async Task<Location> PlatformLocationAsync(GeolocationRequest request, CancellationToken cancellationToken)
         {
-            await Permissions.EnsureGrantedAsync<Permissions.LocationWhenInUse>(true);
+            await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
             var locationManager = Platform.LocationManager;
 

--- a/Xamarin.Essentials/Permissions/Permissions.shared.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.cs
@@ -20,12 +20,12 @@ namespace Xamarin.Essentials
             where TPermission : BasePermission, new() =>
                 new TPermission().EnsureDeclared();
 
-        internal static async Task EnsureGrantedAsync<TPermission>()
+        internal static async Task EnsureGrantedAsync<TPermission>(bool allowRestricted = false)
             where TPermission : BasePermission, new()
         {
             var status = await RequestAsync<TPermission>();
 
-            if (status != PermissionStatus.Granted)
+            if (status != PermissionStatus.Granted || (allowRestricted && status == PermissionStatus.Restricted))
                 throw new PermissionException($"{typeof(TPermission).Name} permission was not granted: {status}");
         }
 

--- a/Xamarin.Essentials/Permissions/Permissions.shared.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.cs
@@ -20,13 +20,22 @@ namespace Xamarin.Essentials
             where TPermission : BasePermission, new() =>
                 new TPermission().EnsureDeclared();
 
-        internal static async Task EnsureGrantedAsync<TPermission>(bool allowRestricted = false)
+        internal static async Task EnsureGrantedAsync<TPermission>()
             where TPermission : BasePermission, new()
         {
             var status = await RequestAsync<TPermission>();
 
-            if (status != PermissionStatus.Granted || (allowRestricted && status == PermissionStatus.Restricted))
+            if (status != PermissionStatus.Granted)
                 throw new PermissionException($"{typeof(TPermission).Name} permission was not granted: {status}");
+        }
+
+        internal static async Task EnsureGrantedOrRestrictedAsync<TPermission>()
+            where TPermission : BasePermission, new()
+        {
+            var status = await RequestAsync<TPermission>();
+
+            if (status != PermissionStatus.Granted && status != PermissionStatus.Restricted)
+                throw new PermissionException($"{typeof(TPermission).Name} permission was not granted or restricted: {status}");
         }
 
         public abstract partial class BasePermission


### PR DESCRIPTION
### Description of Change ###
Allow restricted permissions for "gatekeepers" on android geolocation methods

### Bugs Fixed ###

- Related to issue #
(https://github.com/xamarin/Essentials/issues/1972)

### API Changes ###

Optional parameter added to Permissions.EnsureGrantedAsync that also allows restricted to pass internal gatekeepers.  Default is set to false, so only methods where this is required functionality will care


### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of `main` at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
