### PR TITLE
added push permissions for Android & iOS

### DIFF
--- a/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
+++ b/DeviceTests/DeviceTests.Android/DeviceTests.Android.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>DeviceTests.Droid</RootNamespace>
     <AssemblyName>XamarinEssentialsDeviceTestsAndroid</AssemblyName>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidUseIntermediateDesignerFile>true</AndroidUseIntermediateDesignerFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>

--- a/DeviceTests/DeviceTests.Shared/DeviceTests.Shared.csproj
+++ b/DeviceTests/DeviceTests.Shared/DeviceTests.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">Xamarin.iOS10;MonoAndroid10.0;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">Xamarin.iOS10;MonoAndroid10.0;</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">Xamarin.iOS10;MonoAndroid13.0;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">Xamarin.iOS10;MonoAndroid13.0;</TargetFrameworks>
     <AssemblyName>XamarinEssentialsDeviceTestsShared</AssemblyName>
     <RootNamespace>DeviceTests.Shared</RootNamespace>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>

--- a/DeviceTests/build.cake
+++ b/DeviceTests/build.cake
@@ -36,7 +36,7 @@ var OUTPUT_PATH = MakeAbsolute((DirectoryPath)"../output/");
 var ANDROID_HOME = EnvironmentVariable("ANDROID_HOME");
 
 System.Environment.SetEnvironmentVariable("PATH",
-    $"{ANDROID_HOME}/tools/bin" + System.IO.Path.PathSeparator +
+    $"{ANDROID_HOME}/cmdline-tools/latest/bin" + System.IO.Path.PathSeparator +
     $"{ANDROID_HOME}/platform-tools" + System.IO.Path.PathSeparator +
     $"{ANDROID_HOME}/emulator" + System.IO.Path.PathSeparator +
     EnvironmentVariable("PATH"));

--- a/Samples/Samples.Android/Samples.Android.csproj
+++ b/Samples/Samples.Android/Samples.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>

--- a/Xamarin.Essentials/AppInfo/AppInfo.android.cs
+++ b/Xamarin.Essentials/AppInfo/AppInfo.android.cs
@@ -26,7 +26,9 @@ namespace Xamarin.Essentials
         {
             var pm = Platform.AppContext.PackageManager;
             var packageName = Platform.AppContext.PackageName;
+#pragma warning disable CS0618
             using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
+#pragma warning restore CS0618
             {
                 return info.VersionName;
             }
@@ -36,7 +38,9 @@ namespace Xamarin.Essentials
         {
             var pm = Platform.AppContext.PackageManager;
             var packageName = Platform.AppContext.PackageName;
+#pragma warning disable CS0618
             using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
+#pragma warning restore CS0618
             {
 #if __ANDROID_28__
                 return PackageInfoCompat.GetLongVersionCode(info).ToString(CultureInfo.InvariantCulture);

--- a/Xamarin.Essentials/Connectivity/Connectivity.android.cs
+++ b/Xamarin.Essentials/Connectivity/Connectivity.android.cs
@@ -123,7 +123,9 @@ namespace Xamarin.Essentials
 
                     if (Platform.HasApiLevel(BuildVersionCodes.Lollipop))
                     {
+#pragma warning disable CS0618
                         var networks = manager.GetAllNetworks();
+#pragma warning restore CS0618
 
                         // some devices running 21 and 22 only use the older api.
                         if (networks.Length == 0 && (int)Build.VERSION.SdkInt < 23)
@@ -212,7 +214,9 @@ namespace Xamarin.Essentials
                 var manager = Platform.ConnectivityManager;
                 if (Platform.HasApiLevel(BuildVersionCodes.Lollipop))
                 {
+#pragma warning disable CS0618
                     foreach (var network in manager.GetAllNetworks())
+#pragma warning restore CS0618
                     {
 #pragma warning disable CS0618 // Type or member is obsolete
                         NetworkInfo info = null;

--- a/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.android.cs
+++ b/Xamarin.Essentials/DeviceDisplay/DeviceDisplay.android.cs
@@ -37,7 +37,9 @@ namespace Xamarin.Essentials
         {
             using var displayMetrics = new DisplayMetrics();
             var display = GetDefaultDisplay();
+#pragma warning disable CS0618
             display?.GetRealMetrics(displayMetrics);
+#pragma warning restore CS0618
 
             return new DisplayInfo(
                 width: displayMetrics?.WidthPixels ?? 0,

--- a/Xamarin.Essentials/FileSystem/FileSystem.android.cs
+++ b/Xamarin.Essentials/FileSystem/FileSystem.android.cs
@@ -200,7 +200,9 @@ namespace Xamarin.Essentials
                     else if (storageType.Equals(storageTypeAudio, StringComparison.OrdinalIgnoreCase))
                         contentUri = MediaStore.Audio.Media.ExternalContentUri;
 
+#pragma warning disable CS0618
                     if (contentUri != null && GetDataFilePath(contentUri, $"{MediaStore.MediaColumns.Id}=?", new[] { uriPath }) is string filePath)
+#pragma warning restore CS0618
                         return filePath;
                 }
             }
@@ -237,7 +239,9 @@ namespace Xamarin.Essentials
                 return null;
 
             // resolve or generate a valid destination path
+#pragma warning disable CS0618
             var filename = GetColumnValue(uri, MediaStore.Files.FileColumns.DisplayName) ?? Guid.NewGuid().ToString("N");
+#pragma warning restore CS0618
             if (!Path.HasExtension(filename) && !string.IsNullOrEmpty(extension))
                 filename = Path.ChangeExtension(filename, extension);
 

--- a/Xamarin.Essentials/Flashlight/Flashlight.android.cs
+++ b/Xamarin.Essentials/Flashlight/Flashlight.android.cs
@@ -5,7 +5,9 @@ using Android.Graphics;
 using Android.Hardware.Camera2;
 using Android.OS;
 
+#pragma warning disable CS0618
 using Camera = Android.Hardware.Camera;
+#pragma warning restore CS0618
 
 namespace Xamarin.Essentials
 {

--- a/Xamarin.Essentials/Launcher/Launcher.android.cs
+++ b/Xamarin.Essentials/Launcher/Launcher.android.cs
@@ -18,7 +18,9 @@ namespace Xamarin.Essentials
                 return Task.FromResult(false);
 
             var manager = Platform.AppContext.PackageManager;
+#pragma warning disable CS0618
             var supportedResolvedInfos = manager.QueryIntentActivities(intent, PackageInfoFlags.MatchDefaultOnly);
+#pragma warning restore CS0618
             return Task.FromResult(supportedResolvedInfos.Any());
         }
 

--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -20,7 +20,9 @@ namespace Xamarin.Essentials
         public static bool IsDeclaredInManifest(string permission)
         {
             var context = Platform.AppContext;
+#pragma warning disable CS0618
             var packageInfo = context.PackageManager.GetPackageInfo(context.PackageName, PackageInfoFlags.Permissions);
+#pragma warning restore CS0618
             var requestedPermissions = packageInfo?.RequestedPermissions;
 
             return requestedPermissions?.Any(r => r.Equals(permission, StringComparison.OrdinalIgnoreCase)) ?? false;
@@ -465,6 +467,18 @@ namespace Xamarin.Essentials
         {
             public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
                 new (string, bool)[] { (Manifest.Permission.Vibrate, false) };
+        }
+
+        public partial class PushNotification : BasePlatformPermission
+        {
+#if __ANDROID_33__
+            public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
+                new (string, bool)[] { (Manifest.Permission.PostNotifications, true) };
+#endif
+        }
+
+        public partial class ProvisionalPushNotification : BasePlatformPermission
+        {
         }
     }
 }

--- a/Xamarin.Essentials/Permissions/Permissions.ios.tvos.watchos.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.ios.tvos.watchos.cs
@@ -293,7 +293,7 @@ namespace Xamarin.Essentials
                     UNAuthorizationStatus.NotDetermined => PermissionStatus.Unknown,
                     UNAuthorizationStatus.Denied => PermissionStatus.Denied,
                     UNAuthorizationStatus.Authorized => PermissionStatus.Granted,
-                    UNAuthorizationStatus.Provisional => PermissionStatus.Granted,
+                    UNAuthorizationStatus.Provisional => PermissionStatus.Restricted,
                     UNAuthorizationStatus.Ephemeral => PermissionStatus.Granted,
                     _ => throw new ArgumentOutOfRangeException(
                         paramName: nameof(UNNotificationSettings.AuthorizationStatus),

--- a/Xamarin.Essentials/Permissions/Permissions.shared.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.shared.cs
@@ -145,5 +145,13 @@ namespace Xamarin.Essentials
         public partial class Vibrate
         {
         }
+
+        public partial class PushNotification
+        {
+        }
+
+        public partial class ProvisionalPushNotification
+        {
+        }
     }
 }

--- a/Xamarin.Essentials/Platform/Platform.android.cs
+++ b/Xamarin.Essentials/Platform/Platform.android.cs
@@ -196,7 +196,9 @@ namespace Xamarin.Essentials
             AppContext.GetSystemService(Context.ConnectivityService) as ConnectivityManager;
 
         internal static Vibrator Vibrator =>
+#pragma warning disable CS0618
             AppContext.GetSystemService(Context.VibratorService) as Vibrator;
+#pragma warning restore CS0618
 
         internal static WifiManager WifiManager =>
             AppContext.GetSystemService(Context.WifiService) as WifiManager;
@@ -356,7 +358,9 @@ namespace Xamarin.Essentials
 
             // read the values
             launched = extras.GetBoolean(launchedExtra, false);
+#pragma warning disable CS0618
             actualIntent = extras.GetParcelable(actualIntentExtra) as Intent;
+#pragma warning restore CS0618
             guid = extras.GetString(guidExtra);
             requestCode = extras.GetInt(requestCodeExtra, -1);
 

--- a/Xamarin.Essentials/Types/LocationExtensions.android.cs
+++ b/Xamarin.Essentials/Types/LocationExtensions.android.cs
@@ -36,7 +36,9 @@ namespace Xamarin.Essentials
 #endif
                 Course = location.HasBearing ? location.Bearing : default(double?),
                 Speed = location.HasSpeed ? location.Speed : default(double?),
+#pragma warning disable CS0618
                 IsFromMockProvider = Platform.HasApiLevel(global::Android.OS.BuildVersionCodes.JellyBeanMr2) ? location.IsFromMockProvider : false,
+#pragma warning restore CS0618
                 AltitudeReferenceSystem = AltitudeReferenceSystem.Ellipsoid
             };
 

--- a/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
+++ b/Xamarin.Essentials/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
@@ -22,7 +22,9 @@ namespace Xamarin.Essentials
 
             // read the values
             launched = extras?.GetBoolean(launchedExtra, false) ?? false;
+#pragma warning disable CS0618
             actualIntent = extras?.GetParcelable(actualIntentExtra) as Intent;
+#pragma warning restore CS0618
         }
 
         protected override void OnResume()

--- a/Xamarin.Essentials/Xamarin.Essentials.csproj
+++ b/Xamarin.Essentials/Xamarin.Essentials.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.WatchOS10;MonoAndroid10.0;tizen40;Xamarin.Mac20;</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.WatchOS10;MonoAndroid13.0;tizen40;Xamarin.Mac20;</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.16299;</TargetFrameworks>
     <AssemblyName>Xamarin.Essentials</AssemblyName>
     <RootNamespace>Xamarin.Essentials</RootNamespace>

--- a/Xamarin.Essentials/mdoc.targets
+++ b/Xamarin.Essentials/mdoc.targets
@@ -89,7 +89,7 @@
       <TmpDir>$(MSBuildProjectDirectory)\tmp\</TmpDir>
     </PropertyGroup>
     <ItemGroup>
-      <MDocReferenceAssembly Include="$(BinConfigDir)monoandroid10.0" />
+      <MDocReferenceAssembly Include="$(BinConfigDir)monoandroid13.0" />
     </ItemGroup>
     <PropertyGroup>
       <MDocReferenceAssemblies>@(MDocReferenceAssembly -> '--lib=&quot;%(Identity)&quot;', ' ')</MDocReferenceAssemblies>
@@ -98,7 +98,7 @@
     <MakeDir Directories="$(TmpDir)" />
     <Copy SourceFiles="$(MDocDocumentationDirectory)\..\frameworks.xml" DestinationFolder="$(TmpDir)" />
     <Copy SourceFiles="$(BinConfigDir)netstandard2.0\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials" />
-    <Copy SourceFiles="$(BinConfigDir)monoandroid10.0\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials-android" />
+    <Copy SourceFiles="$(BinConfigDir)monoandroid13.0\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials-android" />
     <Copy SourceFiles="$(BinConfigDir)xamarin.ios10\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials-ios" />
     <Copy SourceFiles="$(BinConfigDir)xamarin.mac20\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials-macos" />
     <Copy SourceFiles="$(BinConfigDir)xamarin.tvos10\$(AssemblyName).dll" DestinationFolder="$(TmpDir)xamarin-essentials-tvos" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ stages:
           windowsImage: ''  # Override the 'windows-latest' default settings
           windowsImageOverride: AzurePipelinesWindows2019compliant
         ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
-          windowsImage: windows-2019
+          windowsImage: windows-2022
         areaPath: 'DevDiv\Xamarin SDK'
         masterBranchName: 'main'
         ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}: #we are shipping our product
@@ -106,7 +106,7 @@ stages:
               demands:
               - ImageOverride -equals AzurePipelinesWindows2019compliant
             ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
-              vmImage: windows-2019
+              vmImage: windows-2022
           steps:
             - script: 'certutil -importpfx $(Build.SourcesDirectory)\DeviceTests\DeviceTests.UWP\DeviceTests.UWP_TemporaryKey.pfx'
               displayName: 'Run certutil'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,15 @@ stages:
           cakeTarget: ci-release # We just want to build the library and nuget
           macosImage: '' # We don't need the macOS build
         preBuildSteps:
+          - task: JavaToolInstaller@0
+            inputs:
+              versionSpec: '11'
+              jdkArchitectureOption: 'x64'
+              jdkSourceOption: 'PreInstalled'
+            displayName: 'Set Java 11'
+          - script: |
+              dotnet tool install --global boots 
+              boots --stable Xamarin.Android
           - pwsh: |
               $pr = "pr." + $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
               $nuget = $env:BASE_VERSION + "-" + $pr + "." + $env:BUILD_NUMBER
@@ -133,7 +142,17 @@ stages:
             cakeFile: DeviceTests/build.cake
             cakeTarget: test-ios-emu
             xharness: '1.0.0-prerelease.21620.1'
-  
+            preBuildSteps:
+              - task: JavaToolInstaller@0
+                inputs:
+                  versionSpec: '11'
+                  jdkArchitectureOption: 'x64'
+                  jdkSourceOption: 'PreInstalled'
+                displayName: 'Set Java 11'
+              - script: |
+                  dotnet tool install --global boots 
+                  boots --stable Xamarin.Android
+
         - template: .ci/build.v1.yml@components
           parameters:
             name: devicetests_android_api_21
@@ -149,7 +168,15 @@ stages:
             preBuildSteps:
               - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-21;google_apis;x86\""
                 displayName: Install the Android emulators
-  
+              - task: JavaToolInstaller@0
+                inputs:
+                  versionSpec: '11'
+                  jdkArchitectureOption: 'x64'
+                  jdkSourceOption: 'PreInstalled'
+                displayName: 'Set Java 11'
+              - script: |
+                  dotnet tool install --global boots 
+                  boots --stable Xamarin.Android
         - template: .ci/build.v1.yml@components
           parameters:
             name: devicetests_android_api_22
@@ -165,7 +192,16 @@ stages:
             preBuildSteps:
               - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-22;google_apis;x86\""
                 displayName: Install the Android emulators
-  
+              - task: JavaToolInstaller@0
+                inputs:
+                  versionSpec: '11'
+                  jdkArchitectureOption: 'x64'
+                  jdkSourceOption: 'PreInstalled'
+                displayName: 'Set Java 11'
+              - script: |
+                  dotnet tool install --global boots 
+                  boots --stable Xamarin.Android
+
 #         - template: .ci/build.v1.yml@components
 #           parameters:
 #             name: devicetests_android_api_23
@@ -198,7 +234,16 @@ stages:
             preBuildSteps:
               - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-24;google_apis;x86\""
                 displayName: Install the Android emulators
-  
+              - task: JavaToolInstaller@0
+                inputs:
+                  versionSpec: '11'
+                  jdkArchitectureOption: 'x64'
+                  jdkSourceOption: 'PreInstalled'
+                displayName: 'Set Java 11'
+              - script: |
+                  dotnet tool install --global boots 
+                  boots --stable Xamarin.Android
+                  
         - template: .ci/build.v1.yml@components
           parameters:
             name: devicetests_android_api_26
@@ -214,7 +259,16 @@ stages:
             preBuildSteps:
               - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-26;google_apis;x86\""
                 displayName: Install the Android emulators
-  
+              - task: JavaToolInstaller@0
+                inputs:
+                  versionSpec: '11'
+                  jdkArchitectureOption: 'x64'
+                  jdkSourceOption: 'PreInstalled'
+                displayName: 'Set Java 11'
+              - script: |
+                  dotnet tool install --global boots 
+                  boots --stable Xamarin.Android
+
         - template: .ci/build.v1.yml@components
           parameters:
             name: devicetests_android_api_29
@@ -230,7 +284,16 @@ stages:
             preBuildSteps:
               - bash: sh -c "echo \"y\" | $ANDROID_HOME/tools/bin/sdkmanager \"system-images;android-29;google_apis;x86\""
                 displayName: Install the Android emulators
-  
+              - task: JavaToolInstaller@0
+                inputs:
+                  versionSpec: '11'
+                  jdkArchitectureOption: 'x64'
+                  jdkSourceOption: 'PreInstalled'
+                displayName: 'Set Java 11'
+              - script: |
+                  dotnet tool install --global boots 
+                  boots --stable Xamarin.Android
+
         # - template: .ci/build.v1.yml@components
         #   parameters:
         #     name: devicetests_android_api_30

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ stages:
           windowsImage: ''  # Override the 'windows-latest' default settings
           windowsImageOverride: AzurePipelinesWindows2019compliant
         ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
-          windowsImage: windows-2022
+          windowsImage: windows-2019
         areaPath: 'DevDiv\Xamarin SDK'
         masterBranchName: 'main'
         ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}: #we are shipping our product
@@ -106,7 +106,7 @@ stages:
               demands:
               - ImageOverride -equals AzurePipelinesWindows2019compliant
             ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
-              vmImage: windows-2022
+              vmImage: windows-2019
           steps:
             - script: 'certutil -importpfx $(Build.SourcesDirectory)\DeviceTests\DeviceTests.UWP\DeviceTests.UWP_TemporaryKey.pfx'
               displayName: 'Run certutil'


### PR DESCRIPTION
### Description of Change ###

Added push notification permissions for Android and iOS to the `Permissons` component.

### Bugs Fixed ###

- Related to issue #2062

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- Permission `Permissions.PushNotification`
- Permission `Permissions.ProvisionalPushNotification`

Changed:

None
 
### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests
- [ ] Has samples
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
  - Omitted, because msbuild tasks given in link is failing
