### PR TITLE
Permissions check method shoud not throw exception when permissions not in manifest

### DIFF
--- a/Samples/Samples.Android/Properties/AndroidManifest.xml
+++ b/Samples/Samples.Android/Properties/AndroidManifest.xml
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.essentials" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
-	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.BATTERY_STATS" />
 	<uses-permission android:name="android.permission.CAMERA" />
@@ -10,6 +8,9 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
+	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<queries>
 		<!-- Email -->
 		<intent>

--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -61,7 +61,12 @@ namespace Xamarin.Essentials
                 {
                     var ap = androidPermission;
                     if (!IsDeclaredInManifest(ap))
-                        throw new PermissionException($"You need to declare using the permission: `{androidPermission}` in your AndroidManifest.xml");
+                    {
+                        if (androidPermission != Manifest.Permission.AccessFineLocation)
+                            System.Diagnostics.Debug.WriteLine($"You need to declare using the permission: `{androidPermission}` in your AndroidManifest.xml");
+
+                        return Task.FromResult(PermissionStatus.Denied);
+                    }
 
                     var status = DoCheck(ap);
                     if (status != PermissionStatus.Granted)
@@ -98,7 +103,12 @@ namespace Xamarin.Essentials
                 var targetsMOrHigher = context.ApplicationInfo.TargetSdkVersion >= BuildVersionCodes.M;
 
                 if (!IsDeclaredInManifest(androidPermission))
-                    throw new PermissionException($"You need to declare using the permission: `{androidPermission}` in your AndroidManifest.xml");
+                {
+                    if (androidPermission != Manifest.Permission.AccessFineLocation)
+                        System.Diagnostics.Debug.WriteLine($"You need to declare using the permission: `{androidPermission}` in your AndroidManifest.xml");
+
+                    return PermissionStatus.Denied;
+                }
 
                 var status = PermissionStatus.Granted;
 


### PR DESCRIPTION

### Description of Change ###

I believe that the Check methods should not throw exceptions since it just asks if it has permissions.
If you request the same with the Android API you also don't get exceptions, just Permission.Denied.

To be able to use Geo Location without FINE_LOCATION ([which is recommended now](https://developer.android.com/training/location/permissions#approximate-request)) it should not crash when only COARSE_LOCATION permission is set.

Also added permission to write external storage in the Android Sample app since it's needed for the MediaPicker.

### Bugs Fixed ###

Related to issue(s)
- #2009

### API Changes ###

No API changes. Just removed exceptions and replace with line in debug console to set the correct permission.
 
### Behavioral Changes ###

People might try/catch for the exception but get a permission denied now. Which is only an improvement.

### PR Checklist ###

- [ ] Has tests => simple change checked with the sample repo
- [ ] Has samples => simple change checked with the sample repo
- [X] Rebased on top of `main` at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation
