### PR TITLE
Fix MediaPicker capture methods in Android 13+

### DIFF
--- a/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
@@ -56,9 +56,9 @@ namespace Xamarin.Essentials
         static async Task<FileResult> PlatformCaptureAsync(MediaPickerOptions options, bool photo)
         {
             await Permissions.EnsureGrantedAsync<Permissions.Camera>();
-			// StorageWrite no longer exists starting from Android API 33
-			if (!OperatingSystem.IsAndroidVersionAtLeast(33))
-				await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
+            // StorageWrite no longer exists starting from Android API 33
+            if (!OperatingSystem.IsAndroidVersionAtLeast(33))
+                await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
 
             var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);
 

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
@@ -56,6 +56,7 @@ namespace Xamarin.Essentials
         static async Task<FileResult> PlatformCaptureAsync(MediaPickerOptions options, bool photo)
         {
             await Permissions.EnsureGrantedAsync<Permissions.Camera>();
+
             // StorageWrite no longer exists starting from Android API 33
             if (!Platform.HasApiLevel(33))
                 await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
@@ -56,7 +56,9 @@ namespace Xamarin.Essentials
         static async Task<FileResult> PlatformCaptureAsync(MediaPickerOptions options, bool photo)
         {
             await Permissions.EnsureGrantedAsync<Permissions.Camera>();
-            await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
+			// StorageWrite no longer exists starting from Android API 33
+			if (!OperatingSystem.IsAndroidVersionAtLeast(33))
+				await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
 
             var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);
 

--- a/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
+++ b/Xamarin.Essentials/MediaPicker/MediaPicker.android.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Essentials
         {
             await Permissions.EnsureGrantedAsync<Permissions.Camera>();
             // StorageWrite no longer exists starting from Android API 33
-            if (!OperatingSystem.IsAndroidVersionAtLeast(33))
+            if (!Platform.HasApiLevel(33))
                 await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
 
             var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);

--- a/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
+++ b/Xamarin.Essentials/SecureStorage/SecureStorage.android.cs
@@ -128,11 +128,11 @@ namespace Xamarin.Essentials
 
         internal static bool AlwaysUseAsymmetricKeyStorage { get; set; } = false;
 
-		// While MD5 is deemed to be not secure anymore, it is not used in a security context here.
-		// Here we hash a key value to ensure compatibility with the underlying platform's preferences storage (so the key was a determinate length and didn't exceed platform limits).
-		// As part as Microsofts ongoing efforts to secure the .NET ecosystem, this usage of an insecure hashing mechanism was flagged.
-		// An exception has been requested for the usage of this "unsafe" hashing mechanism.
-		// More details here (internal link): https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1676270
+        // While MD5 is deemed to be not secure anymore, it is not used in a security context here.
+        // Here we hash a key value to ensure compatibility with the underlying platform's preferences storage (so the key was a determinate length and didn't exceed platform limits).
+        // As part as Microsofts ongoing efforts to secure the .NET ecosystem, this usage of an insecure hashing mechanism was flagged.
+        // An exception has been requested for the usage of this "unsafe" hashing mechanism.
+        // More details here (internal link): https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1676270
         internal static string Md5Hash(string input)
         {
             var hash = new StringBuilder();


### PR DESCRIPTION
Thanks to @Ghostbird in https://github.com/dotnet/maui/pull/12766

### Description of Change ###

Fix the MediaPicker that is requesting permissions that are not correct for Android 33.

### Bugs Fixed ###

- Fixes #2037
- Potentially #2041

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###

None.

### Behavioral Changes ###

Skips the check for `StorageWrite` because that permission is not needed and probably not needed in many versions...

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
