### PR TITLE
Update WebAuthenticator.xml to document exception types

### DIFF
--- a/docs/en/Xamarin.Essentials/WebAuthenticator.xml
+++ b/docs/en/Xamarin.Essentials/WebAuthenticator.xml
@@ -36,6 +36,7 @@
         <param name="callbackUrl">Expected callback url that the navigation flow will eventually redirect to.</param>
         <summary>Begin an authentication flow by navigating to the specified url and waiting for a callback/redirect to the callbackUrl scheme.</summary>
         <returns>Returns a result parsed out from the callback url.</returns>
+        <exception cref="TaskCanceledException">The user canceled the authentication flow.</exception>
         <remarks></remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
AuthenticateAsync throws a TaskCanceledException if the user aborts the process. This should be included in the documentation
 
### Description of Change ###

Added documentation for the exception thrown when users cancel the process.

### Bugs Fixed ###

None - documentation fix only.

### API Changes ###

None - documentation fix only.

### Behavioral Changes ###

None - documentation fix only.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to coding standard
- [X] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
