### PR TITLE
Fix connectivity broadcast receiver never triggered on android 14.0/34+

### DIFF
--- a/Xamarin.Essentials/Connectivity/Connectivity.android.cs
+++ b/Xamarin.Essentials/Connectivity/Connectivity.android.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Essentials
 
             conectivityReceiver = new ConnectivityBroadcastReceiver(OnConnectivityChanged);
 
-            Platform.RegisterBroadcastReceiver(conectivityReceiver, filter, false);
+            Platform.RegisterBroadcastReceiver(conectivityReceiver, filter, true);
         }
 
         static void StopListeners()


### PR DESCRIPTION
Fixes #2130 

Porting this fix from .NET MAUI here: https://github.com/dotnet/maui/issues/19949