### PR TITLE
Adds Granular media permissions for Android 13+

### DIFF
--- a/DeviceTests/DeviceTests.Android/Properties/AndroidManifest.xml
+++ b/DeviceTests/DeviceTests.Android/Properties/AndroidManifest.xml
@@ -1,45 +1,56 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0.1.0" package="com.xamarin.essentials.devicetests" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
-	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.BATTERY_STATS" />
-	<uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.FLASHLIGHT" />
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.VIBRATE" />
-	<uses-permission android:name="android.permission.READ_CONTACTS" />
-	<queries>
-		<!-- Email -->
-		<intent>
-			<action android:name="android.intent.action.SENDTO" />
-			<data android:scheme="mailto" />
-		</intent>
-		<!-- Browser -->
-		<intent>
-			<action android:name="android.intent.action.VIEW" />
-			<data android:scheme="http" />
-		</intent>
-		<!-- Browser -->
-		<intent>
-			<action android:name="android.intent.action.VIEW" />
-			<data android:scheme="https" />
-		</intent>
-		<!-- Sms -->
-		<intent>
-			<action android:name="android.intent.action.VIEW" />
-			<data android:scheme="smsto" />
-		</intent>
-		<!-- PhoneDialer -->
-		<intent>
-			<action android:name="android.intent.action.DIAL" />
-			<data android:scheme="tel" />
-		</intent>
-		<!-- MediaPicker -->
-		<intent>
-			<action android:name="android.media.action.IMAGE_CAPTURE" />
-		</intent>
-	</queries>
-	<application android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/MainTheme"></application>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.essentials" android:installLocation="auto">
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
+  <!--Camera-->
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+  <!--Android 13 specific media folders-->
+  <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" android:minSdkVersion="32"/>
+  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" android:minSdkVersion="32" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="32" />
+
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.BATTERY_STATS" />
+  <uses-permission android:name="android.permission.CAMERA" />
+  <uses-permission android:name="android.permission.FLASHLIGHT" />
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.VIBRATE" />
+  <uses-permission android:name="android.permission.READ_CONTACTS" />
+  <queries>
+    <!-- Email -->
+    <intent>
+      <action android:name="android.intent.action.SENDTO" />
+      <data android:scheme="mailto" />
+    </intent>
+    <!-- Browser -->
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="http" />
+    </intent>
+    <!-- Browser -->
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="https" />
+    </intent>
+    <!-- Sms -->
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="smsto" />
+    </intent>
+    <!-- PhoneDialer -->
+    <intent>
+      <action android:name="android.intent.action.DIAL" />
+      <data android:scheme="tel" />
+    </intent>
+    <!-- MediaPicker -->
+    <intent>
+      <action android:name="android.media.action.IMAGE_CAPTURE" />
+    </intent>
+  </queries>
+  <uses-feature android:name="android.hardware.location" android:required="false" />
+  <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+  <uses-feature android:name="android.hardware.location.network" android:required="false" />
+  <application android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/MainTheme" android:fullBackupContent="@xml/my_backup_rules"></application>
 </manifest>

--- a/Samples/Samples.Android/Properties/AndroidManifest.xml
+++ b/Samples/Samples.Android/Properties/AndroidManifest.xml
@@ -1,8 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.essentials" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
-	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <!--Camera-->
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+  <!--Android 13 specific media folders-->
+  <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" android:minSdkVersion="32"/>
+  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" android:minSdkVersion="32" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="32" />
+  
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.BATTERY_STATS" />
 	<uses-permission android:name="android.permission.CAMERA" />

--- a/Xamarin.Essentials/Permissions/Permissions.android.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.android.cs
@@ -457,8 +457,22 @@ namespace Xamarin.Essentials
 
         public partial class StorageWrite : BasePlatformPermission
         {
-            public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
-                new (string, bool)[] { (Manifest.Permission.WriteExternalStorage, true) };
+            public override (string androidPermission, bool isRuntime)[] RequiredPermissions
+            {
+                get
+                {
+                    if (Platform.HasApiLevel(BuildVersionCodes.Q))
+                    {
+                        return new (string, bool)[]
+                        {
+                            ("android.permission.READ_MEDIA_IMAGES",  true),
+                            ("android.permission.READ_MEDIA_VIDEO",  true),
+                            ("android.permission.READ_MEDIA_AUDIO",  true),
+                        };
+                    }
+                    return new (string, bool)[] { (Manifest.Permission.WriteExternalStorage, true) };
+                }
+            }
         }
 
         public partial class Vibrate : BasePlatformPermission


### PR DESCRIPTION
Adds Granular media permissions for Android 13+
 https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions
 
### Description of Change ###

Adds Granular media permissions for Android 13+
Starting from Android 13 you can no longer request STORAGE_READ, and STORAGE_WRITE permissions.
Instead, you have to ask for granular permissions:
READ_MEDIA_IMAGES
READ_MEDIA_VIDEO
READ_MEDIA_AUDIO

### Bugs Fixed ###

- Related to issue #

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

https://github.com/xamarin/Essentials/issues/2037
https://github.com/xamarin/Essentials/issues/2041


### API Changes ###

 None


### Behavioral Changes ###

None

### PR Checklist ###

- [X] Has tests
- [X] Has samples
- [X] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
