### PR TITLE
Make UWP FilePicker FutureAccessList more robust

### DIFF
--- a/Xamarin.Essentials/FilePicker/FilePicker.uwp.cs
+++ b/Xamarin.Essentials/FilePicker/FilePicker.uwp.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.Storage;
@@ -35,10 +36,49 @@ namespace Xamarin.Essentials
                     resultList.Add(file);
             }
 
-            foreach (var file in resultList)
-                StorageApplicationPermissions.FutureAccessList.Add(file);
+            AddToAndCleanUpFutureAccessList(resultList);
 
             return resultList.Select(storageFile => new FileResult(storageFile));
+        }
+
+        static void AddToAndCleanUpFutureAccessList(List<StorageFile> pickedFiles)
+        {
+            var fal = StorageApplicationPermissions.FutureAccessList;
+
+            try
+            {
+                // Check if (FutureAccessList current items + new picked files) is exceeding maximum items
+                if ((fal.Entries.Count + pickedFiles.Count) >= fal.MaximumItemsAllowed)
+                {
+                    // We assume that the FutureAccessList items are saved in order, there is no metadata
+                    // Therefore we start removing from the bottom of the list
+                    var removeCount = Math.Min(fal.Entries.Count, pickedFiles.Count);
+                    var falTokens = fal.Entries.TakeLast(removeCount).ToList();
+
+                    foreach (var entry in falTokens)
+                    {
+                        fal.Remove(entry.Token);
+                    }
+                }
+
+                // Check if the picked file count doesn't exceed the maximum, else take the last n number or picked files
+                var pickedFilesLimitedToMax = pickedFiles;
+                if (pickedFiles.Count > StorageApplicationPermissions.FutureAccessList.MaximumItemsAllowed)
+                {
+                    pickedFilesLimitedToMax =
+                        pickedFilesLimitedToMax.TakeLast((int)fal.MaximumItemsAllowed).ToList();
+                }
+
+                foreach (var file in pickedFilesLimitedToMax)
+                {
+                    StorageApplicationPermissions.FutureAccessList.Add(file);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Just log, we don't want to break on this
+                Debug.WriteLine($"Error adding to/cleaning up FutureAccessList: {ex.Message}");
+            }
         }
 
         static void SetFileTypes(PickOptions options, FileOpenPicker picker)


### PR DESCRIPTION
### Description of Change ###

When using FilePicker on UWP it will add the entries to something that is called the FutureAccessList. However, that list has a maximum amount of entries and when it reaches that, it will break. This change will add some more robustness.

This adds:
* Check if we're going over the limit with the picked files
* If yes; clean up the list starting with the oldest entries (assumed)
* Add the last _n_ number of picked files back to the list, where _n_ is the amount of files picked, or if that exceed the maximum of the FutureAccessList, it will take that maximum.
* Wraps this whole process in a try/catch so we don't break users apps when something goes wrong, its not that important.

### Bugs Fixed ###

- Fixes #2061
- Closes #2068

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
