### PR TITLE
Bump AspNet.Security.OAuth.Apple to 3.1.8

### DIFF
--- a/Samples/Sample.Server.WebAuthenticator/Sample.Server.WebAuthenticator.csproj
+++ b/Samples/Sample.Server.WebAuthenticator/Sample.Server.WebAuthenticator.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.Apple" Version="3.0.0" />
+    <PackageReference Include="AspNet.Security.OAuth.Apple" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.2" />


### PR DESCRIPTION
### Description of Change ###

Bump AspNet.Security.OAuth.Apple to 3.1.8 to resolve https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/security/advisories/GHSA-3893-h8qg-6h5f.

I've also submitted a similar patch to https://github.com/dotnet/maui/pull/9855.
