### PR TITLE
Added Device ID to DeviceInfo

### DIFF
--- a/Samples/Samples/View/DeviceInfoPage.xaml
+++ b/Samples/Samples/View/DeviceInfoPage.xaml
@@ -14,6 +14,7 @@
         <ScrollView>
             <StackLayout Padding="12,0,12,12" Spacing="6">
                 <Label Text="Device Info:" FontAttributes="Bold" Margin="0,6,0,0" />
+                <Label Text="{Binding DeviceId, StringFormat='Device ID: {0}'}" />
                 <Label Text="{Binding Model, StringFormat='Model: {0}'}" />
                 <Label Text="{Binding Manufacturer, StringFormat='Manufacturer: {0}'}" />
                 <Label Text="{Binding Name, StringFormat='Device Name: {0}'}" />

--- a/Samples/Samples/ViewModel/DeviceInfoViewModel.cs
+++ b/Samples/Samples/ViewModel/DeviceInfoViewModel.cs
@@ -6,6 +6,8 @@ namespace Samples.ViewModel
     {
         DisplayInfo screenMetrics;
 
+        public string DeviceId => DeviceInfo.DeviceId;
+
         public string Model => DeviceInfo.Model;
 
         public string Manufacturer => DeviceInfo.Manufacturer;

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
@@ -10,6 +10,14 @@ namespace Xamarin.Essentials
     {
         const int tabletCrossover = 600;
 
+        static string GetDeviceId()
+        {
+            var context = Application.Context;
+            var id = Settings.Secure.GetString(context.ContentResolver, Settings.Secure.AndroidId);
+
+            return id;
+        }
+
         static string GetModel() => Build.Model;
 
         static string GetManufacturer() => Build.Manufacturer;

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Essentials
 {
     public static partial class DeviceInfo
     {
+        static string GetDeviceId() => UIDevice.CurrentDevice.IdentifierForVendor.AsString();
+
         static string GetModel()
         {
             try

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.macos.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.macos.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using CoreFoundation;
 using Foundation;
 using ObjCRuntime;
 
@@ -13,8 +14,42 @@ namespace Xamarin.Essentials
         [DllImport(Constants.CoreFoundationLibrary)]
         static extern void CFRelease(IntPtr cf);
 
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern uint IOServiceGetMatchingService(uint masterPort, IntPtr matching);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern IntPtr IOServiceMatching(string s);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern IntPtr IORegistryEntryCreateCFProperty(uint entry, IntPtr key, IntPtr allocator, uint options);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern int IOObjectRelease(uint o);
+
         static string GetModel() =>
             IOKit.GetPlatformExpertPropertyValue<NSData>("model")?.ToString() ?? string.Empty;
+
+        static string GetDeviceId() => GetSerial();
+
+        static string GetSerial()
+        {
+            var serial = string.Empty;
+            var platformExpert = IOServiceGetMatchingService(0, IOServiceMatching("IOPlatformExpertDevice"));
+
+            if (platformExpert != 0)
+            {
+                var key = (CFString)"IOPlatformSerialNumber";
+                var serialNumber = IORegistryEntryCreateCFProperty(platformExpert, key.Handle, IntPtr.Zero, 0);
+
+                if (serialNumber != IntPtr.Zero)
+                {
+                    serial = CFString.FromHandle(serialNumber);
+                }
+
+                IOObjectRelease(platformExpert);
+            }
+            return serial;
+        }
 
         static string GetManufacturer() => "Apple";
 

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.macos.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.macos.cs
@@ -29,9 +29,7 @@ namespace Xamarin.Essentials
         static string GetModel() =>
             IOKit.GetPlatformExpertPropertyValue<NSData>("model")?.ToString() ?? string.Empty;
 
-        static string GetDeviceId() => GetSerial();
-
-        static string GetSerial()
+        static string GetDeviceId()
         {
             var serial = string.Empty;
             var platformExpert = IOServiceGetMatchingService(0, IOServiceMatching("IOPlatformExpertDevice"));

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.netstandard.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.netstandard.cs
@@ -2,6 +2,8 @@
 {
     public static partial class DeviceInfo
     {
+        static string GetDeviceId() => throw ExceptionUtils.NotSupportedOrImplementedException;
+
         static string GetModel() => throw ExceptionUtils.NotSupportedOrImplementedException;
 
         static string GetManufacturer() => throw ExceptionUtils.NotSupportedOrImplementedException;

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.shared.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.shared.cs
@@ -4,6 +4,8 @@ namespace Xamarin.Essentials
 {
     public static partial class DeviceInfo
     {
+        public static string DeviceId => GetDeviceId();
+
         public static string Model => GetModel();
 
         public static string Manufacturer => GetManufacturer();

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.tizen.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.tizen.cs
@@ -4,6 +4,9 @@ namespace Xamarin.Essentials
 {
     public static partial class DeviceInfo
     {
+        static string GetDeviceId()
+            => Plat.GetSystemInfo("tizenid");
+
         static string GetModel()
            => Plat.GetSystemInfo("model_name");
 

--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.uwp.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.uwp.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Essentials
             }
         }
 
+        static string GetDeviceId() => SystemIdentification.GetSystemIdForPublisher();
+
         static string GetModel() => deviceInfo.SystemProductName;
 
         static string GetManufacturer() => deviceInfo.SystemManufacturer;

--- a/docs/en/FrameworksIndex/xamarin-essentials-android.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-android.xml
@@ -280,6 +280,7 @@
       <Member Id="P:Xamarin.Essentials.DeviceIdiom.Watch" />
     </Type>
     <Type Name="Xamarin.Essentials.DeviceInfo" Id="T:Xamarin.Essentials.DeviceInfo">
+      <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceId" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceType" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Idiom" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Manufacturer" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-ios.xml
@@ -268,6 +268,7 @@
       <Member Id="P:Xamarin.Essentials.DeviceIdiom.Watch" />
     </Type>
     <Type Name="Xamarin.Essentials.DeviceInfo" Id="T:Xamarin.Essentials.DeviceInfo">
+      <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceId" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceType" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Idiom" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Manufacturer" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-macos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-macos.xml
@@ -267,6 +267,7 @@
       <Member Id="P:Xamarin.Essentials.DeviceIdiom.Watch" />
     </Type>
     <Type Name="Xamarin.Essentials.DeviceInfo" Id="T:Xamarin.Essentials.DeviceInfo">
+      <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceId" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceType" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Idiom" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Manufacturer" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-tvos.xml
@@ -267,6 +267,7 @@
       <Member Id="P:Xamarin.Essentials.DeviceIdiom.Watch" />
     </Type>
     <Type Name="Xamarin.Essentials.DeviceInfo" Id="T:Xamarin.Essentials.DeviceInfo">
+      <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceId" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceType" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Idiom" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Manufacturer" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-uwp.xml
@@ -269,6 +269,7 @@
       <Member Id="P:Xamarin.Essentials.DeviceIdiom.Watch" />
     </Type>
     <Type Name="Xamarin.Essentials.DeviceInfo" Id="T:Xamarin.Essentials.DeviceInfo">
+      <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceId" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceType" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Idiom" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Manufacturer" />

--- a/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials-watchos.xml
@@ -267,6 +267,7 @@
       <Member Id="P:Xamarin.Essentials.DeviceIdiom.Watch" />
     </Type>
     <Type Name="Xamarin.Essentials.DeviceInfo" Id="T:Xamarin.Essentials.DeviceInfo">
+      <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceId" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceType" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Idiom" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Manufacturer" />

--- a/docs/en/FrameworksIndex/xamarin-essentials.xml
+++ b/docs/en/FrameworksIndex/xamarin-essentials.xml
@@ -266,6 +266,7 @@
       <Member Id="P:Xamarin.Essentials.DeviceIdiom.Watch" />
     </Type>
     <Type Name="Xamarin.Essentials.DeviceInfo" Id="T:Xamarin.Essentials.DeviceInfo">
+      <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceId" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.DeviceType" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Idiom" />
       <Member Id="P:Xamarin.Essentials.DeviceInfo.Manufacturer" />

--- a/docs/en/Xamarin.Essentials/DeviceInfo.xml
+++ b/docs/en/Xamarin.Essentials/DeviceInfo.xml
@@ -15,6 +15,24 @@
     <remarks></remarks>
   </Docs>
   <Members>
+    <Member MemberName="DeviceId">
+      <MemberSignature Language="C#" Value="public static string DeviceId { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property string DeviceId" />
+      <MemberSignature Language="DocId" Value="P:Xamarin.Essentials.DeviceInfo.DeviceId" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Xamarin.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets the ID of the device.</summary>
+        <value>Device ID.</value>
+        <remarks></remarks>
+      </Docs>
+    </Member>
     <Member MemberName="DeviceType">
       <MemberSignature Language="C#" Value="public static Xamarin.Essentials.DeviceType DeviceType { get; }" />
       <MemberSignature Language="ILAsm" Value=".property valuetype Xamarin.Essentials.DeviceType DeviceType" />


### PR DESCRIPTION
### Description of Change ###

Added Device ID to DeviceInfo. Useful for distinguishing between various devices a user owns that your app may be installed on.

### API Changes ###

Added: 
 
- `static string DeviceInfo.DeviceId { get; set; }`

### PR Checklist ###

- [x] Has tests (N/A for DeviceInfo)
- [x] Has samples
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
