### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/PRODUCT-FEEDBACK.md
+++ b/PRODUCT-FEEDBACK.md
@@ -3,7 +3,7 @@
 We'd love to hear your thoughts on Xamarin.Essentials. Here are a few links to help get you to the right place:
 
 ### Setup and Common Questions
-* Read through our full [Getting Started with Xamarin.Essetials Guide](https://docs.microsoft.com/xamarin/essentials/get-started)
+* Read through our full [Getting Started with Xamarin.Essetials Guide](https://learn.microsoft.com/xamarin/essentials/get-started)
 * [Frequently Asked Questions on our Wiki](https://github.com/xamarin/Essentials/wiki/FAQ-%7C-Essentials)
 
 ### Propose a Feature

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ iOS, Android, and UWP offer unique operating system and platform APIs that devel
 
 ## Questions
 
-Get your technical questions answered by experts on [Microsoft Q&A](https://docs.microsoft.com/answers/topics/dotnet-xamarinessentials.html?WT.mc_id=friends-0000-jamont).
+Get your technical questions answered by experts on [Microsoft Q&A](https://learn.microsoft.com/answers/topics/dotnet-xamarinessentials.html?WT.mc_id=friends-0000-jamont).
 
 ## Contribution Discussion
 
@@ -33,15 +33,15 @@ Xamarin.Essentials is available via NuGet & is included in every template:
 * NuGet Official Releases: [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.Essentials.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.Essentials)
 * Nightly / CI Releases: https://aka.ms/xamarin-essentials-ci/index.json
 
-Please read our [Getting Started with Xamarin.Essentials guide](https://docs.microsoft.com/xamarin/essentials/get-started?WT.mc_id=friends-0000-jamont) for full setup instructions.
+Please read our [Getting Started with Xamarin.Essentials guide](https://learn.microsoft.com/xamarin/essentials/get-started?WT.mc_id=friends-0000-jamont) for full setup instructions.
 
 ## Documentation
 
-Browse our [full documentation for Xamarin.Essentials](https://docs.microsoft.com/xamarin/essentials?WT.mc_id=friends-0000-jamont), including feature guides, on how to use each feature.
+Browse our [full documentation for Xamarin.Essentials](https://learn.microsoft.com/xamarin/essentials?WT.mc_id=friends-0000-jamont), including feature guides, on how to use each feature.
 
 ## Supported Platforms
 
-Platform support & feature support can be found on our [documentation](https://docs.microsoft.com/xamarin/essentials/platform-feature-support?WT.mc_id=friends-0000-jamont)
+Platform support & feature support can be found on our [documentation](https://learn.microsoft.com/xamarin/essentials/platform-feature-support?WT.mc_id=friends-0000-jamont)
 
 
 ## Contributing


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
