### PR TITLE
Change CMAttitudeReferenceFrame to XMagneticNorthZVertical to remove …

### DIFF
--- a/Xamarin.Essentials/OrientationSensor/OrientationSensor.ios.watchos.cs
+++ b/Xamarin.Essentials/OrientationSensor/OrientationSensor.ios.watchos.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Essentials
             manager.DeviceMotionUpdateInterval = sensorSpeed.ToPlatform();
 
             // use a fixed reference frame where X points north and Z points vertically into the sky
-            manager.StartDeviceMotionUpdates(CMAttitudeReferenceFrame.XTrueNorthZVertical, Platform.GetCurrentQueue(), DataUpdated);
+            manager.StartDeviceMotionUpdates(CMAttitudeReferenceFrame.XMagneticNorthZVertical, Platform.GetCurrentQueue(), DataUpdated);
         }
 
         static void DataUpdated(CMDeviceMotion data, NSError error)


### PR DESCRIPTION
…the dependency on the compass calibration, thus removing the dependency on location services.


### Description of Change ###

Changed the CMAttitudeReferenceFrame value from XTrueNorthZVertical to XMagneticNorthZVertical in OrientationSensor.ios.watchos.cs line #19.

This change is trivial and requires no tests, samples or documentation.

### Bugs Fixed ###

[- Related to issue #2122](https://github.com/xamarin/Essentials/issues/2122)

### API Changes ###

None

### Behavioral Changes ###

Orientation Sensor takes calibration from Magnetic North instead of True North. True north requires Location Services to be enabled for the app, introducing a sensitive permission that is not strictly necessary. This change pulls the functionality into line with the behavior of Android, which uses Magnetic North for its calibration.

### PR Checklist ###

- [ ❌ ] Has tests (if omitted, state reason in description)
- [ ❌ ] Has samples (if omitted, state reason in description)
- [ ✔️ ] Rebased on top of `main` at time of PR
- [ ✔️ ] Changes adhere to coding standard
- [ ❌ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
