### PR TITLE
Add support for iOS17+ Calendar Permissions

### DIFF
--- a/Samples/Samples.iOS/Info.plist
+++ b/Samples/Samples.iOS/Info.plist
@@ -22,7 +22,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>10.0</string>
+	<string>11.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>Xamarin.Essentials</string>
 	<key>CFBundleIdentifier</key>
@@ -78,5 +78,11 @@
 	<array>
 		<string>mailto</string>
 	</array>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Full access to the Calendar</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>Write only access to the Calendar</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>Full access to reminders</string>
 </dict>
 </plist>

--- a/Xamarin.Essentials/Permissions/Permissions.ios.watchos.cs
+++ b/Xamarin.Essentials/Permissions/Permissions.ios.watchos.cs
@@ -28,7 +28,19 @@ namespace Xamarin.Essentials
             {
                 var eventStore = new EKEventStore();
 
-                var results = await eventStore.RequestAccessAsync(entityType);
+                Tuple<bool, NSError> results = null;
+
+                if (Platform.HasOSVersion(17, 0))
+                {
+                    if (entityType == EKEntityType.Reminder)
+                        results = await eventStore.RequestFullAccessToRemindersAsync();
+                    if (entityType == EKEntityType.Event)
+                        results = await eventStore.RequestFullAccessToEventsAsync();
+                }
+                else
+                {
+                    results = await eventStore.RequestAccessAsync(entityType);
+                }
 
                 return results.Item1 ? PermissionStatus.Granted : PermissionStatus.Denied;
             }
@@ -36,8 +48,20 @@ namespace Xamarin.Essentials
 
         public partial class CalendarRead : BasePlatformPermission
         {
-            protected override Func<IEnumerable<string>> RequiredInfoPlistKeys =>
-                () => new string[] { "NSCalendarsUsageDescription" };
+            protected override Func<IEnumerable<string>> RequiredInfoPlistKeys
+            {
+                get
+                {
+                    if (Platform.HasOSVersion(17, 0))
+                    {
+                        return () => new string[] { "NSCalendarsFullAccessUsageDescription" };
+                    }
+                    else
+                    {
+                        return () => new string[] { "NSCalendarsUsageDescription" };
+                    }
+                }
+            }
 
             public override Task<PermissionStatus> CheckStatusAsync()
             {
@@ -60,8 +84,20 @@ namespace Xamarin.Essentials
 
         public partial class CalendarWrite : BasePlatformPermission
         {
-            protected override Func<IEnumerable<string>> RequiredInfoPlistKeys =>
-                () => new string[] { "NSCalendarsUsageDescription" };
+            protected override Func<IEnumerable<string>> RequiredInfoPlistKeys
+            {
+                get
+                {
+                    if (Platform.HasOSVersion(17, 0))
+                    {
+                        return () => new string[] { "NSCalendarsWriteOnlyAccessUsageDescription" };
+                    }
+                    else
+                    {
+                        return () => new string[] { "NSCalendarsUsageDescription" };
+                    }
+                }
+            }
 
             public override Task<PermissionStatus> CheckStatusAsync()
             {
@@ -84,8 +120,20 @@ namespace Xamarin.Essentials
 
         public partial class Reminders : BasePlatformPermission
         {
-            protected override Func<IEnumerable<string>> RequiredInfoPlistKeys =>
-                () => new string[] { "NSRemindersUsageDescription" };
+            protected override Func<IEnumerable<string>> RequiredInfoPlistKeys
+            {
+                get
+                {
+                    if (Platform.HasOSVersion(17, 0))
+                    {
+                        return () => new string[] { "NSRemindersFullAccessUsageDescription" };
+                    }
+                    else
+                    {
+                        return () => new string[] { "NSRemindersUsageDescription" };
+                    }
+                }
+            }
 
             public override Task<PermissionStatus> CheckStatusAsync()
             {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
   - develop
 
 variables:
-  BASE_VERSION: 1.8.0
+  BASE_VERSION: 1.8.1
   PREVIEW_LABEL: 'ci'
   BUILD_NUMBER: $[counter(format('{0}_{1}_{2}', variables['BASE_VERSION'], variables['PREVIEW_LABEL'], variables['Build.SourceBranch']), 1)]
   NUGET_VERSION: $[format('{0}-{1}.{2}', variables['BASE_VERSION'], variables['PREVIEW_LABEL'], variables['BUILD_NUMBER'])]
@@ -47,6 +47,8 @@ stages:
           windowsImageOverride: AzurePipelinesWindows2019compliant
         ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
           windowsImage: windows-2019
+          macosImage: 'macos-13'
+          xcode: '15.0.1'
         areaPath: 'DevDiv\Xamarin SDK'
         masterBranchName: 'main'
         ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}: #we are shipping our product
@@ -141,7 +143,7 @@ stages:
   
         - template: .ci/build.v1.yml@components
           parameters:
-            macosImage: 'macos-12'
+            macosImage: 'macos-13'
             name: devicetests_ios
             runChecks: false
             displayName: iOS
@@ -152,7 +154,7 @@ stages:
             cakeFile: DeviceTests/build.cake
             cakeTarget: test-ios-emu
             cake: $(CAKE_VERSION)
-            xcode: '14.2'
+            xcode: '15.0.1'
             xharness: '1.0.0-prerelease.23212.1'
   
         - template: .ci/build.v1.yml@components


### PR DESCRIPTION
### Description of Change ###

As of iOS 17, there is new permissions for accessing/writing Calendar data and Reminders. This PR adds support for those in the Permissions APIs.

Ports over https://github.com/dotnet/maui/pull/18868 from .NET MAUI

### Bugs Fixed ###

- Fixes #2105