### PR TITLE
[Android] [Battery] Remove code duplication

### DIFF
--- a/Xamarin.Essentials/Battery/Battery.android.cs
+++ b/Xamarin.Essentials/Battery/Battery.android.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Essentials
             {
                 Platform.AppContext.UnregisterReceiver(receiver);
             }
-            catch(Java.Lang.IllegalArgumentException)
+            catch (Java.Lang.IllegalArgumentException)
             {
                 System.Diagnostics.Debug.WriteLine($"{receiver.GetType().Name} already unregistered. Disposing of it.");
             }

--- a/Xamarin.Essentials/Battery/Battery.android.cs
+++ b/Xamarin.Essentials/Battery/Battery.android.cs
@@ -23,15 +23,7 @@ namespace Xamarin.Essentials
             if (!Platform.HasApiLevel(BuildVersionCodes.Lollipop))
                 return;
 
-            try
-            {
-                Platform.AppContext.UnregisterReceiver(powerReceiver);
-            }
-            catch (Java.Lang.IllegalArgumentException)
-            {
-                System.Diagnostics.Debug.WriteLine("Energy saver receiver already unregistered. Disposing of it.");
-            }
-            powerReceiver.Dispose();
+            UnregisterReceiver(powerReceiver);
             powerReceiver = null;
         }
 
@@ -57,16 +49,21 @@ namespace Xamarin.Essentials
 
         static void StopBatteryListeners()
         {
+            UnregisterReceiver(batteryReceiver);
+            batteryReceiver = null;
+        }
+
+        static void UnregisterReceiver(BroadcastReceiver receiver)
+        {
             try
             {
-                Platform.AppContext.UnregisterReceiver(batteryReceiver);
+                Platform.AppContext.UnregisterReceiver(receiver);
             }
-            catch (Java.Lang.IllegalArgumentException)
+            catch(Java.Lang.IllegalArgumentException)
             {
-                System.Diagnostics.Debug.WriteLine("Battery receiver already unregistered. Disposing of it.");
+                System.Diagnostics.Debug.WriteLine($"{receiver.GetType().Name} already unregistered. Disposing of it.");
             }
-            batteryReceiver.Dispose();
-            batteryReceiver = null;
+            receiver.Dispose();
         }
 
         static double PlatformChargeLevel


### PR DESCRIPTION
### Description of Change ###

Extracted duplicate code, into a new method. Tests and samples were ommited as the changes doesn't alternate the current class behavior.

Duplicate code:

```csharp
try
{
    Platform.AppContext.UnregisterReceiver(receiver);
}
catch (Java.Lang.IllegalArgumentException)
{
    System.Diagnostics.Debug.WriteLine("{Receiver name} receiver already unregistered. Disposing of it.");
}
```

### Bugs Fixed ###

- None

### API Changes ###
None


### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
