### PR TITLE
Surface exception for not supported phone number on iOS PhoneDialer

### DIFF
--- a/Xamarin.Essentials/PhoneDialer/PhoneDialer.ios.cs
+++ b/Xamarin.Essentials/PhoneDialer/PhoneDialer.ios.cs
@@ -11,12 +11,12 @@ namespace Xamarin.Essentials
 
         internal static bool IsSupported => UIApplication.SharedApplication.CanOpenUrl(CreateNsUrl(new string('0', 10)));
 
-        static async void PlatformOpen(string number)
+        static void PlatformOpen(string number)
         {
             ValidateOpen(number);
 
             var nsUrl = CreateNsUrl(number);
-            await Launcher.PlatformOpenAsync(nsUrl);
+            Launcher.PlatformOpenAsync(nsUrl);
         }
 
         static NSUrl CreateNsUrl(string number) => new NSUrl(new Uri($"tel:{number}").AbsoluteUri);


### PR DESCRIPTION
### Description of Change ###

Doesn't swallow the exception because of the `async void` that was going on

### Bugs Fixed ###

- Fixes #1652
- Fixes #1984

### API Changes ###
N/A

### Behavioral Changes ###

Doesn't swallow the exception because of the `async void` that was going on

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
