### PR TITLE
added contact phone number type and default (android only so far)

### DIFF
--- a/Xamarin.Essentials/Types/Contact.shared.cs
+++ b/Xamarin.Essentials/Types/Contact.shared.cs
@@ -86,6 +86,13 @@ namespace Xamarin.Essentials
 
     public class ContactPhone
     {
+        public enum PhoneTypes
+        {
+            Unknown,
+            Mobile,
+            Land,
+        }
+
         public ContactPhone()
         {
         }
@@ -95,7 +102,18 @@ namespace Xamarin.Essentials
             PhoneNumber = phoneNumber;
         }
 
+        public ContactPhone(string phoneNumber, PhoneTypes phoneType, bool isDefault)
+        {
+            PhoneNumber = phoneNumber;
+            PhoneType = phoneType;
+            IsDefault = isDefault;
+        }
+
         public string PhoneNumber { get; set; }
+
+        public PhoneTypes PhoneType { get; set; } = PhoneTypes.Unknown;
+
+        public bool IsDefault { get; set; }
 
         public override string ToString() => PhoneNumber;
     }


### PR DESCRIPTION
 
### Description of Change ###

Added additional Contact meta data for phone number type and default (currently Android-only).
It's a minor change and existing tests/samples/docs should be sufficient.

### Bugs Fixed ###

- Related to issue #

none

### API Changes ###

Added: 
 
ContactPhone.PhoneType and ContactPhone.IsDefault properties which are populated on Android.

Changed:

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
